### PR TITLE
Manually refresh manifests

### DIFF
--- a/manifests/forc-0.24.4-nightly-2022-09-24.nix
+++ b/manifests/forc-0.24.4-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.4";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7d000fff4dc27c2ce0ca779a6e204fb0d4e720c";
+  sha256 = "sha256-qtbxzFic0c9x6fbu4t8hdDkKXP9QTF5QcY9hZ+8qYv0=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-09-25.nix
+++ b/manifests/forc-0.24.5-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-09-27.nix
+++ b/manifests/forc-0.24.5-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "535174be2759db62d0838957cf4f89f2c9d8ec71";
+  sha256 = "sha256-nqO6tKI6liTYLXHVIyImfFWeBmu2Z70jEMGAjT7WAic=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-09-28.nix
+++ b/manifests/forc-0.24.5-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5e543382e00a843adb2f64d03eea8576e4c1d53";
+  sha256 = "sha256-nm4FY6pisendzf+hgCm9zDieqVAyRtDNDXjZca79brM=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-09-29.nix
+++ b/manifests/forc-0.24.5-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e6afd8987ead0d453efb5f35e29ce7ba1a0cd070";
+  sha256 = "sha256-Xo8OXRT9UtkEvZvbMAteolHsPKjtx7kl9CZaCuGhV/w=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-09-30.nix
+++ b/manifests/forc-0.24.5-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "076e95fcdb9efc4052dec827418274681d26b00e";
+  sha256 = "sha256-89ZfhctqiTKbwCEz03r9A1AYJ/l+UHsKdCt5mnl6WvM=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-10-01.nix
+++ b/manifests/forc-0.24.5-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e15d71c176359844341e2621a0431f58dfd13c2e";
+  sha256 = "sha256-IAkBhCN7hPGVTBHquhAt0+nEB+0yLM6smnc8pghO/wA=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-10-02.nix
+++ b/manifests/forc-0.24.5-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7b9a022df54ed75832d93833587855af0d08fa";
+  sha256 = "sha256-GJzUqffmvc1CH5K9TeAHvwLs6FyA6/2YSg1RUnpgYio=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-10-03.nix
+++ b/manifests/forc-0.24.5-nightly-2022-10-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe47d44458c1433140afd30a304e2723d1805b5";
+  sha256 = "sha256-sBYTj7BwGyvdw4FTQt331Y/I7XrZVTgrTJIJ/FgPc70=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-10-04.nix
+++ b/manifests/forc-0.24.5-nightly-2022-10-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-10-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a917c66ff1d402c7350664c648e8704b50085281";
+  sha256 = "sha256-jCHeqg6SIP8fnAHm3ZeQt9CdEDz1Cr81NcapE4jQx70=";
+}

--- a/manifests/forc-0.24.5-nightly-2022-10-05.nix
+++ b/manifests/forc-0.24.5-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a8f0c39d0bb3e0424a5cdabf0b625b73c90667c";
+  sha256 = "sha256-8Y1IUqYWk29szUFWBwrk4fGDRvIKcC9XY2Zu/h89Jng=";
+}

--- a/manifests/forc-0.24.5.nix
+++ b/manifests/forc-0.24.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.24.5";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-0.25.0-nightly-2022-10-06.nix
+++ b/manifests/forc-0.25.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-0.25.0.nix
+++ b/manifests/forc-0.25.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.0";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-0.25.1-nightly-2022-10-07.nix
+++ b/manifests/forc-0.25.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4740fb2f9b9c4c4d6e8ba2110831604b40ccc645";
+  sha256 = "sha256-czP0vMoQE3ZjXFcLHNRKntBkbpJb7yPaMsIwxny+xPM=";
+}

--- a/manifests/forc-0.25.1.nix
+++ b/manifests/forc-0.25.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.1";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
+  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
+}

--- a/manifests/forc-0.25.2-nightly-2022-10-08.nix
+++ b/manifests/forc-0.25.2-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.2";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e8a28b5867234a6391bf99ddc55db41957096480";
+  sha256 = "sha256-pw0Zs2LX5D6kyScWDuOz3dobkhRQ5DgySirK4Tj+fBU=";
+}

--- a/manifests/forc-0.25.2-nightly-2022-10-09.nix
+++ b/manifests/forc-0.25.2-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.2";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "61d6d659b22c25a606f1437a122176474293180d";
+  sha256 = "sha256-Ch+iPSPFlnzL9JlZXPHhr7fWTJqNIAP0TfKdyQieQ0M=";
+}

--- a/manifests/forc-0.25.2-nightly-2022-10-10.nix
+++ b/manifests/forc-0.25.2-nightly-2022-10-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.2";
+  date = "2022-10-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "71999d3774ec617e4b1167d891cadb1e6e9f38af";
+  sha256 = "sha256-jVrjARMBQSgfBJTSfL9xUBB0NjjbSAX0m7uaROG5urA=";
+}

--- a/manifests/forc-0.25.2-nightly-2022-10-11.nix
+++ b/manifests/forc-0.25.2-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.2";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb0a5be05549a7a01df684380eaf0c2ec7f46241";
+  sha256 = "sha256-EUmVdkCM6EIL/imd6Xn4/cGp2RyRDcjJ6QjI7BjQNVI=";
+}

--- a/manifests/forc-0.25.2-nightly-2022-10-12.nix
+++ b/manifests/forc-0.25.2-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.2";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7554760ba1cde24db5075183ddc9c3f1359066";
+  sha256 = "sha256-uycMRo7+vIkHKQdcCpxh+eGdpBnuq1b674Aw6TXYgU8=";
+}

--- a/manifests/forc-0.25.2-nightly-2022-10-13.nix
+++ b/manifests/forc-0.25.2-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.2";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "205073dc30db355f065c29db41d591bfc166f3fa";
+  sha256 = "sha256-c3eAp7XB0ziwC4NLCyQeHgflBuwftCv+gy0P/RwJID0=";
+}

--- a/manifests/forc-0.25.2.nix
+++ b/manifests/forc-0.25.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.25.2";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
+  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
+}

--- a/manifests/forc-0.26.0-nightly-2022-10-14.nix
+++ b/manifests/forc-0.26.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.26.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-0.26.0-nightly-2022-10-15.nix
+++ b/manifests/forc-0.26.0-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.26.0";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a9eaef219282566e99d57ff993c613317a9143a9";
+  sha256 = "sha256-noZchaj5q6Y5rp1t6VOfmV96ggJZDNdNMtEmdsbK0cg=";
+}

--- a/manifests/forc-0.26.0-nightly-2022-10-16.nix
+++ b/manifests/forc-0.26.0-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.26.0";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a1d40f58883e3fe8d23140fbf922d263f17b7c20";
+  sha256 = "sha256-3WPBVNfM/lkyA44mVqqR05t0pBfgI5vnBIOGJSMfeW8=";
+}

