### PR TITLE
Don't build/run `forc` tests - they're already run during CI. Refresh manifests.

### DIFF
--- a/manifests/forc-0.29.0-nightly-2022-11-01.nix
+++ b/manifests/forc-0.29.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.29.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bdc3160d92539dee21378633b24475b6d6666e0c";
+  sha256 = "sha256-za7htSCITOpeMWCM/duj9JDIK6UXUedIRs4ydhtJJKM=";
+}

--- a/manifests/forc-0.29.0-nightly-2022-11-02.nix
+++ b/manifests/forc-0.29.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.29.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b0f05c4c1c30d691c34b828c50ff641415eb2530";
+  sha256 = "sha256-EJJGk6iCFwcEEsGYHVsUx+Y2OAjdE98pCCgyqeweD9Q=";
+}

--- a/manifests/forc-0.29.0.nix
+++ b/manifests/forc-0.29.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.29.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
+  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
+}

--- a/manifests/forc-0.30.0-nightly-2022-11-03.nix
+++ b/manifests/forc-0.30.0-nightly-2022-11-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.30.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ff747c226b7bebcdf62960f2040550cec33666c6";
+  sha256 = "sha256-NXzLpC1IxRqF+TvJKwO8bxww9rKpFCjbo+Ou+fMquXY=";
+}

--- a/manifests/forc-0.30.0-nightly-2022-11-04.nix
+++ b/manifests/forc-0.30.0-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.30.0";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4a5e93f5fc66168d70a0f11f0a3ef1ee4ff11c31";
+  sha256 = "sha256-vVMlYw7BAWfOZ2n/n4wtVNZXd1ehsppQLyux3nVNpAA=";
+}

--- a/manifests/forc-0.30.0-nightly-2022-11-05.nix
+++ b/manifests/forc-0.30.0-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.30.0";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-0.30.0.nix
+++ b/manifests/forc-0.30.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.30.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "37deaee8fccf5804d78a003cf64f14fac654fc41";
+  sha256 = "sha256-BIVBDX3i2ym6d/90AuK/I/ATtJqUFZS9OdltCdBtqI0=";
+}

--- a/manifests/forc-0.30.1.nix
+++ b/manifests/forc-0.30.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.30.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-client-0.29.0-nightly-2022-11-01.nix
+++ b/manifests/forc-client-0.29.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.29.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bdc3160d92539dee21378633b24475b6d6666e0c";
+  sha256 = "sha256-za7htSCITOpeMWCM/duj9JDIK6UXUedIRs4ydhtJJKM=";
+}

--- a/manifests/forc-client-0.29.0-nightly-2022-11-02.nix
+++ b/manifests/forc-client-0.29.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.29.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b0f05c4c1c30d691c34b828c50ff641415eb2530";
+  sha256 = "sha256-EJJGk6iCFwcEEsGYHVsUx+Y2OAjdE98pCCgyqeweD9Q=";
+}

--- a/manifests/forc-client-0.29.0.nix
+++ b/manifests/forc-client-0.29.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.29.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
+  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
+}

--- a/manifests/forc-client-0.30.0-nightly-2022-11-03.nix
+++ b/manifests/forc-client-0.30.0-nightly-2022-11-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.30.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ff747c226b7bebcdf62960f2040550cec33666c6";
+  sha256 = "sha256-NXzLpC1IxRqF+TvJKwO8bxww9rKpFCjbo+Ou+fMquXY=";
+}

--- a/manifests/forc-client-0.30.0-nightly-2022-11-04.nix
+++ b/manifests/forc-client-0.30.0-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.30.0";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4a5e93f5fc66168d70a0f11f0a3ef1ee4ff11c31";
+  sha256 = "sha256-vVMlYw7BAWfOZ2n/n4wtVNZXd1ehsppQLyux3nVNpAA=";
+}

--- a/manifests/forc-client-0.30.0-nightly-2022-11-05.nix
+++ b/manifests/forc-client-0.30.0-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.30.0";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-client-0.30.0.nix
+++ b/manifests/forc-client-0.30.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.30.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "37deaee8fccf5804d78a003cf64f14fac654fc41";
+  sha256 = "sha256-BIVBDX3i2ym6d/90AuK/I/ATtJqUFZS9OdltCdBtqI0=";
+}

--- a/manifests/forc-client-0.30.1.nix
+++ b/manifests/forc-client-0.30.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.30.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-explore-0.0.0-nightly-2022-09-01.nix
+++ b/manifests/forc-explore-0.0.0-nightly-2022-09-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.0.0";
+  date = "2022-09-01";
+  url = "https://github.com/fuellabs/forc-explorer";
+  rev = "b660eb736f184d4f2f6972423f109f15bda60e41";
+  sha256 = "sha256-hLB0j8O44D/wbruT1LzVJP9E9Wm3us2OtRrtK/2RgjU=";
+}

--- a/manifests/forc-explore-0.0.0-nightly-2022-10-06.nix
+++ b/manifests/forc-explore-0.0.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.0.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/forc-explorer";
+  rev = "f00da55934d8d11bcb92364ff0d1c608b920f537";
+  sha256 = "sha256-k9lxwIKs9GGaNNxPgjuBrvAMmLXDj5MbmTzyNlHiGPg=";
+}

--- a/manifests/forc-explore-0.0.0-nightly-2022-10-27.nix
+++ b/manifests/forc-explore-0.0.0-nightly-2022-10-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.0.0";
+  date = "2022-10-27";
+  url = "https://github.com/fuellabs/forc-explorer";
+  rev = "76537d536cc75b6a5cef5974eda963cc3fe6a3fc";
+  sha256 = "sha256-dDBXfEa2PDmM94LCUXQr1mTnps0FSDolIPE4Sji8gmQ=";
+}

--- a/manifests/forc-explore-0.0.0-nightly-2022-10-28.nix
+++ b/manifests/forc-explore-0.0.0-nightly-2022-10-28.nix
@@ -1,7 +1,7 @@
 {
   pname = "forc-explore";
-  version = "0.28.1";
-  date = "2022-10-27";
+  version = "0.0.0";
+  date = "2022-10-28";
   url = "https://github.com/fuellabs/forc-explorer";
   rev = "4bb7392eed085ee3a6795b98ea25392b3f41ade8";
   sha256 = "sha256-k8hRcZiKjxh6p0qFRp8xi5oh4k+cgAOylwbq43W7VSA=";

--- a/manifests/forc-explore-0.0.1.nix
+++ b/manifests/forc-explore-0.0.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.0.1";
-  date = "2021-09-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c9781a1acca6eea8a1f2f30607466ae40d76de65";
-  sha256 = "sha256-g6pSdahytTJQJ1rgLCku4289C2dnCLqzvSH8Mq8y26I=";
-}

--- a/manifests/forc-explore-0.0.2.nix
+++ b/manifests/forc-explore-0.0.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.0.2";
-  date = "2021-10-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e0c043bc9463eb266aaf111ff86b8c911602e053";
-  sha256 = "sha256-LwGYEtKpb5eEts1K0TkRPwlWPu7EQLJbtaK8dAFexTk=";
-}

--- a/manifests/forc-explore-0.0.3.nix
+++ b/manifests/forc-explore-0.0.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.0.3";
-  date = "2021-10-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ce7692d119fa9010dd0937b5f10cf5728fe72393";
-  sha256 = "sha256-ygyqjapnGH+tznuYu5x9vnvhfHaoQ82vlyi90s/ZTCU=";
-}

--- a/manifests/forc-explore-0.0.4.nix
+++ b/manifests/forc-explore-0.0.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.0.4";
-  date = "2021-11-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d40239e7d49793c7d3d23e0d3de6595e40b89e11";
-  sha256 = "sha256-Udtk0i4LfiXYMWLZtRiDbjXseqiTs83BJgqHaMvJGLA=";
-}

--- a/manifests/forc-explore-0.1.0.nix
+++ b/manifests/forc-explore-0.1.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.0";
-  date = "2021-12-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "90c9b56a7fc313321fcc7580314284080d00078f";
-  sha256 = "sha256-5VgXmm63O89wp6mayRf6ihMiK/JrXECfkmpo17MPEk4=";
-}

--- a/manifests/forc-explore-0.1.1.nix
+++ b/manifests/forc-explore-0.1.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.1";
-  date = "2021-12-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8a37329cb1848efdeb46e2be1bfdb940b7750262";
-  sha256 = "sha256-Ci4OJGp+iqmojxmf4Cg9m/2WG8jtKOPMDr2z6LDsOdU=";
-}

