### PR TITLE
Update rust-overlay input for latest Rust stable 1.64 release

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663815552,
-        "narHash": "sha256-J4j/d69SGKx1qripBCINe7T3SUtMM1sdj5PoHRThV5Q=",
+        "lastModified": 1663902145,
+        "narHash": "sha256-wuDqTDcD+VtGOFyzrvsALZRw5MkCNPj7rPX6DKt6Pzo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f45f856ae5a9fe2c48d756fa17bb9c5b3b8070c5",
+        "rev": "9e319dd18f7beadab4daaf2426466d4023c1d26f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
It looks like my previous rust-overlay update in #23 was a little early and didn't include 1.64 yet. #23 didn't show any issues yet as none of the packages at the time of that commit were released after 2022-09-23, and so we didn't hit the error until the latest nightlies merged into `master` with #27 which also didn't show any issues as it was was opened before #23 was merged :')

This should fix it! It's probably worth enabling the same branch protection we have on the Sway repo where merging a PR requires it's up to date with `master` to avoid cases like this.