--- a/manifests/forc-0.26.0-nightly-2022-10-17.nix
+++ b/manifests/forc-0.26.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.26.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "314648f8448cefad534f129431ebd15f06e8b418";
+  sha256 = "sha256-zXLLLvftB+aTX4ZFbjfQ/1YLBLCX70ASZ8U6Z1ppXH8=";
+}

--- a/manifests/forc-0.26.0-nightly-2022-10-18.nix
+++ b/manifests/forc-0.26.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.26.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dbd6b9211fd3c4ceeb34b3f6aedb0a7b9f0e6ef8";
+  sha256 = "sha256-Qhf/QDTkb68kX4feeTtdMjSTt34xKhNeRAlhgxGF6wU=";
+}

--- a/manifests/forc-0.26.0-nightly-2022-10-19.nix
+++ b/manifests/forc-0.26.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.26.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a2395b4c99c299cf246f1b1ef59785345c94641e";
+  sha256 = "sha256-GvqPVs1EtRuygKA8kEdZyImxlM835AVMKgK74rnX2wk=";
+}

--- a/manifests/forc-0.26.0-nightly-2022-10-21.nix
+++ b/manifests/forc-0.26.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.26.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0e84d98a06d32a036d88198505e0d6868c985f25";
+  sha256 = "sha256-38yHKfdmro4oDIYQy2HiSgTP3w4soKLiLPRJBUWa4Pg=";
+}

--- a/manifests/forc-0.26.0.nix
+++ b/manifests/forc-0.26.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.26.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-client-0.24.4-nightly-2022-09-24.nix
+++ b/manifests/forc-client-0.24.4-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.4";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7d000fff4dc27c2ce0ca779a6e204fb0d4e720c";
+  sha256 = "sha256-qtbxzFic0c9x6fbu4t8hdDkKXP9QTF5QcY9hZ+8qYv0=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-09-25.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-09-27.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "535174be2759db62d0838957cf4f89f2c9d8ec71";
+  sha256 = "sha256-nqO6tKI6liTYLXHVIyImfFWeBmu2Z70jEMGAjT7WAic=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-09-28.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5e543382e00a843adb2f64d03eea8576e4c1d53";
+  sha256 = "sha256-nm4FY6pisendzf+hgCm9zDieqVAyRtDNDXjZca79brM=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-09-29.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e6afd8987ead0d453efb5f35e29ce7ba1a0cd070";
+  sha256 = "sha256-Xo8OXRT9UtkEvZvbMAteolHsPKjtx7kl9CZaCuGhV/w=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-09-30.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "076e95fcdb9efc4052dec827418274681d26b00e";
+  sha256 = "sha256-89ZfhctqiTKbwCEz03r9A1AYJ/l+UHsKdCt5mnl6WvM=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-10-01.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e15d71c176359844341e2621a0431f58dfd13c2e";
+  sha256 = "sha256-IAkBhCN7hPGVTBHquhAt0+nEB+0yLM6smnc8pghO/wA=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-10-02.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7b9a022df54ed75832d93833587855af0d08fa";
+  sha256 = "sha256-GJzUqffmvc1CH5K9TeAHvwLs6FyA6/2YSg1RUnpgYio=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-10-03.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-10-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe47d44458c1433140afd30a304e2723d1805b5";
+  sha256 = "sha256-sBYTj7BwGyvdw4FTQt331Y/I7XrZVTgrTJIJ/FgPc70=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-10-04.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-10-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-10-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a917c66ff1d402c7350664c648e8704b50085281";
+  sha256 = "sha256-jCHeqg6SIP8fnAHm3ZeQt9CdEDz1Cr81NcapE4jQx70=";
+}

--- a/manifests/forc-client-0.24.5-nightly-2022-10-05.nix
+++ b/manifests/forc-client-0.24.5-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a8f0c39d0bb3e0424a5cdabf0b625b73c90667c";
+  sha256 = "sha256-8Y1IUqYWk29szUFWBwrk4fGDRvIKcC9XY2Zu/h89Jng=";
+}

--- a/manifests/forc-client-0.24.5.nix
+++ b/manifests/forc-client-0.24.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.24.5";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-client-0.25.0-nightly-2022-10-06.nix
+++ b/manifests/forc-client-0.25.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-client-0.25.0.nix
+++ b/manifests/forc-client-0.25.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.0";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-client-0.25.1-nightly-2022-10-07.nix
+++ b/manifests/forc-client-0.25.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4740fb2f9b9c4c4d6e8ba2110831604b40ccc645";
+  sha256 = "sha256-czP0vMoQE3ZjXFcLHNRKntBkbpJb7yPaMsIwxny+xPM=";
+}

--- a/manifests/forc-client-0.25.1.nix
+++ b/manifests/forc-client-0.25.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.1";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
+  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
+}

--- a/manifests/forc-client-0.25.2-nightly-2022-10-08.nix
+++ b/manifests/forc-client-0.25.2-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.2";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e8a28b5867234a6391bf99ddc55db41957096480";
+  sha256 = "sha256-pw0Zs2LX5D6kyScWDuOz3dobkhRQ5DgySirK4Tj+fBU=";
+}

--- a/manifests/forc-client-0.25.2-nightly-2022-10-09.nix
+++ b/manifests/forc-client-0.25.2-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.2";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "61d6d659b22c25a606f1437a122176474293180d";
+  sha256 = "sha256-Ch+iPSPFlnzL9JlZXPHhr7fWTJqNIAP0TfKdyQieQ0M=";
+}

--- a/manifests/forc-client-0.25.2-nightly-2022-10-10.nix
+++ b/manifests/forc-client-0.25.2-nightly-2022-10-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.2";
+  date = "2022-10-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "71999d3774ec617e4b1167d891cadb1e6e9f38af";
+  sha256 = "sha256-jVrjARMBQSgfBJTSfL9xUBB0NjjbSAX0m7uaROG5urA=";
+}

--- a/manifests/forc-client-0.25.2-nightly-2022-10-11.nix
+++ b/manifests/forc-client-0.25.2-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.2";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb0a5be05549a7a01df684380eaf0c2ec7f46241";
+  sha256 = "sha256-EUmVdkCM6EIL/imd6Xn4/cGp2RyRDcjJ6QjI7BjQNVI=";
+}

--- a/manifests/forc-client-0.25.2-nightly-2022-10-12.nix
+++ b/manifests/forc-client-0.25.2-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.2";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7554760ba1cde24db5075183ddc9c3f1359066";
+  sha256 = "sha256-uycMRo7+vIkHKQdcCpxh+eGdpBnuq1b674Aw6TXYgU8=";
+}

--- a/manifests/forc-client-0.25.2-nightly-2022-10-13.nix
+++ b/manifests/forc-client-0.25.2-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.2";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "205073dc30db355f065c29db41d591bfc166f3fa";
+  sha256 = "sha256-c3eAp7XB0ziwC4NLCyQeHgflBuwftCv+gy0P/RwJID0=";
+}