--- a/manifests/forc-explore-0.1.2.nix
+++ b/manifests/forc-explore-0.1.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.2";
-  date = "2021-12-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2431af753ed8fc0a76df53fc72172cb4bdb5d4b9";
-  sha256 = "sha256-FYwNTSaaZdtDGbOQ5/Tk4+lvyZ3PCJBtnNLE6+PuEng=";
-}

--- a/manifests/forc-explore-0.1.3.nix
+++ b/manifests/forc-explore-0.1.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.3";
-  date = "2021-12-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d30d3225a30c46a9675ca5db270597190cc228bc";
-  sha256 = "sha256-3kvkiTVQ5qSLqBPb3kl2VakJfQlCOYaTY9aonRgN6AY=";
-}

--- a/manifests/forc-explore-0.1.4.nix
+++ b/manifests/forc-explore-0.1.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.4";
-  date = "2021-12-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "46305882aa552be287b28e55606ba74b81070460";
-  sha256 = "sha256-/sFiQmmk/L+qqK9J/BrhPahg0no7YculAbB+TyB9s+Y=";
-}

--- a/manifests/forc-explore-0.1.5.nix
+++ b/manifests/forc-explore-0.1.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.5";
-  date = "2021-12-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1923f44784e6d450796b10addd447aeb3325d519";
-  sha256 = "sha256-X/c/HRNrZu3s/wKU2l9pkuuXpqPFZvqeeziW/9iloK4=";
-}

--- a/manifests/forc-explore-0.1.6.nix
+++ b/manifests/forc-explore-0.1.6.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.6";
-  date = "2021-12-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a38a89a042f7ef13ddf67cc7661b37eac96aad8f";
-  sha256 = "sha256-6HM7WTQsYaOXSvu8Jr0lh6KDQFpFJI+XybvzU8jFEic=";
-}

--- a/manifests/forc-explore-0.1.7.nix
+++ b/manifests/forc-explore-0.1.7.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.7";
-  date = "2021-12-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4038415bf9f681fca220bcf3951230b0e9129ba6";
-  sha256 = "sha256-gcKYLveFcyiZtPxGjtk8W9dYCVdVUSsUMTW071WavX0=";
-}

--- a/manifests/forc-explore-0.1.8.nix
+++ b/manifests/forc-explore-0.1.8.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.8";
-  date = "2021-12-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6fd0bc0b6ecf22f3b334a0c8da86e776a7e2b87d";
-  sha256 = "sha256-2M3FGiWEq++cQIkxECjSHabbVuMTkuvCx0eFIuOSeU0=";
-}

--- a/manifests/forc-explore-0.1.9.nix
+++ b/manifests/forc-explore-0.1.9.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.1.9";
-  date = "2021-12-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6fe6354eb96fa9b85c10e89f628bdf7ee525059d";
-  sha256 = "sha256-Bwn4w93PqCxMquIz52cWQ3u0xtZCXf5TzkKzQvnV15M=";
-}

--- a/manifests/forc-explore-0.10.0.nix
+++ b/manifests/forc-explore-0.10.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.10.0";
-  date = "2022-04-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a88ea439c95d9fb2701d6479ce496dc6571e92c2";
-  sha256 = "sha256-YdU+xBfyQ6M4UVl/bgp5ba0byVUY7BMwryIZnradFNs=";
-}

--- a/manifests/forc-explore-0.10.1.nix
+++ b/manifests/forc-explore-0.10.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.10.1";
-  date = "2022-04-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c85d2b712975669d238233297443557969dec43";
-  sha256 = "sha256-8ocDTtJL468H3PpkQu5b9+lZtfjFP3MDK8YE2LtPYy4=";
-}

--- a/manifests/forc-explore-0.10.2.nix
+++ b/manifests/forc-explore-0.10.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.10.2";
-  date = "2022-04-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "443abbffd520f0f964e837fbc784641741fd7950";
-  sha256 = "sha256-qnU5g9Oxusr67zIIei9cAUqT7VVkA2VDXbarM1abOgc=";
-}

--- a/manifests/forc-explore-0.10.3.nix
+++ b/manifests/forc-explore-0.10.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.10.3";
-  date = "2022-04-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e7676db6f4ebc7a3885f87514d16a703a99410d7";
-  sha256 = "sha256-/pWNhRZm+ev48LgpQhjGWuXG2TLvZSTpPHsZPLHcMiw=";
-}

--- a/manifests/forc-explore-0.11.0.nix
+++ b/manifests/forc-explore-0.11.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.11.0";
-  date = "2022-04-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "95816e4e41aae1d3425ba6ff5e7266076d8400fa";
-  sha256 = "sha256-2XvtFdkQwUVlUVSjQeTUHlEROQ8r1GOcG8uCPM3uDTc=";
-}

--- a/manifests/forc-explore-0.12.1.nix
+++ b/manifests/forc-explore-0.12.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.12.1";
-  date = "2022-05-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a03a5d1c068a91779e5ce08eead6c4626de2eb0d";
-  sha256 = "sha256-nE10IRpnOkNHXfLfYhFhucjJ3JgdPW6AuNneLL14ymI=";
-}

--- a/manifests/forc-explore-0.12.2.nix
+++ b/manifests/forc-explore-0.12.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.12.2";
-  date = "2022-05-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2b6e9384f06692ec627293ae5db5e2f748fe2c30";
-  sha256 = "sha256-HTo5eP8jZP5tzesGGA1i5YUmofsWxFJGKw0oMfvWv0c=";
-}

--- a/manifests/forc-explore-0.13.0.nix
+++ b/manifests/forc-explore-0.13.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.13.0";
-  date = "2022-05-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6eef7ab750cd3282f08b6014960cbc02afae717a";
-  sha256 = "sha256-iT90TBcMgmKTl/2MHR37Vtk7LcOshVMSshlU3BLhAG0=";
-}

--- a/manifests/forc-explore-0.13.1.nix
+++ b/manifests/forc-explore-0.13.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.13.1";
-  date = "2022-05-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d73d9d2b4b547e2035ddfe085d439de56ccee1f0";
-  sha256 = "sha256-jbuvLymTQb8g4ERJeu0K24z2OIw8aDlkBPF+YjiUkIE=";
-}

--- a/manifests/forc-explore-0.13.2.nix
+++ b/manifests/forc-explore-0.13.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.13.2";
-  date = "2022-05-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dac1b96419a6ed46a4c531492ae5e794a270d4a1";
-  sha256 = "sha256-LBuJ2ukkK1FosaLcZ10ds8/7ybN1UU/o0d9dRmbG5a4=";
-}

--- a/manifests/forc-explore-0.14.0.nix
+++ b/manifests/forc-explore-0.14.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.14.0";
-  date = "2022-05-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "953dad9cad0defe50ffe04e4031207fd247b63f1";
-  sha256 = "sha256-/z+nNctB9t1qLKiemsg+QuV2jBnuYgd0tCe3cEkI1OU=";
-}

--- a/manifests/forc-explore-0.14.1.nix
+++ b/manifests/forc-explore-0.14.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.14.1";
-  date = "2022-05-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "02ef7d10b6bf883d73fc1fd23034dc814dfffea2";
-  sha256 = "sha256-8Uh2gbZb1R1llk3h+DeCF3heBO2Ec3nJNqI6hpSTfq8=";
-}

--- a/manifests/forc-explore-0.14.2.nix
+++ b/manifests/forc-explore-0.14.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.14.2";
-  date = "2022-05-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6fc5c69f29a5aab0b6ca677d9384d0d5eaffb232";
-  sha256 = "sha256-JGicorHY6HfSWoZa2nFOnx45qDrnXmORzHOOKHk/6sM=";
-}

--- a/manifests/forc-explore-0.14.3.nix
+++ b/manifests/forc-explore-0.14.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.14.3";
-  date = "2022-05-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "17f856bfa0d500e06fff2c470e8e6113533faf97";
-  sha256 = "sha256-VfyRHFmz89GT7UP/JCR8lPZY5vxhfxnyyWheQdWSRn0=";
-}

--- a/manifests/forc-explore-0.14.4.nix
+++ b/manifests/forc-explore-0.14.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.14.4";
-  date = "2022-05-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b067a7dd64b26bd763eca268fef3849c2c77028d";
-  sha256 = "sha256-VJGi0FlI+majMW66lo4Sxyo9NaaO+LgFyg7hHwckD1k=";
-}

