### PR TITLE
Add required nix configuration to flake `nixConfig` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,17 @@ for both `x86_64-linux` and `x86_64-darwin` systems.
 
 ## System Requirements
 
-Requires a recent version of [Nix][nix-manual] with [the "flakes"
-feature][nix-flakes] enabled.
+Requires a recent version of [Nix][nix-manual] with the ["flakes"][nix-flakes]
+and "nix command" features available.
 
-We also recommend enabling the Fuel Labs Nix cache hosted by
-[cachix][fuellabs-cachix]. Otherwise, upon first use Nix will try to build all
-of the packages from scratch which can take a long time!
-
-On **NixOS**, we can enable the necessary features and our cache within our
-NixOS configuration (i.e. `/etc/nixos/configuration.nix`) like so:
+On **NixOS**, we can enable these features within our NixOS configuration (i.e.
+`/etc/nixos/configuration.nix`) like so:
 
 ```nix
 {
   nix = {
     settings = {
       experimental-features = ["nix-command" "flakes"];
-      substituters = ["https://mitchmindtree-fuellabs.cachix.org"];
-      trusted-public-keys = [
-        "mitchmindtree-fuellabs.cachix.org-1:UDUQvwjM3wRCZe1chrgqAehb3M0M5x9qjpEwJwPn7Ik="
-      ];
     };
   };
 }
@@ -37,19 +29,13 @@ file (e.g.  `/etc/nix/nix.conf`):
 
 ```conf
 experimental-features = nix-command flakes
-substituters = https://cache.nixos.org/ https://mitchmindtree-fuellabs.cachix.org
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= mitchmindtree-fuellabs.cachix.org-1:UDUQvwjM3wRCZe1chrgqAehb3M0M5x9qjpEwJwPn7Ik=
 ```
 
-On non-NixOS Linux systems, be sure to make sure that your user is part of the
-`nixbld` group. Only this group has permissions to access the caches. You can
-check if your user is a part of the group with the `groups` command. You can add
-your user to the `nixbld` group with the following, replacing `user` with your
-username:
-
-```
-$ sudo usermod -a -G nixbld user
-```
+On first use of the fuel.nix flake, Nix will ask if you'd like to let the flake
+specify values for `extra-substituters` and `extra-trusted-public-keys`. It is
+recommended to accept these values as they enable the official nixos and
+[fuellabs][fuellabs-cachix] caches. Otherwise, upon first use Nix will try to
+build all of the packages from scratch, which can take a long time!
 
 ## Packages
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,17 @@
     A Nix flake for the Fuel Labs ecosystem.
   '';
 
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.nixos.org"
+      "https://mitchmindtree-fuellabs.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "mitchmindtree-fuellabs.cachix.org-1:UDUQvwjM3wRCZe1chrgqAehb3M0M5x9qjpEwJwPn7Ik="
+    ];
+  };
+
   inputs = {
     nixpkgs = {
       url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
An attempt at enabling the fuellabs nix cache via the flake's `nixConfig` attribute. The idea is to hopefully remove the need for adding cache info to the user's global config and ease usage slightly.

From `nix help flake`:

> nixConfig: a set of nix.conf options to be set when evaluating any
> part of a flake. In the interests of security, only a small set of
> whitelisted options (currently bash-prompt, bash-prompt-prefix,
> bash-prompt-suffix, and flake-registry) are allowed to be set without
> confirmation so long as accept-flake-config is not set in the global
> configuration.

Currently this doesn't seem to be working - I'm running into the same issue described here https://github.com/NixOS/nix/issues/6672. Either the user has to be part of the "trusted-users" set (i.e. is allowed to specify new substituters) or the fuellabs cache already has to be part of the global `trusted-substituters` list, otherwise the fuellabs cache is ignored.

The `nixConfig` also allows you to specify the required "nix-command" and "flakes" `experimental-features`. However, you already need to have these features to even start using the flake, so I've omitted them from the config as the user should always already have them.