--- a/manifests/forc-client-0.25.2.nix
+++ b/manifests/forc-client-0.25.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.25.2";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
+  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
+}

--- a/manifests/forc-client-0.26.0-nightly-2022-10-14.nix
+++ b/manifests/forc-client-0.26.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.26.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-client-0.26.0-nightly-2022-10-15.nix
+++ b/manifests/forc-client-0.26.0-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.26.0";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a9eaef219282566e99d57ff993c613317a9143a9";
+  sha256 = "sha256-noZchaj5q6Y5rp1t6VOfmV96ggJZDNdNMtEmdsbK0cg=";
+}

--- a/manifests/forc-client-0.26.0-nightly-2022-10-16.nix
+++ b/manifests/forc-client-0.26.0-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.26.0";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a1d40f58883e3fe8d23140fbf922d263f17b7c20";
+  sha256 = "sha256-3WPBVNfM/lkyA44mVqqR05t0pBfgI5vnBIOGJSMfeW8=";
+}

--- a/manifests/forc-client-0.26.0-nightly-2022-10-17.nix
+++ b/manifests/forc-client-0.26.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.26.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "314648f8448cefad534f129431ebd15f06e8b418";
+  sha256 = "sha256-zXLLLvftB+aTX4ZFbjfQ/1YLBLCX70ASZ8U6Z1ppXH8=";
+}

--- a/manifests/forc-client-0.26.0-nightly-2022-10-18.nix
+++ b/manifests/forc-client-0.26.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.26.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dbd6b9211fd3c4ceeb34b3f6aedb0a7b9f0e6ef8";
+  sha256 = "sha256-Qhf/QDTkb68kX4feeTtdMjSTt34xKhNeRAlhgxGF6wU=";
+}

--- a/manifests/forc-client-0.26.0-nightly-2022-10-19.nix
+++ b/manifests/forc-client-0.26.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.26.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a2395b4c99c299cf246f1b1ef59785345c94641e";
+  sha256 = "sha256-GvqPVs1EtRuygKA8kEdZyImxlM835AVMKgK74rnX2wk=";
+}

--- a/manifests/forc-client-0.26.0-nightly-2022-10-21.nix
+++ b/manifests/forc-client-0.26.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.26.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0e84d98a06d32a036d88198505e0d6868c985f25";
+  sha256 = "sha256-38yHKfdmro4oDIYQy2HiSgTP3w4soKLiLPRJBUWa4Pg=";
+}

--- a/manifests/forc-client-0.26.0.nix
+++ b/manifests/forc-client-0.26.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.26.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-explore-0.24.4-nightly-2022-09-24.nix
+++ b/manifests/forc-explore-0.24.4-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.4";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7d000fff4dc27c2ce0ca779a6e204fb0d4e720c";
+  sha256 = "sha256-qtbxzFic0c9x6fbu4t8hdDkKXP9QTF5QcY9hZ+8qYv0=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-25.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-27.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "535174be2759db62d0838957cf4f89f2c9d8ec71";
+  sha256 = "sha256-nqO6tKI6liTYLXHVIyImfFWeBmu2Z70jEMGAjT7WAic=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-28.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5e543382e00a843adb2f64d03eea8576e4c1d53";
+  sha256 = "sha256-nm4FY6pisendzf+hgCm9zDieqVAyRtDNDXjZca79brM=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-29.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e6afd8987ead0d453efb5f35e29ce7ba1a0cd070";
+  sha256 = "sha256-Xo8OXRT9UtkEvZvbMAteolHsPKjtx7kl9CZaCuGhV/w=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-30.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "076e95fcdb9efc4052dec827418274681d26b00e";
+  sha256 = "sha256-89ZfhctqiTKbwCEz03r9A1AYJ/l+UHsKdCt5mnl6WvM=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-01.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e15d71c176359844341e2621a0431f58dfd13c2e";
+  sha256 = "sha256-IAkBhCN7hPGVTBHquhAt0+nEB+0yLM6smnc8pghO/wA=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-02.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7b9a022df54ed75832d93833587855af0d08fa";
+  sha256 = "sha256-GJzUqffmvc1CH5K9TeAHvwLs6FyA6/2YSg1RUnpgYio=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-03.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe47d44458c1433140afd30a304e2723d1805b5";
+  sha256 = "sha256-sBYTj7BwGyvdw4FTQt331Y/I7XrZVTgrTJIJ/FgPc70=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-04.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-10-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a917c66ff1d402c7350664c648e8704b50085281";
+  sha256 = "sha256-jCHeqg6SIP8fnAHm3ZeQt9CdEDz1Cr81NcapE4jQx70=";
+}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-05.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a8f0c39d0bb3e0424a5cdabf0b625b73c90667c";
+  sha256 = "sha256-8Y1IUqYWk29szUFWBwrk4fGDRvIKcC9XY2Zu/h89Jng=";
+}

--- a/manifests/forc-explore-0.24.5.nix
+++ b/manifests/forc-explore-0.24.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.24.5";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-explore-0.25.0-nightly-2022-10-06.nix
+++ b/manifests/forc-explore-0.25.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-explore-0.25.0.nix
+++ b/manifests/forc-explore-0.25.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.0";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-explore-0.25.1-nightly-2022-10-07.nix
+++ b/manifests/forc-explore-0.25.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4740fb2f9b9c4c4d6e8ba2110831604b40ccc645";
+  sha256 = "sha256-czP0vMoQE3ZjXFcLHNRKntBkbpJb7yPaMsIwxny+xPM=";
+}

--- a/manifests/forc-explore-0.25.1.nix
+++ b/manifests/forc-explore-0.25.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.1";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
+  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
+}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-08.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.2";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e8a28b5867234a6391bf99ddc55db41957096480";
+  sha256 = "sha256-pw0Zs2LX5D6kyScWDuOz3dobkhRQ5DgySirK4Tj+fBU=";
+}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-09.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.2";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "61d6d659b22c25a606f1437a122176474293180d";
+  sha256 = "sha256-Ch+iPSPFlnzL9JlZXPHhr7fWTJqNIAP0TfKdyQieQ0M=";
+}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-10.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.2";
+  date = "2022-10-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "71999d3774ec617e4b1167d891cadb1e6e9f38af";
+  sha256 = "sha256-jVrjARMBQSgfBJTSfL9xUBB0NjjbSAX0m7uaROG5urA=";
+}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-11.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.2";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb0a5be05549a7a01df684380eaf0c2ec7f46241";
+  sha256 = "sha256-EUmVdkCM6EIL/imd6Xn4/cGp2RyRDcjJ6QjI7BjQNVI=";
+}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-12.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.2";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7554760ba1cde24db5075183ddc9c3f1359066";
+  sha256 = "sha256-uycMRo7+vIkHKQdcCpxh+eGdpBnuq1b674Aw6TXYgU8=";
+}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-13.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.2";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "205073dc30db355f065c29db41d591bfc166f3fa";
+  sha256 = "sha256-c3eAp7XB0ziwC4NLCyQeHgflBuwftCv+gy0P/RwJID0=";
+}