--- a/manifests/forc-explore-0.14.5.nix
+++ b/manifests/forc-explore-0.14.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.14.5";
-  date = "2022-06-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "60c626cf486d5c53c44d84db1ec81cb90174cad3";
-  sha256 = "sha256-3zI62Q+jaZYml3PjHn5Xsx635ARfUPsXBpOGDc0QzVM=";
-}

--- a/manifests/forc-explore-0.15.0.nix
+++ b/manifests/forc-explore-0.15.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.15.0";
-  date = "2022-06-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ee7822c411a3d6135ea590bbc5c85527c4ede6d7";
-  sha256 = "sha256-7qdjLcxcKCHt+RNrVU9WRK+DUepB0G/5RkScHHWRFJQ=";
-}

--- a/manifests/forc-explore-0.15.1.nix
+++ b/manifests/forc-explore-0.15.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.15.1";
-  date = "2022-06-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a34b4b99fcdd065d559f6cbb9dec0697c3f5edd1";
-  sha256 = "sha256-kR1NJqI6fOyDne1zvwIG2M92+dSOn+6Hby+Q4iMJAAQ=";
-}

--- a/manifests/forc-explore-0.15.2.nix
+++ b/manifests/forc-explore-0.15.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.15.2";
-  date = "2022-06-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "eab07e48bc6dbd0c80aedc1e363bb63a6d5f0e28";
-  sha256 = "sha256-vE29EiJYF4T6FW/1odNJyZOc5HKHR5sC10bASSFcmuc=";
-}

--- a/manifests/forc-explore-0.16.0.nix
+++ b/manifests/forc-explore-0.16.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.16.0";
-  date = "2022-06-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "948f7aba42b4138433fb5b61c698c8f4a60db424";
-  sha256 = "sha256-5yPftMl1LJkub2yeGHF1BrLZZSYzg82IYFVpVWG0v48=";
-}

--- a/manifests/forc-explore-0.16.1.nix
+++ b/manifests/forc-explore-0.16.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.16.1";
-  date = "2022-06-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dcf22453aeb054335d96ef810da9d4f756d869b7";
-  sha256 = "sha256-kAZVbgkf7ganCs+sBPL0eMmR3MDCm6s+qL8d1CfHL8U=";
-}

--- a/manifests/forc-explore-0.16.2.nix
+++ b/manifests/forc-explore-0.16.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.16.2";
-  date = "2022-06-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7920330d34c97cf418b6d0e1561f978068158228";
-  sha256 = "sha256-NpCpZYxgJeUcgw5QqnAhzVmEkMrR7cs2Sj6aW6Rm6JU=";
-}

--- a/manifests/forc-explore-0.17.0.nix
+++ b/manifests/forc-explore-0.17.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.17.0";
-  date = "2022-07-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b81bcd9652d4fc9908d1971c9215a7cfdde39adc";
-  sha256 = "sha256-cOyJXvwyZbZeTLfw9xoAtY1rsHN29VXLkRsEeCZyDmI=";
-}

--- a/manifests/forc-explore-0.18.0.nix
+++ b/manifests/forc-explore-0.18.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.18.0";
-  date = "2022-07-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ada0d294a68e5ca3070e3c46eb89619e7d87caf2";
-  sha256 = "sha256-9a39KoLnQ7urf7pBwxFy8B2+SELuhhx6JDZjyZo2rSQ=";
-}

--- a/manifests/forc-explore-0.18.1.nix
+++ b/manifests/forc-explore-0.18.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.18.1";
-  date = "2022-07-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3bd8eaf4a0f11a3009c9421100cc06c2e897b6c2";
-  sha256 = "sha256-WI7srBdT5WAMZ6OfUWAcihZcpxbn/ogfVE3LaoQptcM=";
-}

--- a/manifests/forc-explore-0.19.0.nix
+++ b/manifests/forc-explore-0.19.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.19.0";
-  date = "2022-07-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c716e1ba55d755555ed5aa186c883f73c4f90dc";
-  sha256 = "sha256-DKB7ykAHVte8Dt566iNdY6CIkvs06zRxCWT50LoQRBk=";
-}

--- a/manifests/forc-explore-0.19.1.nix
+++ b/manifests/forc-explore-0.19.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.19.1";
-  date = "2022-08-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1202e790c119ff9f04c847ecaab3411cfaf32f94";
-  sha256 = "sha256-jFtMg6C861fIWZBmX5SbSsvQwPUr+KWQOcQnPDweWUo=";
-}

--- a/manifests/forc-explore-0.19.2.nix
+++ b/manifests/forc-explore-0.19.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.19.2";
-  date = "2022-08-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6808861389966f99887f71476918a562a9edd90e";
-  sha256 = "sha256-LL5jMwMvw//bN8SkI5K/tNF+7NKuuOXpcMGezEmrQ4g=";
-}

--- a/manifests/forc-explore-0.2.0.nix
+++ b/manifests/forc-explore-0.2.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.2.0";
-  date = "2022-01-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "38479274e0c50518e20c919682b8173ae4a555d3";
-  sha256 = "sha256-48BfRiY2evrKlcz1bXBWoWQgRtkk4jc2r3GZRj28sPo=";
-}

--- a/manifests/forc-explore-0.2.1.nix
+++ b/manifests/forc-explore-0.2.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.2.1";
-  date = "2022-01-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a790fd729b2021f837be924c7b8b21099b9f6c12";
-  sha256 = "sha256-TUQQa1uE9JuZzEnXxrOAeBplNkzt9MRWzPjxZdECZg8=";
-}

--- a/manifests/forc-explore-0.20.0.nix
+++ b/manifests/forc-explore-0.20.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.20.0";
-  date = "2022-08-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "fc3a05d87d1178e937fc5e4742b13fcca490057d";
-  sha256 = "sha256-gJaLWboU9LNEn9Xu+0AIveFvG3wCTMH1P95H+DVJCRw=";
-}

--- a/manifests/forc-explore-0.20.1.nix
+++ b/manifests/forc-explore-0.20.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.20.1";
-  date = "2022-08-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "21887f4b321bfacb16c7a6602071e3b6ea1c8df1";
-  sha256 = "sha256-mO7vojv7gEfBJaEmBW2uQTo1ecLNoTL6E1o1d68saBQ=";
-}

--- a/manifests/forc-explore-0.20.2.nix
+++ b/manifests/forc-explore-0.20.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.20.2";
-  date = "2022-08-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6a8116fcee71aa960217b1672bac0c35d1fce42c";
-  sha256 = "sha256-JfjHda4vRGPiZ2EhJbGMzpSJ24bFFS3WlPxtXmI3mno=";
-}

--- a/manifests/forc-explore-0.21.0-nightly-2022-09-01.nix
+++ b/manifests/forc-explore-0.21.0-nightly-2022-09-01.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.21.0";
-  date = "2022-09-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "11fd90a14d48ab363a297cec267b3f91327502f5";
-  sha256 = "sha256-B7ExtUjq1hgmXlqjvQSyFFeOC94j5ODYt29OtOcAsEk=";
-}

--- a/manifests/forc-explore-0.21.0.nix
+++ b/manifests/forc-explore-0.21.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.21.0";
-  date = "2022-08-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "32b5b142b54d3d38ae1f7df69f465138e86de82d";
-  sha256 = "sha256-joWJifoFBzzK9FdhQwyYwVuDU4/8hQzmrUgD7+2BSJY=";
-}

--- a/manifests/forc-explore-0.22.0.nix
+++ b/manifests/forc-explore-0.22.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.22.0";
-  date = "2022-08-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6e1fbca21f0979d226efd7ceea5b6d71696536cd";
-  sha256 = "sha256-cK7YReHEq3Z/wVV6bxTohdHI9c2zSz53Sej8GCWSIrI=";
-}

--- a/manifests/forc-explore-0.22.1-nightly-2022-09-02.nix
+++ b/manifests/forc-explore-0.22.1-nightly-2022-09-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.22.1";
-  date = "2022-09-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ecf537a5c892ddab7997a34d9a128007cfdd91fc";
-  sha256 = "sha256-BuKsDcrqSOE41InAcyFBqR02m6iEjb9cr7J3omF6Hao=";
-}

--- a/manifests/forc-explore-0.22.1-nightly-2022-09-03.nix
+++ b/manifests/forc-explore-0.22.1-nightly-2022-09-03.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.22.1";
-  date = "2022-09-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b696495c8fb9b207626a3dafbee0550407198d12";
-  sha256 = "sha256-2X0wu0De384uIBy5KxiR/lbD9bzGYKmdBqnhWpDzCt0=";
-}

