### PR TITLE
Dynamically link to precompiled `rocksdb` from `fuel-core`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -193,7 +193,7 @@
         name = "fuel-core-dev";
         inputsFrom = with fuelpkgs; [fuel-core fuel-gql-cli];
         buildInputs = [pkgs.grpc-tools];
-        inherit (fuelpkgs.fuel-core) LIBCLANG_PATH;
+        inherit (fuelpkgs.fuel-core) LIBCLANG_PATH ROCKSDB_LIB_DIR;
         PROTOC = "${pkgs.grpc-tools}/bin/protoc";
         NIX_CFLAGS_COMPILE = fuelpkgs.fuel-core.NIX_CFLAGS_COMPILE or "";
       };
@@ -211,7 +211,7 @@
           latestPublished = pkgs.lib.filterAttrs (n: v: isLatestPublished n) fuelpkgs;
         in
           pkgs.lib.mapAttrsToList (n: v: v) latestPublished;
-        inherit (fuel-core-dev) LIBCLANG_PATH PROTOC NIX_CFLAGS_COMPILE;
+        inherit (fuel-core-dev) LIBCLANG_PATH ROCKSDB_LIB_DIR PROTOC NIX_CFLAGS_COMPILE;
       };
       default = fuel-dev;
     };

--- a/patches.nix
+++ b/patches.nix
@@ -48,19 +48,17 @@
     };
   }
 
-  # The fuel-core crate requires clang and pkg-config, and that the
-  # `LIBCLANG_PATH` environment variable is set.
+  # The fuel-core crate requires clang for the rocksdb bindings generation.
+  # We also specify `ROCKSDB_LIB_DIR` in order to allow the rocksdb build
+  # script to use rocksdb as a dynamic library.
   {
     condition = m: m.pname == "fuel-core";
     patch = m: {
-      nativeBuildInputs =
-        (m.nativeBuildInputs or [])
-        ++ [
-          pkgs.clang
-          pkgs.pkg-config
-        ];
+      nativeBuildInputs = (m.nativeBuildInputs or []) ++ [pkgs.clang];
+      buildInputs = (m.buildInputs or []) ++ [pkgs.rocksdb];
       doCheck = false; # Already tested at repo, causes longer build times.
       LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+      ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
     };
   }
 


### PR DESCRIPTION
@Voxelot @freesig here we go, definitely speeds up the `fuel-core` build quite a bit locally, and slims the binary size by about a third!

Here are the changes I'm seeing with `fuel-core` `0.10.1`:

**Before**

```
$ ldd ./result/bin/fuel-core

        linux-vdso.so.1 (0x00007ffe3e3eb000)
        libstdc++.so.6 => /nix/store/k2a429wpxgfwp4jaacl9iaqw4kxqjaxa-gcc-11.3.0-lib/lib/libstdc++.so.6 (0x00007f20236ed000)
        libgcc_s.so.1 => /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libgcc_s.so.1 (0x00007f20236d3000)
        libm.so.6 => /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libm.so.6 (0x00007f20235f3000)
        libc.so.6 => /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libc.so.6 (0x00007f20233e9000)
        /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/ld-linux-x86-64.so.2 => /nix/store/bzd91shky9j9d43girrrj6vmqlw7x9m8-glibc-2.35-163/lib64/ld-linux-x86-64.so.2 (0x00007f2024b94000)

$ ls -ahl ./result/bin/fuel-core

-r-xr-xr-x 1 root root  22M Jan  1  1970 fuel-core
```

**After**

```
$ ldd ./result/bin/fuel-core

        linux-vdso.so.1 (0x00007ffe1af53000)
        librocksdb.so.7 => /nix/store/n8fl280p0hdnz9qajwihzsn707jfgkdw-rocksdb-7.4.5/lib/librocksdb.so.7 (0x00007f62e74af000)
        libgcc_s.so.1 => /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libgcc_s.so.1 (0x00007f62e7495000)
        libm.so.6 => /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libm.so.6 (0x00007f62e73b5000)
        libc.so.6 => /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libc.so.6 (0x00007f62e71ab000)
        libsnappy.so.1 => /nix/store/hpmn4gz49wzm5zszg9s24y8sanp29i8c-snappy-1.1.9/lib/libsnappy.so.1 (0x00007f62e719b000)
        libz.so.1 => /nix/store/z18zgvspmxi88ipmk3f3nicvasfq3199-zlib-1.2.12/lib/libz.so.1 (0x00007f62e717d000)
        libbz2.so.1 => /nix/store/1pbdai0n0n16z01nk9yybrll4g2a6mls-bzip2-1.0.8/lib/libbz2.so.1 (0x00007f62e716a000)
        liblz4.so.1 => /nix/store/94ky79f8slvqz77vrc03n228m2xjrvs5-lz4-1.9.3/lib/liblz4.so.1 (0x00007f62e7136000)
        libzstd.so.1 => /nix/store/dq2hx1zvsf8zq1n3b3f7ipzh2kjk7hww-zstd-1.5.2/lib/libzstd.so.1 (0x00007f62e7071000)
        libstdc++.so.6 => /nix/store/k2a429wpxgfwp4jaacl9iaqw4kxqjaxa-gcc-11.3.0-lib/lib/libstdc++.so.6 (0x00007f62e6e58000)
        libpthread.so.0 => /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libpthread.so.0 (0x00007f62e6e53000)
        /nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/ld-linux-x86-64.so.2 => /nix/store/bzd91shky9j9d43girrrj6vmqlw7x9m8-glibc-2.35-163/lib64/ld-linux-x86-64.so.2 (0x00007f62e8c18000)

$ ls -ahl ./result/bin/fuel-core

-r-xr-xr-x 1 root root  15M Jan  1  1970 fuel-core
```

Note that it seems we still need to keep clang around for bindgen in order for the rocksdb build script to generate the bindings from its headers.

Closes #19.