--- a/manifests/forc-explore-0.25.2.nix
+++ b/manifests/forc-explore-0.25.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.25.2";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
+  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
+}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-14.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.26.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-15.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.26.0";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a9eaef219282566e99d57ff993c613317a9143a9";
+  sha256 = "sha256-noZchaj5q6Y5rp1t6VOfmV96ggJZDNdNMtEmdsbK0cg=";
+}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-16.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.26.0";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a1d40f58883e3fe8d23140fbf922d263f17b7c20";
+  sha256 = "sha256-3WPBVNfM/lkyA44mVqqR05t0pBfgI5vnBIOGJSMfeW8=";
+}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-17.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.26.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "314648f8448cefad534f129431ebd15f06e8b418";
+  sha256 = "sha256-zXLLLvftB+aTX4ZFbjfQ/1YLBLCX70ASZ8U6Z1ppXH8=";
+}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-18.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.26.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dbd6b9211fd3c4ceeb34b3f6aedb0a7b9f0e6ef8";
+  sha256 = "sha256-Qhf/QDTkb68kX4feeTtdMjSTt34xKhNeRAlhgxGF6wU=";
+}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-19.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.26.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a2395b4c99c299cf246f1b1ef59785345c94641e";
+  sha256 = "sha256-GvqPVs1EtRuygKA8kEdZyImxlM835AVMKgK74rnX2wk=";
+}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-21.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.26.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0e84d98a06d32a036d88198505e0d6868c985f25";
+  sha256 = "sha256-38yHKfdmro4oDIYQy2HiSgTP3w4soKLiLPRJBUWa4Pg=";
+}

--- a/manifests/forc-explore-0.26.0.nix
+++ b/manifests/forc-explore-0.26.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.26.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-fmt-0.24.4-nightly-2022-09-24.nix
+++ b/manifests/forc-fmt-0.24.4-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.4";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7d000fff4dc27c2ce0ca779a6e204fb0d4e720c";
+  sha256 = "sha256-qtbxzFic0c9x6fbu4t8hdDkKXP9QTF5QcY9hZ+8qYv0=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-09-25.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-09-27.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "535174be2759db62d0838957cf4f89f2c9d8ec71";
+  sha256 = "sha256-nqO6tKI6liTYLXHVIyImfFWeBmu2Z70jEMGAjT7WAic=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-09-28.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5e543382e00a843adb2f64d03eea8576e4c1d53";
+  sha256 = "sha256-nm4FY6pisendzf+hgCm9zDieqVAyRtDNDXjZca79brM=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-09-29.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e6afd8987ead0d453efb5f35e29ce7ba1a0cd070";
+  sha256 = "sha256-Xo8OXRT9UtkEvZvbMAteolHsPKjtx7kl9CZaCuGhV/w=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-09-30.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "076e95fcdb9efc4052dec827418274681d26b00e";
+  sha256 = "sha256-89ZfhctqiTKbwCEz03r9A1AYJ/l+UHsKdCt5mnl6WvM=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-10-01.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e15d71c176359844341e2621a0431f58dfd13c2e";
+  sha256 = "sha256-IAkBhCN7hPGVTBHquhAt0+nEB+0yLM6smnc8pghO/wA=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-10-02.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7b9a022df54ed75832d93833587855af0d08fa";
+  sha256 = "sha256-GJzUqffmvc1CH5K9TeAHvwLs6FyA6/2YSg1RUnpgYio=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-10-03.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-10-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe47d44458c1433140afd30a304e2723d1805b5";
+  sha256 = "sha256-sBYTj7BwGyvdw4FTQt331Y/I7XrZVTgrTJIJ/FgPc70=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-10-04.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-10-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-10-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a917c66ff1d402c7350664c648e8704b50085281";
+  sha256 = "sha256-jCHeqg6SIP8fnAHm3ZeQt9CdEDz1Cr81NcapE4jQx70=";
+}

--- a/manifests/forc-fmt-0.24.5-nightly-2022-10-05.nix
+++ b/manifests/forc-fmt-0.24.5-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a8f0c39d0bb3e0424a5cdabf0b625b73c90667c";
+  sha256 = "sha256-8Y1IUqYWk29szUFWBwrk4fGDRvIKcC9XY2Zu/h89Jng=";
+}

--- a/manifests/forc-fmt-0.24.5.nix
+++ b/manifests/forc-fmt-0.24.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.24.5";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-fmt-0.25.0-nightly-2022-10-06.nix
+++ b/manifests/forc-fmt-0.25.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-fmt-0.25.0.nix
+++ b/manifests/forc-fmt-0.25.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.0";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-fmt-0.25.1-nightly-2022-10-07.nix
+++ b/manifests/forc-fmt-0.25.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4740fb2f9b9c4c4d6e8ba2110831604b40ccc645";
+  sha256 = "sha256-czP0vMoQE3ZjXFcLHNRKntBkbpJb7yPaMsIwxny+xPM=";
+}

--- a/manifests/forc-fmt-0.25.1.nix
+++ b/manifests/forc-fmt-0.25.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.1";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
+  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
+}

--- a/manifests/forc-fmt-0.25.2-nightly-2022-10-08.nix
+++ b/manifests/forc-fmt-0.25.2-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.2";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e8a28b5867234a6391bf99ddc55db41957096480";
+  sha256 = "sha256-pw0Zs2LX5D6kyScWDuOz3dobkhRQ5DgySirK4Tj+fBU=";
+}

--- a/manifests/forc-fmt-0.25.2-nightly-2022-10-09.nix
+++ b/manifests/forc-fmt-0.25.2-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.2";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "61d6d659b22c25a606f1437a122176474293180d";
+  sha256 = "sha256-Ch+iPSPFlnzL9JlZXPHhr7fWTJqNIAP0TfKdyQieQ0M=";
+}

--- a/manifests/forc-fmt-0.25.2-nightly-2022-10-10.nix
+++ b/manifests/forc-fmt-0.25.2-nightly-2022-10-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.2";
+  date = "2022-10-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "71999d3774ec617e4b1167d891cadb1e6e9f38af";
+  sha256 = "sha256-jVrjARMBQSgfBJTSfL9xUBB0NjjbSAX0m7uaROG5urA=";
+}

--- a/manifests/forc-fmt-0.25.2-nightly-2022-10-11.nix
+++ b/manifests/forc-fmt-0.25.2-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.2";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb0a5be05549a7a01df684380eaf0c2ec7f46241";
+  sha256 = "sha256-EUmVdkCM6EIL/imd6Xn4/cGp2RyRDcjJ6QjI7BjQNVI=";
+}