--- a/manifests/forc-explore-0.22.1.nix
+++ b/manifests/forc-explore-0.22.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.22.1";
-  date = "2022-08-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c486eabc3ed4d8c53b63735188f2c1db5d17703c";
-  sha256 = "sha256-fChGs4bPxg82noIJooec6Tk908T8BrDUWH6YQNvAuhg=";
-}

--- a/manifests/forc-explore-0.23.0-nightly-2022-09-04.nix
+++ b/manifests/forc-explore-0.23.0-nightly-2022-09-04.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.23.0";
-  date = "2022-09-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4712e5b26c6c0f778d7771ef1b35a229fe3a371d";
-  sha256 = "sha256-ZdH69u5DOe/fjARXWpJe0J21K/rVL4YJD5/qHQdlr50=";
-}

--- a/manifests/forc-explore-0.23.0-nightly-2022-09-05.nix
+++ b/manifests/forc-explore-0.23.0-nightly-2022-09-05.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.23.0";
-  date = "2022-09-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "36aa76d3e1572d2d3054483be59345797ce04b36";
-  sha256 = "sha256-A4NYsyilLbJeqGkOtR67wrIUEWsqwtW4RsY4asNXScM=";
-}

--- a/manifests/forc-explore-0.23.0-nightly-2022-09-06.nix
+++ b/manifests/forc-explore-0.23.0-nightly-2022-09-06.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.23.0";
-  date = "2022-09-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a989e6ca0caf6ace4630cd72a2ff8c875c141a43";
-  sha256 = "sha256-5xMmLJ0aMfPJwfscUtVH88pOLTsnCeX2yW0VGGVwYyM=";
-}

--- a/manifests/forc-explore-0.23.0.nix
+++ b/manifests/forc-explore-0.23.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.23.0";
-  date = "2022-09-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4712e5b26c6c0f778d7771ef1b35a229fe3a371d";
-  sha256 = "sha256-ZdH69u5DOe/fjARXWpJe0J21K/rVL4YJD5/qHQdlr50=";
-}

--- a/manifests/forc-explore-0.24.0-nightly-2022-09-07.nix
+++ b/manifests/forc-explore-0.24.0-nightly-2022-09-07.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.0";
-  date = "2022-09-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8200174bb35f2dc7131238b2930130a5b4ec7c1c";
-  sha256 = "sha256-Tgo+l8EhUnxzVmMnDHylk62p62W8rW0062I7alLTdoY=";
-}

--- a/manifests/forc-explore-0.24.0.nix
+++ b/manifests/forc-explore-0.24.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.0";
-  date = "2022-09-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ea4f1b7885248c2b4c4d0da394c2cc50ea1583e8";
-  sha256 = "sha256-2DwlfRw+aw9g4E2wPeomlGH/qe6O0kKha3Vu3+HY4AI=";
-}

--- a/manifests/forc-explore-0.24.1-nightly-2022-09-08.nix
+++ b/manifests/forc-explore-0.24.1-nightly-2022-09-08.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.1";
-  date = "2022-09-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "54e1a340e6c0c9a675e8a66aab03f579d5d6b39b";
-  sha256 = "sha256-t/VFaYCANGY5CM2FFrLhNiBB5eAL/CFCZvIzigr3d1I=";
-}

--- a/manifests/forc-explore-0.24.1-nightly-2022-09-09.nix
+++ b/manifests/forc-explore-0.24.1-nightly-2022-09-09.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.1";
-  date = "2022-09-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "095bfe030934f31ea85c7c85e3f0e47dc51c11bd";
-  sha256 = "sha256-U04I1XLtQlaOIjJrwcndkXCNp8m6RINumrhhtuQpLZ8=";
-}

--- a/manifests/forc-explore-0.24.1.nix
+++ b/manifests/forc-explore-0.24.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.1";
-  date = "2022-09-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "54e1a340e6c0c9a675e8a66aab03f579d5d6b39b";
-  sha256 = "sha256-t/VFaYCANGY5CM2FFrLhNiBB5eAL/CFCZvIzigr3d1I=";
-}

--- a/manifests/forc-explore-0.24.2-nightly-2022-09-10.nix
+++ b/manifests/forc-explore-0.24.2-nightly-2022-09-10.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.2";
-  date = "2022-09-10";
-  url = "https://github.com/fuellabs/sway";
-  rev = "719dca1bd0ec8cc58e651d7327fb0e16276eb69e";
-  sha256 = "sha256-iGn796XsI8yEZi6dJNAdfvekDr97DOq03DOOVUvFCi0=";
-}

--- a/manifests/forc-explore-0.24.2.nix
+++ b/manifests/forc-explore-0.24.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.2";
-  date = "2022-09-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "057e83aee87d17c3812f223f5fc7884cf6d3468a";
-  sha256 = "sha256-XQePJ7tvPqjAAnqdpavkUxuCtH8MmaiXSDrhIUpjVQo=";
-}

--- a/manifests/forc-explore-0.24.3-nightly-2022-09-13.nix
+++ b/manifests/forc-explore-0.24.3-nightly-2022-09-13.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.3";
-  date = "2022-09-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "9aeb723b732741e1211c4fb78195f2e60d262f42";
-  sha256 = "sha256-ylhVuNFQ6ckZlRl3cBrAc7AWCSX68Ar1wUAfN2JQENw=";
-}

--- a/manifests/forc-explore-0.24.3-nightly-2022-09-15.nix
+++ b/manifests/forc-explore-0.24.3-nightly-2022-09-15.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.3";
-  date = "2022-09-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0b69f4d4920febbbe3149efe2aa520d57b0ffdbc";
-  sha256 = "sha256-oMFE41zjmnoPCulMvEf8ZK/vcteVQecSbwv9gRXSIps=";
-}

--- a/manifests/forc-explore-0.24.3-nightly-2022-09-16.nix
+++ b/manifests/forc-explore-0.24.3-nightly-2022-09-16.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.3";
-  date = "2022-09-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "68351a542386c41892064e86b3eca857f414c8ce";
-  sha256 = "sha256-6Qgz0X+jo07Ee3UzCvRW0yrS11nIGuhpjnQymXWo520=";
-}

--- a/manifests/forc-explore-0.24.3.nix
+++ b/manifests/forc-explore-0.24.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.3";
-  date = "2022-09-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "95cd150cacef407a1f30c89899c539b0d57f099d";
-  sha256 = "sha256-oWQpD2HohdjQ0lcnOjipT0oTIX68KnoWy13FeXYKi7E=";
-}

--- a/manifests/forc-explore-0.24.4-nightly-2022-09-17.nix
+++ b/manifests/forc-explore-0.24.4-nightly-2022-09-17.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.4";
-  date = "2022-09-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c5399ebe258c5cb3f7c1962fbbe42a3e063e3e4";
-  sha256 = "sha256-NM1Yc9xTnaTbz/pj4wbJR4YnJt/x3u1RFW3G8nsIOs8=";
-}

--- a/manifests/forc-explore-0.24.4-nightly-2022-09-18.nix
+++ b/manifests/forc-explore-0.24.4-nightly-2022-09-18.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.4";
-  date = "2022-09-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "df9d5c031ddee0ca8b05eddbcf274aac14c0589e";
-  sha256 = "sha256-2JxH1LA/Qe97MZj5lmK1mjxPQpvImgiRJc3A8+KHrDQ=";
-}

--- a/manifests/forc-explore-0.24.4-nightly-2022-09-20.nix
+++ b/manifests/forc-explore-0.24.4-nightly-2022-09-20.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.4";
-  date = "2022-09-20";
-  url = "https://github.com/fuellabs/sway";
-  rev = "315cae6fd111d3c3cb61b2ecd37085372e690475";
-  sha256 = "sha256-HxWKV/dFuAwBb+qy2jhgkS2w9mPNRiF9VWN3nAstfTA=";
-}

--- a/manifests/forc-explore-0.24.4-nightly-2022-09-21.nix
+++ b/manifests/forc-explore-0.24.4-nightly-2022-09-21.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.4";
-  date = "2022-09-21";
-  url = "https://github.com/fuellabs/sway";
-  rev = "17d61c9ff348e812d2f25122836b173c7c350927";
-  sha256 = "sha256-QCOL2/eCWF6OylH+WxvXlitrR6eY2Qe/iveKDXqjui4=";
-}

