### PR TITLE
Update the README with instructions for adding the nixos cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,18 @@ file (e.g.  `/etc/nix/nix.conf`):
 
 ```conf
 experimental-features = nix-command flakes
-substituters = https://mitchmindtree-fuellabs.cachix.org
-trusted-public-keys = mitchmindtree-fuellabs.cachix.org-1:UDUQvwjM3wRCZe1chrgqAehb3M0M5x9qjpEwJwPn7Ik=
+substituters = https://cache.nixos.org/ https://mitchmindtree-fuellabs.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= mitchmindtree-fuellabs.cachix.org-1:UDUQvwjM3wRCZe1chrgqAehb3M0M5x9qjpEwJwPn7Ik=
+```
+
+On non-NixOS Linux systems, be sure to make sure that your user is part of the
+`nixbld` group. Only this group has permissions to access the caches. You can
+check if your user is a part of the group with the `groups` command. You can add
+your user to the `nixbld` group with the following, replacing `user` with your
+username:
+
+```
+$ sudo usermod -a -G nixbld user
 ```
 
 ## Packages


### PR DESCRIPTION
After helping @voxelot work out why Nix was trying to build perl from scratch on Ubuntu, I realised we need to make sure we also include the standard nixos cache in the `nix.conf`.

I've also added a note for non-NixOS Linux users about ensuring their user is in the `nixbld` group to ensure they have permissions to use the remote caches to populate the local `/nix/store`.