--- a/manifests/forc-fmt-0.25.2-nightly-2022-10-12.nix
+++ b/manifests/forc-fmt-0.25.2-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.2";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7554760ba1cde24db5075183ddc9c3f1359066";
+  sha256 = "sha256-uycMRo7+vIkHKQdcCpxh+eGdpBnuq1b674Aw6TXYgU8=";
+}

--- a/manifests/forc-fmt-0.25.2-nightly-2022-10-13.nix
+++ b/manifests/forc-fmt-0.25.2-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.2";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "205073dc30db355f065c29db41d591bfc166f3fa";
+  sha256 = "sha256-c3eAp7XB0ziwC4NLCyQeHgflBuwftCv+gy0P/RwJID0=";
+}

--- a/manifests/forc-fmt-0.25.2.nix
+++ b/manifests/forc-fmt-0.25.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.25.2";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
+  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
+}

--- a/manifests/forc-fmt-0.26.0-nightly-2022-10-14.nix
+++ b/manifests/forc-fmt-0.26.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.26.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-fmt-0.26.0-nightly-2022-10-15.nix
+++ b/manifests/forc-fmt-0.26.0-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.26.0";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a9eaef219282566e99d57ff993c613317a9143a9";
+  sha256 = "sha256-noZchaj5q6Y5rp1t6VOfmV96ggJZDNdNMtEmdsbK0cg=";
+}

--- a/manifests/forc-fmt-0.26.0-nightly-2022-10-16.nix
+++ b/manifests/forc-fmt-0.26.0-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.26.0";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a1d40f58883e3fe8d23140fbf922d263f17b7c20";
+  sha256 = "sha256-3WPBVNfM/lkyA44mVqqR05t0pBfgI5vnBIOGJSMfeW8=";
+}

--- a/manifests/forc-fmt-0.26.0-nightly-2022-10-17.nix
+++ b/manifests/forc-fmt-0.26.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.26.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "314648f8448cefad534f129431ebd15f06e8b418";
+  sha256 = "sha256-zXLLLvftB+aTX4ZFbjfQ/1YLBLCX70ASZ8U6Z1ppXH8=";
+}

--- a/manifests/forc-fmt-0.26.0-nightly-2022-10-18.nix
+++ b/manifests/forc-fmt-0.26.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.26.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dbd6b9211fd3c4ceeb34b3f6aedb0a7b9f0e6ef8";
+  sha256 = "sha256-Qhf/QDTkb68kX4feeTtdMjSTt34xKhNeRAlhgxGF6wU=";
+}

--- a/manifests/forc-fmt-0.26.0-nightly-2022-10-19.nix
+++ b/manifests/forc-fmt-0.26.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.26.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a2395b4c99c299cf246f1b1ef59785345c94641e";
+  sha256 = "sha256-GvqPVs1EtRuygKA8kEdZyImxlM835AVMKgK74rnX2wk=";
+}

--- a/manifests/forc-fmt-0.26.0-nightly-2022-10-21.nix
+++ b/manifests/forc-fmt-0.26.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.26.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0e84d98a06d32a036d88198505e0d6868c985f25";
+  sha256 = "sha256-38yHKfdmro4oDIYQy2HiSgTP3w4soKLiLPRJBUWa4Pg=";
+}

--- a/manifests/forc-fmt-0.26.0.nix
+++ b/manifests/forc-fmt-0.26.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.26.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-lsp-0.24.4-nightly-2022-09-24.nix
+++ b/manifests/forc-lsp-0.24.4-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.4";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7d000fff4dc27c2ce0ca779a6e204fb0d4e720c";
+  sha256 = "sha256-qtbxzFic0c9x6fbu4t8hdDkKXP9QTF5QcY9hZ+8qYv0=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-09-25.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-09-27.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "535174be2759db62d0838957cf4f89f2c9d8ec71";
+  sha256 = "sha256-nqO6tKI6liTYLXHVIyImfFWeBmu2Z70jEMGAjT7WAic=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-09-28.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5e543382e00a843adb2f64d03eea8576e4c1d53";
+  sha256 = "sha256-nm4FY6pisendzf+hgCm9zDieqVAyRtDNDXjZca79brM=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-09-29.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e6afd8987ead0d453efb5f35e29ce7ba1a0cd070";
+  sha256 = "sha256-Xo8OXRT9UtkEvZvbMAteolHsPKjtx7kl9CZaCuGhV/w=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-09-30.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "076e95fcdb9efc4052dec827418274681d26b00e";
+  sha256 = "sha256-89ZfhctqiTKbwCEz03r9A1AYJ/l+UHsKdCt5mnl6WvM=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-10-01.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e15d71c176359844341e2621a0431f58dfd13c2e";
+  sha256 = "sha256-IAkBhCN7hPGVTBHquhAt0+nEB+0yLM6smnc8pghO/wA=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-10-02.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7b9a022df54ed75832d93833587855af0d08fa";
+  sha256 = "sha256-GJzUqffmvc1CH5K9TeAHvwLs6FyA6/2YSg1RUnpgYio=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-10-03.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-10-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe47d44458c1433140afd30a304e2723d1805b5";
+  sha256 = "sha256-sBYTj7BwGyvdw4FTQt331Y/I7XrZVTgrTJIJ/FgPc70=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-10-04.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-10-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-10-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a917c66ff1d402c7350664c648e8704b50085281";
+  sha256 = "sha256-jCHeqg6SIP8fnAHm3ZeQt9CdEDz1Cr81NcapE4jQx70=";
+}

--- a/manifests/forc-lsp-0.24.5-nightly-2022-10-05.nix
+++ b/manifests/forc-lsp-0.24.5-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a8f0c39d0bb3e0424a5cdabf0b625b73c90667c";
+  sha256 = "sha256-8Y1IUqYWk29szUFWBwrk4fGDRvIKcC9XY2Zu/h89Jng=";
+}

--- a/manifests/forc-lsp-0.24.5.nix
+++ b/manifests/forc-lsp-0.24.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.24.5";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-lsp-0.25.0-nightly-2022-10-06.nix
+++ b/manifests/forc-lsp-0.25.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-lsp-0.25.0.nix
+++ b/manifests/forc-lsp-0.25.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.0";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-lsp-0.25.1-nightly-2022-10-07.nix
+++ b/manifests/forc-lsp-0.25.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4740fb2f9b9c4c4d6e8ba2110831604b40ccc645";
+  sha256 = "sha256-czP0vMoQE3ZjXFcLHNRKntBkbpJb7yPaMsIwxny+xPM=";
+}

--- a/manifests/forc-lsp-0.25.1.nix
+++ b/manifests/forc-lsp-0.25.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.1";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
+  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
+}

--- a/manifests/forc-lsp-0.25.2-nightly-2022-10-08.nix
+++ b/manifests/forc-lsp-0.25.2-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.2";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e8a28b5867234a6391bf99ddc55db41957096480";
+  sha256 = "sha256-pw0Zs2LX5D6kyScWDuOz3dobkhRQ5DgySirK4Tj+fBU=";
+}

