### PR TITLE
Update the version of Rust used to 1.64 for all pkgs after 2022-09-23

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660618363,
-        "narHash": "sha256-SdIGzmiMjAfKyZScxb497AA4oHiiaHMPhb9iwLtoaMk=",
+        "lastModified": 1663815552,
+        "narHash": "sha256-J4j/d69SGKx1qripBCINe7T3SUtMM1sdj5PoHRThV5Q=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b480a97c66038e9a6ff68cbf0c4fa4a783416e0b",
+        "rev": "f45f856ae5a9fe2c48d756fa17bb9c5b3b8070c5",
         "type": "github"
       },
       "original": {

--- a/patches.nix
+++ b/patches.nix
@@ -147,4 +147,13 @@
       NIX_CFLAGS_COMPILE = pkgs.lib.optionalString pkgs.stdenv.cc.isClang "-Wno-error=unused-private-field -faligned-allocation";
     };
   }
+
+  # `fuel-core` needs Rust 1.64 as of bcb86da09b6fdce09f13ef4181a0ca6461f8e2a8.
+  # This changes the Rust used for all pkgs to 1.64 from the day of the commit.
+  {
+    condition = m: m.date >= "2022-09-23";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.64.0".default;
+    };
+  }
 ]


### PR DESCRIPTION
This should account for https://github.com/FuelLabs/fuel-core/commit/bcb86da09b6fdce09f13ef4181a0ca6461f8e2a8 while still allowing to use 1.63 (and in turn, already cached builds) for prior versions.