--- a/manifests/forc-explore-0.24.4-nightly-2022-09-22.nix
+++ b/manifests/forc-explore-0.24.4-nightly-2022-09-22.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.4";
-  date = "2022-09-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a324023d4c1e0047618dcdaad486061e34920f64";
-  sha256 = "sha256-LJLH7ezwX6kp+4bH9FHbPby733DLkR0/m8vOjkQwxds=";
-}

--- a/manifests/forc-explore-0.24.4-nightly-2022-09-23.nix
+++ b/manifests/forc-explore-0.24.4-nightly-2022-09-23.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.4";
-  date = "2022-09-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "56dc0f4105a456ae1311405368c57a3caab3490e";
-  sha256 = "sha256-wfl9MD5qnXCeotcIZ/THA67vzE3Ob0aGqc8GPOtLYlw=";
-}

--- a/manifests/forc-explore-0.24.4-nightly-2022-09-24.nix
+++ b/manifests/forc-explore-0.24.4-nightly-2022-09-24.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.4";
-  date = "2022-09-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f7d000fff4dc27c2ce0ca779a6e204fb0d4e720c";
-  sha256 = "sha256-qtbxzFic0c9x6fbu4t8hdDkKXP9QTF5QcY9hZ+8qYv0=";
-}

--- a/manifests/forc-explore-0.24.4.nix
+++ b/manifests/forc-explore-0.24.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.4";
-  date = "2022-09-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f7800e18979dd8e4c8d672b8e7aae1758c2edb88";
-  sha256 = "sha256-jRqUQv7nsv0xq+CNrEYCnt0yfiVycTUF3eYOMt/DCdQ=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-25.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-25.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-09-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e695606d8884a18664f6231681333a784e623bc9";
-  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-27.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-27.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-09-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "535174be2759db62d0838957cf4f89f2c9d8ec71";
-  sha256 = "sha256-nqO6tKI6liTYLXHVIyImfFWeBmu2Z70jEMGAjT7WAic=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-28.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-28.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-09-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c5e543382e00a843adb2f64d03eea8576e4c1d53";
-  sha256 = "sha256-nm4FY6pisendzf+hgCm9zDieqVAyRtDNDXjZca79brM=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-29.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-29.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-09-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e6afd8987ead0d453efb5f35e29ce7ba1a0cd070";
-  sha256 = "sha256-Xo8OXRT9UtkEvZvbMAteolHsPKjtx7kl9CZaCuGhV/w=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-09-30.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-09-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-09-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "076e95fcdb9efc4052dec827418274681d26b00e";
-  sha256 = "sha256-89ZfhctqiTKbwCEz03r9A1AYJ/l+UHsKdCt5mnl6WvM=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-01.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-01.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-10-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e15d71c176359844341e2621a0431f58dfd13c2e";
-  sha256 = "sha256-IAkBhCN7hPGVTBHquhAt0+nEB+0yLM6smnc8pghO/wA=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-02.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-10-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6f7b9a022df54ed75832d93833587855af0d08fa";
-  sha256 = "sha256-GJzUqffmvc1CH5K9TeAHvwLs6FyA6/2YSg1RUnpgYio=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-03.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-03.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-10-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4fe47d44458c1433140afd30a304e2723d1805b5";
-  sha256 = "sha256-sBYTj7BwGyvdw4FTQt331Y/I7XrZVTgrTJIJ/FgPc70=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-04.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-04.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-10-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a917c66ff1d402c7350664c648e8704b50085281";
-  sha256 = "sha256-jCHeqg6SIP8fnAHm3ZeQt9CdEDz1Cr81NcapE4jQx70=";
-}

--- a/manifests/forc-explore-0.24.5-nightly-2022-10-05.nix
+++ b/manifests/forc-explore-0.24.5-nightly-2022-10-05.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-10-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8a8f0c39d0bb3e0424a5cdabf0b625b73c90667c";
-  sha256 = "sha256-8Y1IUqYWk29szUFWBwrk4fGDRvIKcC9XY2Zu/h89Jng=";
-}

--- a/manifests/forc-explore-0.24.5.nix
+++ b/manifests/forc-explore-0.24.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.24.5";
-  date = "2022-09-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e695606d8884a18664f6231681333a784e623bc9";
-  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
-}

--- a/manifests/forc-explore-0.25.0-nightly-2022-10-06.nix
+++ b/manifests/forc-explore-0.25.0-nightly-2022-10-06.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.0";
-  date = "2022-10-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
-  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
-}

--- a/manifests/forc-explore-0.25.0.nix
+++ b/manifests/forc-explore-0.25.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.0";
-  date = "2022-10-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
-  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
-}

--- a/manifests/forc-explore-0.25.1-nightly-2022-10-07.nix
+++ b/manifests/forc-explore-0.25.1-nightly-2022-10-07.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.1";
-  date = "2022-10-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4740fb2f9b9c4c4d6e8ba2110831604b40ccc645";
-  sha256 = "sha256-czP0vMoQE3ZjXFcLHNRKntBkbpJb7yPaMsIwxny+xPM=";
-}

--- a/manifests/forc-explore-0.25.1.nix
+++ b/manifests/forc-explore-0.25.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.1";
-  date = "2022-10-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
-  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
-}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-08.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-08.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.2";
-  date = "2022-10-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e8a28b5867234a6391bf99ddc55db41957096480";
-  sha256 = "sha256-pw0Zs2LX5D6kyScWDuOz3dobkhRQ5DgySirK4Tj+fBU=";
-}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-09.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-09.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.2";
-  date = "2022-10-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "61d6d659b22c25a606f1437a122176474293180d";
-  sha256 = "sha256-Ch+iPSPFlnzL9JlZXPHhr7fWTJqNIAP0TfKdyQieQ0M=";
-}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-10.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-10.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.2";
-  date = "2022-10-10";
-  url = "https://github.com/fuellabs/sway";
-  rev = "71999d3774ec617e4b1167d891cadb1e6e9f38af";
-  sha256 = "sha256-jVrjARMBQSgfBJTSfL9xUBB0NjjbSAX0m7uaROG5urA=";
-}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-11.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-11.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.2";
-  date = "2022-10-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "bb0a5be05549a7a01df684380eaf0c2ec7f46241";
-  sha256 = "sha256-EUmVdkCM6EIL/imd6Xn4/cGp2RyRDcjJ6QjI7BjQNVI=";
-}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-12.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-12.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.2";
-  date = "2022-10-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6f7554760ba1cde24db5075183ddc9c3f1359066";
-  sha256 = "sha256-uycMRo7+vIkHKQdcCpxh+eGdpBnuq1b674Aw6TXYgU8=";
-}

--- a/manifests/forc-explore-0.25.2-nightly-2022-10-13.nix
+++ b/manifests/forc-explore-0.25.2-nightly-2022-10-13.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.2";
-  date = "2022-10-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "205073dc30db355f065c29db41d591bfc166f3fa";
-  sha256 = "sha256-c3eAp7XB0ziwC4NLCyQeHgflBuwftCv+gy0P/RwJID0=";
-}

--- a/manifests/forc-explore-0.25.2.nix
+++ b/manifests/forc-explore-0.25.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.25.2";
-  date = "2022-10-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
-  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-14.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-14.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
-  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-15.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-15.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a9eaef219282566e99d57ff993c613317a9143a9";
-  sha256 = "sha256-noZchaj5q6Y5rp1t6VOfmV96ggJZDNdNMtEmdsbK0cg=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-16.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-16.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a1d40f58883e3fe8d23140fbf922d263f17b7c20";
-  sha256 = "sha256-3WPBVNfM/lkyA44mVqqR05t0pBfgI5vnBIOGJSMfeW8=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-17.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-17.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "314648f8448cefad534f129431ebd15f06e8b418";
-  sha256 = "sha256-zXLLLvftB+aTX4ZFbjfQ/1YLBLCX70ASZ8U6Z1ppXH8=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-18.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-18.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dbd6b9211fd3c4ceeb34b3f6aedb0a7b9f0e6ef8";
-  sha256 = "sha256-Qhf/QDTkb68kX4feeTtdMjSTt34xKhNeRAlhgxGF6wU=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-19.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-19.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a2395b4c99c299cf246f1b1ef59785345c94641e";
-  sha256 = "sha256-GvqPVs1EtRuygKA8kEdZyImxlM835AVMKgK74rnX2wk=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-21.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-21.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-21";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0e84d98a06d32a036d88198505e0d6868c985f25";
-  sha256 = "sha256-38yHKfdmro4oDIYQy2HiSgTP3w4soKLiLPRJBUWa4Pg=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-22.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-22.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "aaf7c8833ed3f5949dc501c741014b640b426889";
-  sha256 = "sha256-3n0ewjyJl6HVS++MDTBgtUMMoJt6KhFb2iypBJDm7xw=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-23.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-23.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ef8088ab8282a14579bde6af7fec9314435b4a9d";
-  sha256 = "sha256-DpoMWFk+Jhou3I6khR77I5X0Zmt+bxq94XgtvSLHWmo=";
-}