--- a/manifests/forc-lsp-0.25.2-nightly-2022-10-09.nix
+++ b/manifests/forc-lsp-0.25.2-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.2";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "61d6d659b22c25a606f1437a122176474293180d";
+  sha256 = "sha256-Ch+iPSPFlnzL9JlZXPHhr7fWTJqNIAP0TfKdyQieQ0M=";
+}

--- a/manifests/forc-lsp-0.25.2-nightly-2022-10-10.nix
+++ b/manifests/forc-lsp-0.25.2-nightly-2022-10-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.2";
+  date = "2022-10-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "71999d3774ec617e4b1167d891cadb1e6e9f38af";
+  sha256 = "sha256-jVrjARMBQSgfBJTSfL9xUBB0NjjbSAX0m7uaROG5urA=";
+}

--- a/manifests/forc-lsp-0.25.2-nightly-2022-10-11.nix
+++ b/manifests/forc-lsp-0.25.2-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.2";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb0a5be05549a7a01df684380eaf0c2ec7f46241";
+  sha256 = "sha256-EUmVdkCM6EIL/imd6Xn4/cGp2RyRDcjJ6QjI7BjQNVI=";
+}

--- a/manifests/forc-lsp-0.25.2-nightly-2022-10-12.nix
+++ b/manifests/forc-lsp-0.25.2-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.2";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7554760ba1cde24db5075183ddc9c3f1359066";
+  sha256 = "sha256-uycMRo7+vIkHKQdcCpxh+eGdpBnuq1b674Aw6TXYgU8=";
+}

--- a/manifests/forc-lsp-0.25.2-nightly-2022-10-13.nix
+++ b/manifests/forc-lsp-0.25.2-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.2";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "205073dc30db355f065c29db41d591bfc166f3fa";
+  sha256 = "sha256-c3eAp7XB0ziwC4NLCyQeHgflBuwftCv+gy0P/RwJID0=";
+}

--- a/manifests/forc-lsp-0.25.2.nix
+++ b/manifests/forc-lsp-0.25.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.25.2";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
+  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
+}

--- a/manifests/forc-lsp-0.26.0-nightly-2022-10-14.nix
+++ b/manifests/forc-lsp-0.26.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.26.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-lsp-0.26.0-nightly-2022-10-15.nix
+++ b/manifests/forc-lsp-0.26.0-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.26.0";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a9eaef219282566e99d57ff993c613317a9143a9";
+  sha256 = "sha256-noZchaj5q6Y5rp1t6VOfmV96ggJZDNdNMtEmdsbK0cg=";
+}

--- a/manifests/forc-lsp-0.26.0-nightly-2022-10-16.nix
+++ b/manifests/forc-lsp-0.26.0-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.26.0";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a1d40f58883e3fe8d23140fbf922d263f17b7c20";
+  sha256 = "sha256-3WPBVNfM/lkyA44mVqqR05t0pBfgI5vnBIOGJSMfeW8=";
+}

--- a/manifests/forc-lsp-0.26.0-nightly-2022-10-17.nix
+++ b/manifests/forc-lsp-0.26.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.26.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "314648f8448cefad534f129431ebd15f06e8b418";
+  sha256 = "sha256-zXLLLvftB+aTX4ZFbjfQ/1YLBLCX70ASZ8U6Z1ppXH8=";
+}

--- a/manifests/forc-lsp-0.26.0-nightly-2022-10-18.nix
+++ b/manifests/forc-lsp-0.26.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.26.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dbd6b9211fd3c4ceeb34b3f6aedb0a7b9f0e6ef8";
+  sha256 = "sha256-Qhf/QDTkb68kX4feeTtdMjSTt34xKhNeRAlhgxGF6wU=";
+}

--- a/manifests/forc-lsp-0.26.0-nightly-2022-10-19.nix
+++ b/manifests/forc-lsp-0.26.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.26.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a2395b4c99c299cf246f1b1ef59785345c94641e";
+  sha256 = "sha256-GvqPVs1EtRuygKA8kEdZyImxlM835AVMKgK74rnX2wk=";
+}

--- a/manifests/forc-lsp-0.26.0-nightly-2022-10-21.nix
+++ b/manifests/forc-lsp-0.26.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.26.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0e84d98a06d32a036d88198505e0d6868c985f25";
+  sha256 = "sha256-38yHKfdmro4oDIYQy2HiSgTP3w4soKLiLPRJBUWa4Pg=";
+}

--- a/manifests/forc-lsp-0.26.0.nix
+++ b/manifests/forc-lsp-0.26.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.26.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-wallet-0.1.0-nightly-2022-09-24.nix
+++ b/manifests/forc-wallet-0.1.0-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.0";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "906565d7284874c256b31bef85ce48361465bb4d";
+  sha256 = "sha256-fys+EBmOgtXDxpZvNaVw+BHTTzTKQ+TeqwuMrq5peww=";
+}

--- a/manifests/forc-wallet-0.1.0-nightly-2022-09-28.nix
+++ b/manifests/forc-wallet-0.1.0-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.0";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "bc5bcd0dc90cb14bb9a3a736686bf3a81c2b7a9b";
+  sha256 = "sha256-L7GYJzL5Nt2AfwpQt3tlm4FWQHu/Yyog8cD9rUBUOBg=";
+}

--- a/manifests/forc-wallet-0.1.1-nightly-2022-09-29.nix
+++ b/manifests/forc-wallet-0.1.1-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.1";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "26ad2ccd366545376f54ed8d255421846e9833ed";
+  sha256 = "sha256-gzX/U8FLJB8ut1f+uq7IZu5+iPhpjUs+wwZ1HWRj9Dw=";
+}

--- a/manifests/forc-wallet-0.1.1-nightly-2022-10-01.nix
+++ b/manifests/forc-wallet-0.1.1-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.1";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "52e9089cd2760be6d3422124b768c5225ec5a641";
+  sha256 = "sha256-YIpQJBEk3Sw14/EymwA40z8GAOF6mKEDu4L3tRaxTMk=";
+}

--- a/manifests/forc-wallet-0.1.1.nix
+++ b/manifests/forc-wallet-0.1.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.1";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "26ad2ccd366545376f54ed8d255421846e9833ed";
+  sha256 = "sha256-gzX/U8FLJB8ut1f+uq7IZu5+iPhpjUs+wwZ1HWRj9Dw=";
+}

--- a/manifests/forc-wallet-0.1.2-nightly-2022-10-02.nix
+++ b/manifests/forc-wallet-0.1.2-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.2";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "9473052e88048f58e8c4e1eba0ff88ef6a4cdd59";
+  sha256 = "sha256-JZqq+lfkDtlYMiPuLZVDGJMRqnblJ8V6qiBueHII6oU=";
+}

--- a/manifests/forc-wallet-0.1.2-nightly-2022-10-11.nix
+++ b/manifests/forc-wallet-0.1.2-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.2";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "4ee5257ecac3322bb89676d253c4706ae81cf969";
+  sha256 = "sha256-Ve4Q8jDXPaRykxXdZhYqdd7+xmOczvn3AFACETDMOcw=";
+}

--- a/manifests/forc-wallet-0.1.2-nightly-2022-10-15.nix
+++ b/manifests/forc-wallet-0.1.2-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.2";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "ad1d7830b9ff9bb83e008c0a0c5606bc17d96ede";
+  sha256 = "sha256-5b7W5XLZ/fwGZe9kKnEDp69GjJ+8GqkXApctyzLw2S4=";
+}

--- a/manifests/forc-wallet-0.1.2.nix
+++ b/manifests/forc-wallet-0.1.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.2";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "9473052e88048f58e8c4e1eba0ff88ef6a4cdd59";
+  sha256 = "sha256-JZqq+lfkDtlYMiPuLZVDGJMRqnblJ8V6qiBueHII6oU=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-09-24.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "96e526e931406779198869f7dc0a88024c4c6c10";
+  sha256 = "sha256-WVTMNT+MJ7TMZBGmxbHKrD9p5jl58OK89NPJq7R5IWc=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-09-25.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "b869d0cec27c1c8dad2eda298ff753f9c752c34f";
+  sha256 = "sha256-pO9XFCcsV2bYcHPFct6LqKMnODJ9EJeqJKLj/u/pgQE=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-09-28.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "5adbad955902baa0f7b9e7d1b9bc7c6840960348";
+  sha256 = "sha256-Yk4Un1X82vdc8ov0Ek22Bk/EyZqB3q7dFR/xUeNTK0I=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-09-29.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "f4d84f51cdc5cb5f5f4a3718ebb3162078e9b485";
+  sha256 = "sha256-6aWJNgcc5jRR3EiqGJYv/s3bDrjmvE6BdYEHaQ/tkqc=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-09-30.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "ee8cd4269fcd3c5c3d20792b699ace9451863f63";
+  sha256 = "sha256-LTthp8B6g7u64hHtATD1AseiIOhuc1oUpVglMKd9r+8=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-10-01.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e54e28849b6e9aa2fbea583133d7ae774491281b";
+  sha256 = "sha256-tfUj/unLA6tg4cWMlhaTGI3aoplbvaYpMW5eQEn3UN0=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-10-05.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "05137b29524080bbcf1c1e4b211d9176ab5f2c2d";
+  sha256 = "sha256-kAm3EdoF9BpDs7j5jySgRFr96v0uIquKajd4phN4ZE8=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-10-07.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "5af563cdbf9d581d8e9cdc945da5950e4e6a073e";
+  sha256 = "sha256-8XdgTZmpiOK74uXe+gV8UoRYeIIHL6RfdEfQlCxsWAs=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-10-08.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "15e097e0a6081666409c6f57a530b98af3fad375";
+  sha256 = "sha256-OAnpHXRFu4YiefzQ4BYjRVi9Rs+YeRgZn7mKUOrqgqg=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-10-11.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "8fad2ecac08429d29e9f84699d513babaa2762b8";
+  sha256 = "sha256-JetaA7QhQ7/Bm8HI8T2WKmNMHp0bccHMVESIhCt1QIs=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-10-12.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4eb8da604ecf214ac5d1796076d70b966799a3ee";
+  sha256 = "sha256-Q4PyHSLTQGSe4ydc+W21IwEqjoJetlXn6Od1uWoPcz4=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-10-13.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "00740186f7a6dbc7134918d7f9d62f55e887a807";
+  sha256 = "sha256-89n83cI0YZyn/AXgdpclGsNeQCVxfGXA9FEFpiOB9Cs=";
+}

--- a/manifests/fuel-core-0.10.1-nightly-2022-10-14.nix
+++ b/manifests/fuel-core-0.10.1-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.10.1";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "da0a38fc3cfaf83b1f13fb032f45fe711e68b7b1";
+  sha256 = "sha256-6LFNShZWSrhz6s2BGYZ3EZI2R5PP09t5zRRatSYWCyc=";
+}

--- a/manifests/fuel-core-0.11.0.nix
+++ b/manifests/fuel-core-0.11.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.11.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "c5c6ff6b5d936c5fefa4e813ed3058e5edbdf2cb";
+  sha256 = "sha256-s59pnFh6vEFQO6575QznnIBqegUfS3aXDa7PNJiGte0=";
+}

--- a/manifests/fuel-core-0.11.1-nightly-2022-10-15.nix
+++ b/manifests/fuel-core-0.11.1-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.11.1";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1f50e628f253dc9373a3dde078893e3ecfa3bdac";
+  sha256 = "sha256-kr0PCnFu2WZ5qrir6XOXjqvHGQ4TvHxXzH+DJMAXMdw=";
+}

--- a/manifests/fuel-core-0.11.1.nix
+++ b/manifests/fuel-core-0.11.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.11.1";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1f50e628f253dc9373a3dde078893e3ecfa3bdac";
+  sha256 = "sha256-kr0PCnFu2WZ5qrir6XOXjqvHGQ4TvHxXzH+DJMAXMdw=";
+}

--- a/manifests/fuel-core-0.11.2-nightly-2022-10-16.nix
+++ b/manifests/fuel-core-0.11.2-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.11.2";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e908718de48e2b24c2c908a4eb892d6f5a336738";
+  sha256 = "sha256-Tew+KpAW2Guw/nLOUiWen17wJOwLeZ64zFJx2gkAvMY=";
+}

--- a/manifests/fuel-core-0.11.2-nightly-2022-10-17.nix
+++ b/manifests/fuel-core-0.11.2-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.11.2";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "106002abdf659c5c4a3bb912e0a2ae9aa141405e";
+  sha256 = "sha256-+6w1OCiJ19J/wZRxNMueJLjFveDethqezP/vbr+fJU8=";
+}

--- a/manifests/fuel-core-0.11.2-nightly-2022-10-20.nix
+++ b/manifests/fuel-core-0.11.2-nightly-2022-10-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.11.2";
+  date = "2022-10-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "5df9fe8fd7fb70c6fc656b5223116ebeb4fa35f4";
+  sha256 = "sha256-TB+1dzlJGM+wHVdawu/9H4hL2Jg+a6Xqyr2m8YRp+z4=";
+}