--- a/manifests/forc-explore-0.26.0-nightly-2022-10-24.nix
+++ b/manifests/forc-explore-0.26.0-nightly-2022-10-24.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3270118703b3516bffc1b2ae6f99c11aed7b1130";
-  sha256 = "sha256-Y8cJ8RYDjkVFGqJ++ZNNehS4QESC/cpqLI8N1bkjwc4=";
-}

--- a/manifests/forc-explore-0.26.0.nix
+++ b/manifests/forc-explore-0.26.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.26.0";
-  date = "2022-10-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
-  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
-}

--- a/manifests/forc-explore-0.27.0-nightly-2022-10-25.nix
+++ b/manifests/forc-explore-0.27.0-nightly-2022-10-25.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.27.0";
-  date = "2022-10-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8ae44c2ea0eb154f77e769ef3f69d7f1ab0116b9";
-  sha256 = "sha256-5yuILUm2XiRpou8bTKdfyXOYGkoKpxJ/YhsqXyJPtlk=";
-}

--- a/manifests/forc-explore-0.27.0.nix
+++ b/manifests/forc-explore-0.27.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.27.0";
-  date = "2022-10-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "40f1e79de08af109f2ebb066f51704f36094ed1e";
-  sha256 = "sha256-qIso6YBCs4HKu1fAqM0fgq0vcaOqgGeZ2CY0ZLjTm+o=";
-}

--- a/manifests/forc-explore-0.28.0.nix
+++ b/manifests/forc-explore-0.28.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.28.0";
-  date = "2022-10-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a7978381effcf999adc5726587bf8f711f04e414";
-  sha256 = "sha256-3xqbdGXjWIfdZV7po64bp+N79MGfEkL0fRyKcel0A2s=";
-}

--- a/manifests/forc-explore-0.28.1-nightly-2022-10-26.nix
+++ b/manifests/forc-explore-0.28.1-nightly-2022-10-26.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.28.1";
-  date = "2022-10-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "203b59053c713574007a94663923411f18c501ef";
-  sha256 = "sha256-bnVLOvj+NkTapIe47m3zLcZsLuBHQ3thSzUkiuHUddc=";
-}

--- a/manifests/forc-explore-0.28.1-nightly-2022-10-27.nix
+++ b/manifests/forc-explore-0.28.1-nightly-2022-10-27.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.28.1";
-  date = "2022-10-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "18a9eb235a8d8255cf90faa25989a563ccf99d12";
-  sha256 = "sha256-7QTYA/vscSnJfGfaiKd/KfxvtG0ny0r8It8lqaJHtoM=";
-}

--- a/manifests/forc-explore-0.28.1-nightly-2022-10-28.nix
+++ b/manifests/forc-explore-0.28.1-nightly-2022-10-28.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.28.1";
-  date = "2022-10-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c0880ebce66b625352222cd737361e9574c6681c";
-  sha256 = "sha256-UXM7jrrVSKj+h5UDo3hG7iBsEaFRGs0Kv/hBFneYkr8=";
-}

--- a/manifests/forc-explore-0.28.1-nightly-2022-10-29.nix
+++ b/manifests/forc-explore-0.28.1-nightly-2022-10-29.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.28.1";
-  date = "2022-10-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "51987a96a6f0ac23f4102478290e0bc1736b2af6";
-  sha256 = "sha256-qTgRMNueyU9NtCI6KHumAjrFYqJ2xqWEqW8py1okZsU=";
-}

--- a/manifests/forc-explore-0.28.1-nightly-2022-10-30.nix
+++ b/manifests/forc-explore-0.28.1-nightly-2022-10-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.28.1";
-  date = "2022-10-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "03ded848a6281930714a4b97a74364697705baf2";
-  sha256 = "sha256-sztgZklxQotgNRvJs0wbmP4n+Rty0kb6/I15nOEDoxU=";
-}

--- a/manifests/forc-explore-0.28.1-nightly-2022-10-31.nix
+++ b/manifests/forc-explore-0.28.1-nightly-2022-10-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.28.1";
-  date = "2022-10-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1668ee5d01a83267a77e1b759178874d525ef726";
-  sha256 = "sha256-o00OwNerNsWhF2eKbd1ukKNDVG667y9WRyMUnZrA1IU=";
-}

--- a/manifests/forc-explore-0.29.0-nightly-2022-11-01.nix
+++ b/manifests/forc-explore-0.29.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.29.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bdc3160d92539dee21378633b24475b6d6666e0c";
+  sha256 = "sha256-za7htSCITOpeMWCM/duj9JDIK6UXUedIRs4ydhtJJKM=";
+}

--- a/manifests/forc-explore-0.29.0-nightly-2022-11-01.nix
+++ b/manifests/forc-explore-0.29.0-nightly-2022-11-01.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.29.0";
-  date = "2022-11-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "bdc3160d92539dee21378633b24475b6d6666e0c";
-  sha256 = "sha256-za7htSCITOpeMWCM/duj9JDIK6UXUedIRs4ydhtJJKM=";
-}

--- a/manifests/forc-explore-0.29.0-nightly-2022-11-02.nix
+++ b/manifests/forc-explore-0.29.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.29.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b0f05c4c1c30d691c34b828c50ff641415eb2530";
+  sha256 = "sha256-EJJGk6iCFwcEEsGYHVsUx+Y2OAjdE98pCCgyqeweD9Q=";
+}

--- a/manifests/forc-explore-0.29.0-nightly-2022-11-02.nix
+++ b/manifests/forc-explore-0.29.0-nightly-2022-11-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.29.0";
-  date = "2022-11-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b0f05c4c1c30d691c34b828c50ff641415eb2530";
-  sha256 = "sha256-EJJGk6iCFwcEEsGYHVsUx+Y2OAjdE98pCCgyqeweD9Q=";
-}

--- a/manifests/forc-explore-0.29.0.nix
+++ b/manifests/forc-explore-0.29.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.29.0";
-  date = "2022-10-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
-  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
-}

--- a/manifests/forc-explore-0.29.0.nix
+++ b/manifests/forc-explore-0.29.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-explore";
+  version = "0.29.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
+  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
+}

--- a/manifests/forc-explore-0.3.0.nix
+++ b/manifests/forc-explore-0.3.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.3.0";
-  date = "2022-01-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b81eee7d23af71958ba1a3276855949277902a57";
-  sha256 = "sha256-25ZOELcJchuJapvGZFigzsl3BPEUW/R3f5NhvoXBKeE=";
-}

--- a/manifests/forc-explore-0.3.1.nix
+++ b/manifests/forc-explore-0.3.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.3.1";
-  date = "2022-01-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d9b5a1103a1f37672d6f09c8dae34b813872d44b";
-  sha256 = "sha256-eYVjjBkg6Gxc7mKMl7oaK3Ws2XVDHWAt+z3WIjGM3Xs=";
-}

--- a/manifests/forc-explore-0.3.2.nix
+++ b/manifests/forc-explore-0.3.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.3.2";
-  date = "2022-01-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3012191420362e9ba1df0324b2a9e80eeded7e1d";
-  sha256 = "sha256-5AirUGidtaNFfVf4uSutfrEvs2wd/ROiDyudYHb2EWQ=";
-}

--- a/manifests/forc-explore-0.3.3.nix
+++ b/manifests/forc-explore-0.3.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.3.3";
-  date = "2022-01-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "441ab123839f2eb4f5dd1b055fdbe5a5b26a6736";
-  sha256 = "sha256-QI8nqWfKr+/yGP96NnNdpKGwHHzA6UxEyQvjwQLgcSU=";
-}

--- a/manifests/forc-explore-0.4.0.nix
+++ b/manifests/forc-explore-0.4.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.4.0";
-  date = "2022-02-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6332f9ad955e1f8e744cc87e07d028092874e0d5";
-  sha256 = "sha256-lDyAgfNC5ezqptxuM7lycuVEofI5W62hzY011MzXUt8=";
-}