--- a/manifests/fuel-core-0.11.2.nix
+++ b/manifests/fuel-core-0.11.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.11.2";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "ebc75e7b7107a563be7d1523270b18eebecd2dde";
+  sha256 = "sha256-/iZYCqHZS92coLj44ddl5i/kq38EeT1y5vTa5mdm2CQ=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-24.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "96e526e931406779198869f7dc0a88024c4c6c10";
+  sha256 = "sha256-WVTMNT+MJ7TMZBGmxbHKrD9p5jl58OK89NPJq7R5IWc=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-25.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "b869d0cec27c1c8dad2eda298ff753f9c752c34f";
+  sha256 = "sha256-pO9XFCcsV2bYcHPFct6LqKMnODJ9EJeqJKLj/u/pgQE=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-28.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "5adbad955902baa0f7b9e7d1b9bc7c6840960348";
+  sha256 = "sha256-Yk4Un1X82vdc8ov0Ek22Bk/EyZqB3q7dFR/xUeNTK0I=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-29.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "f4d84f51cdc5cb5f5f4a3718ebb3162078e9b485";
+  sha256 = "sha256-6aWJNgcc5jRR3EiqGJYv/s3bDrjmvE6BdYEHaQ/tkqc=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-30.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "ee8cd4269fcd3c5c3d20792b699ace9451863f63";
+  sha256 = "sha256-LTthp8B6g7u64hHtATD1AseiIOhuc1oUpVglMKd9r+8=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-01.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e54e28849b6e9aa2fbea583133d7ae774491281b";
+  sha256 = "sha256-tfUj/unLA6tg4cWMlhaTGI3aoplbvaYpMW5eQEn3UN0=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-05.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "05137b29524080bbcf1c1e4b211d9176ab5f2c2d";
+  sha256 = "sha256-kAm3EdoF9BpDs7j5jySgRFr96v0uIquKajd4phN4ZE8=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-07.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "5af563cdbf9d581d8e9cdc945da5950e4e6a073e";
+  sha256 = "sha256-8XdgTZmpiOK74uXe+gV8UoRYeIIHL6RfdEfQlCxsWAs=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-08.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "15e097e0a6081666409c6f57a530b98af3fad375";
+  sha256 = "sha256-OAnpHXRFu4YiefzQ4BYjRVi9Rs+YeRgZn7mKUOrqgqg=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-11.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "8fad2ecac08429d29e9f84699d513babaa2762b8";
+  sha256 = "sha256-JetaA7QhQ7/Bm8HI8T2WKmNMHp0bccHMVESIhCt1QIs=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-12.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4eb8da604ecf214ac5d1796076d70b966799a3ee";
+  sha256 = "sha256-Q4PyHSLTQGSe4ydc+W21IwEqjoJetlXn6Od1uWoPcz4=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-13.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "00740186f7a6dbc7134918d7f9d62f55e887a807";
+  sha256 = "sha256-89n83cI0YZyn/AXgdpclGsNeQCVxfGXA9FEFpiOB9Cs=";
+}

--- a/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-14.nix
+++ b/manifests/fuel-gql-cli-0.10.1-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.10.1";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "da0a38fc3cfaf83b1f13fb032f45fe711e68b7b1";
+  sha256 = "sha256-6LFNShZWSrhz6s2BGYZ3EZI2R5PP09t5zRRatSYWCyc=";
+}

--- a/manifests/fuel-gql-cli-0.11.0.nix
+++ b/manifests/fuel-gql-cli-0.11.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.11.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "c5c6ff6b5d936c5fefa4e813ed3058e5edbdf2cb";
+  sha256 = "sha256-s59pnFh6vEFQO6575QznnIBqegUfS3aXDa7PNJiGte0=";
+}

--- a/manifests/fuel-gql-cli-0.11.1-nightly-2022-10-15.nix
+++ b/manifests/fuel-gql-cli-0.11.1-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.11.1";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1f50e628f253dc9373a3dde078893e3ecfa3bdac";
+  sha256 = "sha256-kr0PCnFu2WZ5qrir6XOXjqvHGQ4TvHxXzH+DJMAXMdw=";
+}

--- a/manifests/fuel-gql-cli-0.11.1.nix
+++ b/manifests/fuel-gql-cli-0.11.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.11.1";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1f50e628f253dc9373a3dde078893e3ecfa3bdac";
+  sha256 = "sha256-kr0PCnFu2WZ5qrir6XOXjqvHGQ4TvHxXzH+DJMAXMdw=";
+}

--- a/manifests/fuel-gql-cli-0.11.2-nightly-2022-10-16.nix
+++ b/manifests/fuel-gql-cli-0.11.2-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.11.2";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e908718de48e2b24c2c908a4eb892d6f5a336738";
+  sha256 = "sha256-Tew+KpAW2Guw/nLOUiWen17wJOwLeZ64zFJx2gkAvMY=";
+}

--- a/manifests/fuel-gql-cli-0.11.2-nightly-2022-10-17.nix
+++ b/manifests/fuel-gql-cli-0.11.2-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.11.2";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "106002abdf659c5c4a3bb912e0a2ae9aa141405e";
+  sha256 = "sha256-+6w1OCiJ19J/wZRxNMueJLjFveDethqezP/vbr+fJU8=";
+}

--- a/manifests/fuel-gql-cli-0.11.2-nightly-2022-10-20.nix
+++ b/manifests/fuel-gql-cli-0.11.2-nightly-2022-10-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.11.2";
+  date = "2022-10-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "5df9fe8fd7fb70c6fc656b5223116ebeb4fa35f4";
+  sha256 = "sha256-TB+1dzlJGM+wHVdawu/9H4hL2Jg+a6Xqyr2m8YRp+z4=";
+}

--- a/manifests/fuel-gql-cli-0.11.2.nix
+++ b/manifests/fuel-gql-cli-0.11.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.11.2";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "ebc75e7b7107a563be7d1523270b18eebecd2dde";
+  sha256 = "sha256-/iZYCqHZS92coLj44ddl5i/kq38EeT1y5vTa5mdm2CQ=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -165,4 +165,18 @@
       doCheck = false; # Already tested at repo.
     };
   }
+
+  # At some point around this date, Sway LSP started requiring the CoreServices
+  # framework on Darwin due to a dependency update. Here we just make it
+  # available to all fuel packages going forward.
+  {
+    condition = m: pkgs.lib.hasInfix "darwin" pkgs.system && m.date >= "2022-10-10";
+    patch = m: {
+      buildInputs =
+        (m.buildInputs or [])
+        ++ [
+          pkgs.darwin.apple_sdk.frameworks.CoreServices
+        ];
+    };
+  }
 ]

--- a/patches.nix
+++ b/patches.nix
@@ -154,4 +154,15 @@
       rust = pkgs.rust-bin.stable."1.64.0".default;
     };
   }
+
+  # Since this date, `forc-wallet` got some tests that require doing file
+  # operations that are unpermitted in Nix's sandbox during a build. These
+  # tests are run at `forc-wallet`'s repo CI, so it's fine to disable the check
+  # here.
+  {
+    condition = m: m.pname == "forc-wallet" && m.date >= "2022-10-10";
+    patch = m: {
+      doCheck = false; # Already tested at repo.
+    };
+  }
 ]


### PR DESCRIPTION
This updates all latest and nightly fuel packages and makes the manifests available for all versions released over the past month.

Achieved by `cd`ing into a local checkout and running:

```console
nix run .#refresh-manifests
```

Until #22 lands, we'll need to continue to manually refresh these manifests like this when we want to update.