--- a/manifests/forc-explore-0.5.0.nix
+++ b/manifests/forc-explore-0.5.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.5.0";
-  date = "2022-02-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c58c09ffba1719b187a3e1112639eec649eab5e";
-  sha256 = "sha256-11OIZruYjYrylHv8zQOfLW9Fzs0p7aGOWQfq7UQN+5w=";
-}

--- a/manifests/forc-explore-0.6.0.nix
+++ b/manifests/forc-explore-0.6.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.6.0";
-  date = "2022-03-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "35e5a2f12e137953b82470e9637e4969ca064e4a";
-  sha256 = "sha256-HKmNBduWtyIoaUwkj2Nu9GznUOoZFctcaRhFJOnTWLY=";
-}

--- a/manifests/forc-explore-0.6.1.nix
+++ b/manifests/forc-explore-0.6.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.6.1";
-  date = "2022-03-10";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3268092ce50e5058b11a5ea2e7f35c6e19352d68";
-  sha256 = "sha256-JOH4UosK8x7FmMqx2qkEqWnyO+z9XPl1C/BrnXWz4uw=";
-}

--- a/manifests/forc-explore-0.7.0.nix
+++ b/manifests/forc-explore-0.7.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.7.0";
-  date = "2022-03-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7dd186041fbd2d4040b9a374fedc9a0cbed9eecb";
-  sha256 = "sha256-B37FgsnDop9Vyn5t7aSn2RceGG3pdLxrHUJHZ2s53d8=";
-}

--- a/manifests/forc-explore-0.8.0.nix
+++ b/manifests/forc-explore-0.8.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.8.0";
-  date = "2022-03-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "04d26d6924788875fb01fa4fe58fe969849dcfc5";
-  sha256 = "sha256-MTQlnuP9WVHL/rNHsMdmYqvIgHL5IJmIjUF9WqM55M0=";
-}

--- a/manifests/forc-explore-0.9.0.nix
+++ b/manifests/forc-explore-0.9.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.9.0";
-  date = "2022-03-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "fdebe28e2803ef32238e6b39693748b6bdf6f34e";
-  sha256 = "sha256-dzEkvJ+nP6+Xzp+nVz+VKy0RmfN/UkX/JlP/0cXqaY0=";
-}

--- a/manifests/forc-explore-0.9.1.nix
+++ b/manifests/forc-explore-0.9.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.9.1";
-  date = "2022-03-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "72aa51d6da3d49b1bad2e6d6fffe6d4b3e331380";
-  sha256 = "sha256-Mu3niggbgovHWhm6GtU/hhWqANm5YWFvdsrDExUPKYc=";
-}

--- a/manifests/forc-explore-0.9.2.nix
+++ b/manifests/forc-explore-0.9.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-explore";
-  version = "0.9.2";
-  date = "2022-03-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4905aa0b2b6cb7178d6229e7bed94c241a418c26";
-  sha256 = "sha256-C+1vF48WryCdT2X09E8RwcY8LRHxGX3ncRkc2MtNnY4=";
-}

--- a/manifests/forc-fmt-0.29.0-nightly-2022-11-01.nix
+++ b/manifests/forc-fmt-0.29.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.29.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bdc3160d92539dee21378633b24475b6d6666e0c";
+  sha256 = "sha256-za7htSCITOpeMWCM/duj9JDIK6UXUedIRs4ydhtJJKM=";
+}

--- a/manifests/forc-fmt-0.29.0-nightly-2022-11-02.nix
+++ b/manifests/forc-fmt-0.29.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.29.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b0f05c4c1c30d691c34b828c50ff641415eb2530";
+  sha256 = "sha256-EJJGk6iCFwcEEsGYHVsUx+Y2OAjdE98pCCgyqeweD9Q=";
+}

--- a/manifests/forc-fmt-0.29.0.nix
+++ b/manifests/forc-fmt-0.29.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.29.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
+  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
+}

--- a/manifests/forc-fmt-0.30.0-nightly-2022-11-03.nix
+++ b/manifests/forc-fmt-0.30.0-nightly-2022-11-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.30.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ff747c226b7bebcdf62960f2040550cec33666c6";
+  sha256 = "sha256-NXzLpC1IxRqF+TvJKwO8bxww9rKpFCjbo+Ou+fMquXY=";
+}

--- a/manifests/forc-fmt-0.30.0-nightly-2022-11-04.nix
+++ b/manifests/forc-fmt-0.30.0-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.30.0";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4a5e93f5fc66168d70a0f11f0a3ef1ee4ff11c31";
+  sha256 = "sha256-vVMlYw7BAWfOZ2n/n4wtVNZXd1ehsppQLyux3nVNpAA=";
+}

--- a/manifests/forc-fmt-0.30.0-nightly-2022-11-05.nix
+++ b/manifests/forc-fmt-0.30.0-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.30.0";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-fmt-0.30.0.nix
+++ b/manifests/forc-fmt-0.30.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.30.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "37deaee8fccf5804d78a003cf64f14fac654fc41";
+  sha256 = "sha256-BIVBDX3i2ym6d/90AuK/I/ATtJqUFZS9OdltCdBtqI0=";
+}

--- a/manifests/forc-fmt-0.30.1.nix
+++ b/manifests/forc-fmt-0.30.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.30.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-lsp-0.29.0-nightly-2022-11-01.nix
+++ b/manifests/forc-lsp-0.29.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.29.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bdc3160d92539dee21378633b24475b6d6666e0c";
+  sha256 = "sha256-za7htSCITOpeMWCM/duj9JDIK6UXUedIRs4ydhtJJKM=";
+}

--- a/manifests/forc-lsp-0.29.0-nightly-2022-11-02.nix
+++ b/manifests/forc-lsp-0.29.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.29.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b0f05c4c1c30d691c34b828c50ff641415eb2530";
+  sha256 = "sha256-EJJGk6iCFwcEEsGYHVsUx+Y2OAjdE98pCCgyqeweD9Q=";
+}

--- a/manifests/forc-lsp-0.29.0.nix
+++ b/manifests/forc-lsp-0.29.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.29.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
+  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
+}

--- a/manifests/forc-lsp-0.30.0-nightly-2022-11-03.nix
+++ b/manifests/forc-lsp-0.30.0-nightly-2022-11-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.30.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ff747c226b7bebcdf62960f2040550cec33666c6";
+  sha256 = "sha256-NXzLpC1IxRqF+TvJKwO8bxww9rKpFCjbo+Ou+fMquXY=";
+}

--- a/manifests/forc-lsp-0.30.0-nightly-2022-11-04.nix
+++ b/manifests/forc-lsp-0.30.0-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.30.0";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4a5e93f5fc66168d70a0f11f0a3ef1ee4ff11c31";
+  sha256 = "sha256-vVMlYw7BAWfOZ2n/n4wtVNZXd1ehsppQLyux3nVNpAA=";
+}

--- a/manifests/forc-lsp-0.30.0-nightly-2022-11-05.nix
+++ b/manifests/forc-lsp-0.30.0-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.30.0";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-lsp-0.30.0.nix
+++ b/manifests/forc-lsp-0.30.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.30.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "37deaee8fccf5804d78a003cf64f14fac654fc41";
+  sha256 = "sha256-BIVBDX3i2ym6d/90AuK/I/ATtJqUFZS9OdltCdBtqI0=";
+}

--- a/manifests/forc-lsp-0.30.1.nix
+++ b/manifests/forc-lsp-0.30.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.30.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/fuel-core-0.13.0-nightly-2022-11-01.nix
+++ b/manifests/fuel-core-0.13.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.13.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4b2bc255c342dbd7c070d863fe37f56d5e5a2c12";
+  sha256 = "sha256-dT3XuR0PbXnH7u4CcEtty8YMmFv2VcFMal1oeR6Mtxo=";
+}

--- a/manifests/fuel-core-0.13.1-nightly-2022-11-02.nix
+++ b/manifests/fuel-core-0.13.1-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.13.1";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4e95b987609fd49cec54a3537da951b27bd8329e";
+  sha256 = "sha256-2O60UmTknwYdxWnAkBnwswZTCIKIZwl61cp9WMh+vJ0=";
+}

--- a/manifests/fuel-core-0.13.1-nightly-2022-11-02.nix
+++ b/manifests/fuel-core-0.13.1-nightly-2022-11-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "fuel-core";
-  version = "0.13.1";
-  date = "2022-11-02";
-  url = "https://github.com/fuellabs/fuel-core";
-  rev = "4e95b987609fd49cec54a3537da951b27bd8329e";
-  sha256 = "sha256-2O60UmTknwYdxWnAkBnwswZTCIKIZwl61cp9WMh+vJ0=";
-}

--- a/manifests/fuel-core-0.13.1.nix
+++ b/manifests/fuel-core-0.13.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.13.1";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "c3b72504502c861308ccf8012c2fb731c9dc0919";
+  sha256 = "sha256-jiZ2YtmzXhy9sXGtXSifk7w3uyOj4Wi2PFrg4yA5FVk=";
+}

--- a/manifests/fuel-core-0.13.2-nightly-2022-11-02.nix
+++ b/manifests/fuel-core-0.13.2-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.13.2";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4e95b987609fd49cec54a3537da951b27bd8329e";
+  sha256 = "sha256-2O60UmTknwYdxWnAkBnwswZTCIKIZwl61cp9WMh+vJ0=";
+}

--- a/manifests/fuel-core-0.13.2-nightly-2022-11-04.nix
+++ b/manifests/fuel-core-0.13.2-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.13.2";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4af835460d7143a33425c12b6b10291221be42d5";
+  sha256 = "sha256-XPme0yrEkEV9h8llfK0OO4OQvrTbB7AII4WDK4HuuCs=";
+}

--- a/manifests/fuel-core-0.13.2-nightly-2022-11-05.nix
+++ b/manifests/fuel-core-0.13.2-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.13.2";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "3f37b3268d5fe1282febfff68c95e1379c3ebaa5";
+  sha256 = "sha256-xk1T0yph+1KRDFqYIQus7yyB5mkVm353Dl1+ACODdZw=";
+}

--- a/manifests/fuel-core-0.13.2.nix
+++ b/manifests/fuel-core-0.13.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.13.2";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4e95b987609fd49cec54a3537da951b27bd8329e";
+  sha256 = "sha256-2O60UmTknwYdxWnAkBnwswZTCIKIZwl61cp9WMh+vJ0=";
+}

--- a/manifests/fuel-gql-cli-0.13.0-nightly-2022-11-01.nix
+++ b/manifests/fuel-gql-cli-0.13.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.13.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4b2bc255c342dbd7c070d863fe37f56d5e5a2c12";
+  sha256 = "sha256-dT3XuR0PbXnH7u4CcEtty8YMmFv2VcFMal1oeR6Mtxo=";
+}

--- a/manifests/fuel-gql-cli-0.13.1-nightly-2022-11-02.nix
+++ b/manifests/fuel-gql-cli-0.13.1-nightly-2022-11-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "fuel-gql-cli";
-  version = "0.13.1";
-  date = "2022-11-02";
-  url = "https://github.com/fuellabs/fuel-core";
-  rev = "4e95b987609fd49cec54a3537da951b27bd8329e";
-  sha256 = "sha256-2O60UmTknwYdxWnAkBnwswZTCIKIZwl61cp9WMh+vJ0=";
-}

--- a/manifests/fuel-gql-cli-0.13.1-nightly-2022-11-02.nix
+++ b/manifests/fuel-gql-cli-0.13.1-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.13.1";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4e95b987609fd49cec54a3537da951b27bd8329e";
+  sha256 = "sha256-2O60UmTknwYdxWnAkBnwswZTCIKIZwl61cp9WMh+vJ0=";
+}

--- a/manifests/fuel-gql-cli-0.13.1.nix
+++ b/manifests/fuel-gql-cli-0.13.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.13.1";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "c3b72504502c861308ccf8012c2fb731c9dc0919";
+  sha256 = "sha256-jiZ2YtmzXhy9sXGtXSifk7w3uyOj4Wi2PFrg4yA5FVk=";
+}

--- a/manifests/fuel-gql-cli-0.13.2-nightly-2022-11-02.nix
+++ b/manifests/fuel-gql-cli-0.13.2-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.13.2";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4e95b987609fd49cec54a3537da951b27bd8329e";
+  sha256 = "sha256-2O60UmTknwYdxWnAkBnwswZTCIKIZwl61cp9WMh+vJ0=";
+}

--- a/manifests/fuel-gql-cli-0.13.2-nightly-2022-11-04.nix
+++ b/manifests/fuel-gql-cli-0.13.2-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.13.2";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4af835460d7143a33425c12b6b10291221be42d5";
+  sha256 = "sha256-XPme0yrEkEV9h8llfK0OO4OQvrTbB7AII4WDK4HuuCs=";
+}

--- a/manifests/fuel-gql-cli-0.13.2-nightly-2022-11-05.nix
+++ b/manifests/fuel-gql-cli-0.13.2-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.13.2";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "3f37b3268d5fe1282febfff68c95e1379c3ebaa5";
+  sha256 = "sha256-xk1T0yph+1KRDFqYIQus7yyB5mkVm353Dl1+ACODdZw=";
+}

--- a/manifests/fuel-gql-cli-0.13.2.nix
+++ b/manifests/fuel-gql-cli-0.13.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-gql-cli";
+  version = "0.13.2";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4e95b987609fd49cec54a3537da951b27bd8329e";
+  sha256 = "sha256-2O60UmTknwYdxWnAkBnwswZTCIKIZwl61cp9WMh+vJ0=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -74,7 +74,7 @@
   # Some `forc-pkg` and some crates that depend on it require openssl, so add
   # the required packages.
   {
-    condition = m: m.pname == "forc" || m.pname == "forc-client" || m.pname == "forc-lsp";
+    condition = m: pkgs.lib.any (n: m.pname == n) ["forc" "forc-client" "forc-lsp"];
     patch = m: {
       nativeBuildInputs =
         (m.nativeBuildInputs or [])
@@ -88,7 +88,7 @@
   # The forc plugins that reside in the Sway repo are in a dedicated
   # subdirectory.
   {
-    condition = m: m.pname == "forc-client" || m.pname == "forc-explore" || m.pname == "forc-fmt" || m.pname == "forc-lsp";
+    condition = m: m.pname == "forc-client" || m.pname == "forc-fmt" || m.pname == "forc-lsp";
     patch = m: {
       buildAndTestSubdir = "forc-plugins/${m.pname}";
     };
@@ -184,7 +184,7 @@
   # that are unpermitted in Nix's sandbox during a build. These tests are run
   # at `forc`'s repo CI, so it's fine to disable the check here.
   {
-    condition = m: m.pname == "forc" && m.date >= "2022-10-31";
+    condition = m: pkgs.lib.any (n: m.pname == n) ["forc" "forc-client" "forc-lsp"] && m.date >= "2022-10-31";
     patch = m: {
       doCheck = false; # Already tested at repo.
     };

--- a/patches.nix
+++ b/patches.nix
@@ -184,7 +184,7 @@
   # that are unpermitted in Nix's sandbox during a build. These tests are run
   # at `forc`'s repo CI, so it's fine to disable the check here.
   {
-    condition = m: m.pname == "forc" && m.date >= "2022-11-01";
+    condition = m: m.pname == "forc" && m.date >= "2022-10-31";
     patch = m: {
       doCheck = false; # Already tested at repo.
     };

--- a/patches.nix
+++ b/patches.nix
@@ -179,4 +179,14 @@
         ];
     };
   }
+
+  # Since this date, `forc` got some tests that require doing file operations
+  # that are unpermitted in Nix's sandbox during a build. These tests are run
+  # at `forc`'s repo CI, so it's fine to disable the check here.
+  {
+    condition = m: m.pname == "forc" && m.date >= "2022-11-01";
+    patch = m: {
+      doCheck = false; # Already tested at repo.
+    };
+  }
 ]

--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -19,6 +19,7 @@ echo "Manifests directory: $MANIFESTS_DIR"
 
 # The set of fuel repositories.
 declare -A fuel_repos=(
+    [forc-explorer]="https://github.com/fuellabs/forc-explorer"
     [forc-wallet]="https://github.com/fuellabs/forc-wallet"
     [fuel-core]="https://github.com/fuellabs/fuel-core"
     [sway]="https://github.com/fuellabs/sway"
@@ -44,7 +45,7 @@ declare -A pkg_forc_client=(
 )
 declare -A pkg_forc_explore=(
     [name]="forc-explore"
-    [repo]="${fuel_repos[sway]}"
+    [repo]="${fuel_repos[forc-explorer]}"
 )
 declare -A pkg_forc_fmt=(
     [name]="forc-fmt"


### PR DESCRIPTION
The new forc tests try to do some file I/O that's unpermitted in the Nix sandbox. This disables them as they're not required anyway.