### PR TITLE
Add the `fuel-indexer` package

### DIFF
--- a/filters.nix
+++ b/filters.nix
@@ -6,9 +6,6 @@ with pkgs.lib; [
   # Specify some minimum versions that we want to support, to save ourselves
   # having to build everything since the dawn of time and from having to patch
   # old unused versions.
-  (m: m.pname != "fuel-core" || versionAtLeast m.version "0.9.0")
-  (m: m.pname != "fuel-core-client" || (versionAtLeast m.version "0.14.2" && m.date >= "2022-12-17"))
-  (m: m.pname != "fuel-gql-cli" || (versionAtLeast m.version "0.9.0" && m.date < "2022-12-17"))
   (m: m.pname != "forc" || versionAtLeast m.version "0.19.0")
   (m: m.pname != "forc-client" || versionAtLeast m.version "0.19.0")
   (m: m.pname != "forc-doc" || versionAtLeast m.version "0.29.0")
@@ -17,4 +14,8 @@ with pkgs.lib; [
   (m: m.pname != "forc-lsp" || versionAtLeast m.version "0.19.0")
   (m: m.pname != "forc-tx" || versionAtLeast m.version "0.33.1")
   (m: m.pname != "forc-wallet" || versionAtLeast m.version "0.1.0")
+  (m: m.pname != "fuel-core" || versionAtLeast m.version "0.9.0")
+  (m: m.pname != "fuel-core-client" || (versionAtLeast m.version "0.14.2" && m.date >= "2022-12-17"))
+  (m: m.pname != "fuel-gql-cli" || (versionAtLeast m.version "0.9.0" && m.date < "2022-12-17"))
+  (m: m.pname != "fuel-indexer" || versionAtLeast m.version "0.1.8")
 ]

--- a/filters.nix
+++ b/filters.nix
@@ -11,6 +11,7 @@ with pkgs.lib; [
   (m: m.pname != "forc-doc" || versionAtLeast m.version "0.29.0")
   (m: m.pname != "forc-explore" || versionAtLeast m.version "0.19.0")
   (m: m.pname != "forc-fmt" || versionAtLeast m.version "0.19.0")
+  (m: m.pname != "forc-index" || versionAtLeast m.version "0.1.8")
   (m: m.pname != "forc-lsp" || versionAtLeast m.version "0.19.0")
   (m: m.pname != "forc-tx" || versionAtLeast m.version "0.33.1")
   (m: m.pname != "forc-wallet" || versionAtLeast m.version "0.1.0")

--- a/flake.nix
+++ b/flake.nix
@@ -201,6 +201,14 @@
         NIX_CFLAGS_COMPILE = fuelpkgs.fuel-core-nightly.NIX_CFLAGS_COMPILE or "";
       };
 
+      fuel-indexer-dev = pkgs.mkShell {
+        name = "fuel-indexer-dev";
+        inputsFrom = with fuelpkgs; [fuel-indexer-nightly];
+        buildInputs = with fuelpkgs; [fuel-core fuel-gql-cli];
+        inherit (fuelpkgs.fuel-indexer-nightly) SQLX_OFFLINE;
+        inherit (fuel-core-dev) LIBCLANG_PATH NIX_CFLAGS_COMPILE PROTOC ROCKSDB_LIB_DIR;
+      };
+
       sway-dev = pkgs.mkShell {
         name = "sway-dev";
         inputsFrom = with fuelpkgs;
@@ -222,8 +230,9 @@
           isCurrentNightly = name: name != "fuel-nightly" && pkgs.lib.hasSuffix "nightly" name;
           currentNightlies = pkgs.lib.filterAttrs (n: v: isCurrentNightly n) fuelpkgs;
         in
-          (pkgs.lib.mapAttrsToList (n: v: v) currentNightlies) ++ [fuel-core-dev sway-dev];
+          (pkgs.lib.mapAttrsToList (n: v: v) currentNightlies) ++ [fuel-core-dev fuel-indexer-dev sway-dev];
         inherit (fuel-core-dev) LIBCLANG_PATH ROCKSDB_LIB_DIR PROTOC NIX_CFLAGS_COMPILE;
+        inherit (fuel-indexer-dev) SQLX_OFFLINE;
       };
       default = fuel-dev;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -203,8 +203,8 @@
 
       fuel-indexer-dev = pkgs.mkShell {
         name = "fuel-indexer-dev";
-        inputsFrom = with fuelpkgs; [fuel-indexer-nightly];
-        buildInputs = with fuelpkgs; [fuel-core fuel-gql-cli];
+        inputsFrom = with fuelpkgs; [forc-index-nightly fuel-indexer-nightly];
+        buildInputs = with fuelpkgs; [fuel-core fuel-core-client];
         inherit (fuelpkgs.fuel-indexer-nightly) SQLX_OFFLINE;
         inherit (fuel-core-dev) LIBCLANG_PATH NIX_CFLAGS_COMPILE PROTOC ROCKSDB_LIB_DIR;
       };

--- a/manifests/forc-index-0.0.0-nightly-2022-09-01.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "926e64a76b53af0c76af0640f49a089225b7f6ba";
+  sha256 = "sha256-7KV4/u6Ej9t3U77hencL9AVtaiXUx63GqVwJxxkrrIA=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-02.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-02";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "d8a83fdaf2f743f33a6243ecabdbbe2f4f79baca";
+  sha256 = "sha256-w7x6aj9dWDE2GW8CT/QPC9GBa41s3tS47QFHq1h9Qxg=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-03.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-03";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "621cf75f5ec463cd997326483df1c6391dc32326";
+  sha256 = "sha256-QkTyo1Hx3i0OhmlwEEP9XD7Si1h8K3xeOe2nyQNoNkw=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-07.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-07";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "0a9c7f9a28f26ad42ede96dc9501f3b0596dd340";
+  sha256 = "sha256-eK2QVHynvn3yJQUdplGNm2s5ZaWI4Ywl3W+A/fW8kko=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-08.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-08";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "07ef8b9c86b650e34d992e1cee5f80173227118e";
+  sha256 = "sha256-5zls1LeBY8TLD9H+e6Rx2gwvfY3CXWnV+LPrKAcuvfE=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-09.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "b6ca31afce56f1590cb4fa295d654ec26972c470";
+  sha256 = "sha256-cUJAXxF0tPSDnJloFVmF5lBxvlvRxy8VIM/05W59WGM=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-13.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "c15c39e8f6f214d668ff4e1c10a307d8d3593dbc";
+  sha256 = "sha256-9dJE8ArkX4Q5j7kXt147mS5LKMlRV+bIzrdWSJDkUTE=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-15.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-15";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "63fe99453edb4d9631e7fc3e20ee5227c3f6050f";
+  sha256 = "sha256-rCxuPQytty9zF5qQtxRXFUNtPK6coUQSESFWAZBO05A=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-17.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a14d4af24c59831f387112cd61aa49a0d16d37c5";
+  sha256 = "sha256-L0/w5gB7C20FVAnk9fPsKKETUQRaH7ovyjLsPrj6uIE=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-24.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "019ab9aaba4e1fbafd42613f2f5d6eac6fe80969";
+  sha256 = "sha256-DgVKN4/40yh/0K0gzM5AgXFNhkil/yV8FZTuq/pYmBU=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-09-27.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "74f30fb3abf9709c74dd07d1cede44930077bc78";
+  sha256 = "sha256-ynRorDghwivXizDS3MUsdocrw7Uqc42xZAPVgby40WI=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-01.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "aa005ac2d506c4a13a15c7ea8aa64ed7f3694eb2";
+  sha256 = "sha256-afw3tHkNJL8RwMZ1B4jq8hoblAI+FGoyDvdN7kMvh1g=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-07.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "2ad8b2b73f1b3b26341e78cc83d93993340162a4";
+  sha256 = "sha256-SwBCh/VVpUWf8hOA6aPsJvGzHGAMuMf4r6HT/MhXMHE=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-09.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "0a92066f82fd13ee88606ab57c5fb2af18e89dbc";
+  sha256 = "sha256-vpT1CkYzNLpKIgb0qOaoFFFq5PLYnkcpWVLaCCoQ5uI=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-12.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "39cc18d028d66a330adba5edb778b87457d3255b";
+  sha256 = "sha256-mvfehXXJmruRjx3255j1PhB93k+Na2uu43iBBzH417w=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-13.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "2ce05f696a3bd01cd945b0c76450091d97f122bb";
+  sha256 = "sha256-ZOqLnGPvVw7v0wHUt95hyZjIO3UrJJvNtYKQmdp7INU=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-14.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "221197d01c4b9ef41149654614b93e346a2d8a3b";
+  sha256 = "sha256-SgexLcN7Dc6tYjIrj+GRyGvc4wDuNWcEU8ESeUiNYvQ=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-17.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "aea945cb8498800736a29807fb86f0139376a469";
+  sha256 = "sha256-2jOiStmbNoJfa1uz8K9shbw4axPN7ARLQ6cXefObhMQ=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-18.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "3ce2dd66bb245f36b29c150424d7db844558784b";
+  sha256 = "sha256-uaRHsv5auMwLSAGtNvxVWnLUVs7ZKrCY3/yIybeINe4=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-19.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "1bda330952782b1ec4768365015b52b7ee8cd4ce";
+  sha256 = "sha256-cfnn3BK625V0+M8mk3fW6Ope4y3UU6PtDSuDmm1zAWs=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-20.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-20";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "70c81e098cd070c359911e28cefe67bfe45bad2d";
+  sha256 = "sha256-F6JSy2F5lbsa/H/DLnpM1tCnOpcYaOXDcx4yEL23rFA=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-21.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "5ef73d25b23868282381bf8ca8843bc11191eac2";
+  sha256 = "sha256-0q70qRPq/9/sSp3m5jslVdUZ7mrP0HYOa4nUCxo/7Bk=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-22.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-22";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "fc01f6e86526a24a5787785e1b11e5b69bfe7de5";
+  sha256 = "sha256-XsPr1UhXiyLJYCagyl+WTGqmn+3Fjrcu2aMuzZhsJOc=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-23.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-23";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "3abd406744fff31d60c3248a4775b863eb96066f";
+  sha256 = "sha256-uK3sfABB/vy/h96cM8pm69MheADJ4LmfjRGqhyCAQCE=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-25.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "2be0075e03cf811b285b5b857210fea751430844";
+  sha256 = "sha256-iL2/3vbYbOq6b4wQFTf8PhPRrOPRlPtYlEVSdg/ZaLA=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-26.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-26";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "09985514674396e4c68a44941d26d2e314da48f3";
+  sha256 = "sha256-48DKmfta1MniADdEqXQVsgJdUTIdXaTNVp7gCqSOtk4=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-29.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-29";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "27ad86e9f4c552c5eb58ab7fabf8ee8b05027923";
+  sha256 = "sha256-u1hcwDqyQKxlPNUsS4NEW8Xpl/PQ4vTKKQA1kptrHaM=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-10-31.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-10-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "33d341d9335e4a6cb889c7b724846516731171eb";
+  sha256 = "sha256-/POIfDsSNJ5P7TwvZLMxzms5YnFZFtjWj+dYHYRwvXg=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-11-01.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "ccf3df7f5a51f2351e3f32b7951b53b80ac7fc8a";
+  sha256 = "sha256-IVV1h/eiev0/OpO1aFD3UtXYpka5dJ1CsFSDT/pH2T8=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-11-02.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "984be3a4707e33df7c911d623080d5e9f7cdedfb";
+  sha256 = "sha256-K+hl5A0gq909urG7I69gMAc8BWbuUCwvmG1mh3S1Nzo=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-11-03.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-11-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "55602585ecd5bcd7e597ae01101ba7a5a0627b4c";
+  sha256 = "sha256-TnybIZA2VvHaILzEg5KHrvWl8u6xX04yEL/gCz3P5W4=";
+}

--- a/manifests/forc-index-0.0.0-nightly-2022-11-04.nix
+++ b/manifests/forc-index-0.0.0-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.0.0";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "0522ce0e21b63af7c246449b4f6a09e66184255d";
+  sha256 = "sha256-Vf8Kw7Ecbj066FEBXkaqZ9s8lLs8bbZU+zcWTSR0wb0=";
+}

--- a/manifests/forc-index-0.1.0.nix
+++ b/manifests/forc-index-0.1.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cd2aaa2ef96163347ec86cb2f59114a95841ae4d";
+  sha256 = "sha256-+uVXLMbJsA3EdWi7VS9lvJmciCB1v5b0Uw8xw5OJ9pY=";
+}

--- a/manifests/forc-index-0.1.1.nix
+++ b/manifests/forc-index-0.1.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "522651e91bb09870f0791975cf547ae5596de403";
+  sha256 = "sha256-8iDZxmolZXC3gSmoZA1/SvuMliTC2dEbVA2iyiskZA0=";
+}

--- a/manifests/forc-index-0.1.10-nightly-2022-12-07.nix
+++ b/manifests/forc-index-0.1.10-nightly-2022-12-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.10";
+  date = "2022-12-07";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "b474f1d5ad34a938cf5d9c19d3c88cb15142f2dd";
+  sha256 = "sha256-2NFe1/Njx4qEKNtcH6WllM/g5/GkOrh6s2/pNR7rb4k=";
+}

--- a/manifests/forc-index-0.1.10-nightly-2022-12-08.nix
+++ b/manifests/forc-index-0.1.10-nightly-2022-12-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.10";
+  date = "2022-12-08";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a5dca28edd9f715cde5f1664bf9d08bfd8e284d6";
+  sha256 = "sha256-BsIMDMfq9gXpUDCyvMgzCQTQS/8BHAezWk2mezU4t5I=";
+}

--- a/manifests/forc-index-0.1.10-nightly-2022-12-09.nix
+++ b/manifests/forc-index-0.1.10-nightly-2022-12-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.10";
+  date = "2022-12-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "c94767a92f970cfe0a60d2a45070399ed3aa2873";
+  sha256 = "sha256-RYJie53HS1xCkvEFGrYOxBq8wuuFbNhgF3d9ZGUpEqU=";
+}

--- a/manifests/forc-index-0.1.10-nightly-2022-12-10.nix
+++ b/manifests/forc-index-0.1.10-nightly-2022-12-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.10";
+  date = "2022-12-10";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cddc972b524bb90bbfe4a334bf78d5c60c0c5bb8";
+  sha256 = "sha256-rsiQhLASHbp1tpucbcgVDYQdUNAnxTjUuWB/J3brNrE=";
+}

--- a/manifests/forc-index-0.1.10.nix
+++ b/manifests/forc-index-0.1.10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.10";
+  date = "2022-12-06";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "daef60d5a5ddfb1b50b638df1db9650553ca326a";
+  sha256 = "sha256-IN+0K8MeSg1nRpkjzrmQV9Ycir89iONiovam1rKB06Q=";
+}

--- a/manifests/forc-index-0.1.11-nightly-2022-12-11.nix
+++ b/manifests/forc-index-0.1.11-nightly-2022-12-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-11";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4300093aea4cc7ad4eff048493ce5272b75eeb19";
+  sha256 = "sha256-hMfwBiUInTyLCx/KTsXYCFaa6D3FpQi3w9WKekFVFZk=";
+}

--- a/manifests/forc-index-0.1.11-nightly-2022-12-13.nix
+++ b/manifests/forc-index-0.1.11-nightly-2022-12-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "24bc274af8e1953d3f311c7b406cad154a391a72";
+  sha256 = "sha256-W2LoqzLnxl2TaigPloVonpsc1hWI7UTdk/rnx6wTuQ0=";
+}

--- a/manifests/forc-index-0.1.11-nightly-2022-12-14.nix
+++ b/manifests/forc-index-0.1.11-nightly-2022-12-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cf64694f328a0c80a358d77bc6501112d8487666";
+  sha256 = "sha256-leHhwweWEuVTmjCClmXU8tpaiGWKZvy6OI/fFLKyFjU=";
+}

--- a/manifests/forc-index-0.1.11-nightly-2022-12-15.nix
+++ b/manifests/forc-index-0.1.11-nightly-2022-12-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-15";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "88c33f0ecc08da34b2c20d93f0c37d16e2bf2007";
+  sha256 = "sha256-XOEDtDDahHeOUPdAx9OVWQU0RhCYCujNKLh/jZT2Dmw=";
+}

--- a/manifests/forc-index-0.1.11-nightly-2022-12-16.nix
+++ b/manifests/forc-index-0.1.11-nightly-2022-12-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4f0923d1da9a34fde689ccbd6e517122e46c61ce";
+  sha256 = "sha256-OYr4OATf9LOodZKNrW+N3T6pQm1fNrA1FzStpD09C0s=";
+}

--- a/manifests/forc-index-0.1.11-nightly-2022-12-17.nix
+++ b/manifests/forc-index-0.1.11-nightly-2022-12-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "f440ce382103380ba840f28b4e93685b1f30ad1c";
+  sha256 = "sha256-QBp3Aps2Tl5LUDx1aocLOoNHifz9IAt/rXdypUlfV44=";
+}

--- a/manifests/forc-index-0.1.11-nightly-2022-12-20.nix
+++ b/manifests/forc-index-0.1.11-nightly-2022-12-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-20";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "93f1d4c4e127f9278d35314206e8b8362fdd02d0";
+  sha256 = "sha256-qMJbIUw6oB3tutaRwIXcmvxksiGehU9pxXnEsWmIDrs=";
+}

--- a/manifests/forc-index-0.1.11-nightly-2022-12-21.nix
+++ b/manifests/forc-index-0.1.11-nightly-2022-12-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4213eca3b05a131dfb66cfde7606fe91e77accc5";
+  sha256 = "sha256-hD2e/jzDJmww5iJVjXLWH9cWgt1szphdDKIfDMyrmgU=";
+}

--- a/manifests/forc-index-0.1.11.nix
+++ b/manifests/forc-index-0.1.11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.11";
+  date = "2022-12-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4300093aea4cc7ad4eff048493ce5272b75eeb19";
+  sha256 = "sha256-hMfwBiUInTyLCx/KTsXYCFaa6D3FpQi3w9WKekFVFZk=";
+}

--- a/manifests/forc-index-0.1.12-nightly-2022-12-23.nix
+++ b/manifests/forc-index-0.1.12-nightly-2022-12-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.12";
+  date = "2022-12-23";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "5f189e5eaad1d2191bd42ee8ca90b02fc9532494";
+  sha256 = "sha256-lVvOo7jHmGmEXUrRSKB1S6tRkaiKTqqXtPktMRQABPs=";
+}

--- a/manifests/forc-index-0.1.12-nightly-2022-12-27.nix
+++ b/manifests/forc-index-0.1.12-nightly-2022-12-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.12";
+  date = "2022-12-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "5716e33aa8b2b74ac66d44e31581f9757044d503";
+  sha256 = "sha256-/agfx51yKR3oA+JSghfw8szGaOrkADcC/1hYCM8zvfk=";
+}

--- a/manifests/forc-index-0.1.12-nightly-2023-01-10.nix
+++ b/manifests/forc-index-0.1.12-nightly-2023-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.12";
+  date = "2023-01-10";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "993051e96467c8227085548f3825ee9d86444903";
+  sha256 = "sha256-t2kRh2VnyTk/tiEFceL43tjq8WlcvIiT2DIQ+rOG9Fc=";
+}

--- a/manifests/forc-index-0.1.12-nightly-2023-01-11.nix
+++ b/manifests/forc-index-0.1.12-nightly-2023-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.12";
+  date = "2023-01-11";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a467e5e6af557cf0655f629cc3d5c2f81c480b81";
+  sha256 = "sha256-WgR3gWixrMKccu9xbWCjR+gZPYzp6p+SuMrXJqn3x4o=";
+}

--- a/manifests/forc-index-0.1.12-nightly-2023-01-12.nix
+++ b/manifests/forc-index-0.1.12-nightly-2023-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.12";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "8e398e3b73cc2ca38ba8c413904f1fd29c28838b";
+  sha256 = "sha256-ySczdi40TVXhVxgJ7TWHNNbCvY1mzQ/r4zo4xQmTxYw=";
+}

--- a/manifests/forc-index-0.1.12.nix
+++ b/manifests/forc-index-0.1.12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.12";
+  date = "2022-12-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4e3550248c95d3f71248f76b2fd11519d11eef1b";
+  sha256 = "sha256-NKaq5uTq0ir6Ik91zBep5HnvZPa52nSAQWZDLQt3YJ0=";
+}

--- a/manifests/forc-index-0.1.13-nightly-2023-01-13.nix
+++ b/manifests/forc-index-0.1.13-nightly-2023-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.13";
+  date = "2023-01-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "820575a12d79797526e1b73db7d7288a63599f14";
+  sha256 = "sha256-eJbYFMNSBtaGITr3jhwDBffX/0SNlqJzlK5hy+M+KYA=";
+}

--- a/manifests/forc-index-0.1.13-nightly-2023-01-14.nix
+++ b/manifests/forc-index-0.1.13-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.13";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "971afc8569b78c608cf0740ca6a5e8f3167e6c0a";
+  sha256 = "sha256-59hCW5/VXIIphYpsu2zi88WQMIUZbRSKbelD151UBac=";
+}

--- a/manifests/forc-index-0.1.13-nightly-2023-01-19.nix
+++ b/manifests/forc-index-0.1.13-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.13";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "da16a31f1f125092d3e475b37222d0b511d71743";
+  sha256 = "sha256-0iAbgKdGUSe46v2DNP548tJfrL9FR0LZYqoldfMJGpE=";
+}

--- a/manifests/forc-index-0.1.13-nightly-2023-01-21.nix
+++ b/manifests/forc-index-0.1.13-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.13";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "b78ba940ee47aeeac4a00e94a8434f6dec673754";
+  sha256 = "sha256-VTD0AtDBk3ijtvlOaobeqmjHJu+y/oL9IYBptcwnJDI=";
+}

--- a/manifests/forc-index-0.1.13-nightly-2023-01-23.nix
+++ b/manifests/forc-index-0.1.13-nightly-2023-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.13";
+  date = "2023-01-23";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "778aa6c149961c3c4dd07e236a3f32371486c740";
+  sha256 = "sha256-6m9tcd8vl7dm3zVFHorsD8VeIGnKQ7jN1yu8WPrYo64=";
+}

--- a/manifests/forc-index-0.1.13-nightly-2023-01-24.nix
+++ b/manifests/forc-index-0.1.13-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.13";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "aacd7119c64629f714f9949032f7532db8235fab";
+  sha256 = "sha256-1mKRyJQt9cQkYNnw9DWVJgD1OGw7ifU5qCW1YWC4tWY=";
+}

--- a/manifests/forc-index-0.1.13.nix
+++ b/manifests/forc-index-0.1.13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.13";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "c2425c8b63f01ef1b540ff3e5832ebdc018b951d";
+  sha256 = "sha256-qPyJScMVk2il14OJgxGe/qHsPY9mq09FFn1vT4DdNYQ=";
+}

--- a/manifests/forc-index-0.1.2-nightly-2022-11-05.nix
+++ b/manifests/forc-index-0.1.2-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.2";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4a57dbd2bec8e51fb0999afc93542c64b42cba37";
+  sha256 = "sha256-lyAsROkqCSYli8oSaOgWHFWv6ulHQ4e/srTipjYhfsY=";
+}

--- a/manifests/forc-index-0.1.2-nightly-2022-11-09.nix
+++ b/manifests/forc-index-0.1.2-nightly-2022-11-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.2";
+  date = "2022-11-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "612d4c387cc6c75848d4b029e80226d0b1bde683";
+  sha256 = "sha256-GSDzd7ZAHBX3EnhpZb1yuxtsR1YvB7m/h/9j4z48imc=";
+}

--- a/manifests/forc-index-0.1.2-nightly-2022-11-11.nix
+++ b/manifests/forc-index-0.1.2-nightly-2022-11-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.2";
+  date = "2022-11-11";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "568be2dda271e92c1ed5b23ae8a158b44aad544c";
+  sha256 = "sha256-arnQwXuIgQA5IkXOSruHS7RNEeqRJWPM/1XqfadPOA0=";
+}

--- a/manifests/forc-index-0.1.2-nightly-2022-11-12.nix
+++ b/manifests/forc-index-0.1.2-nightly-2022-11-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.2";
+  date = "2022-11-12";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "738d4add6e5f772797aaae6035b1f64ac688645e";
+  sha256 = "sha256-fGxvgrg95pqtg68TZwtFEsOZayKHOOWX3SYyE90qBWw=";
+}

--- a/manifests/forc-index-0.1.2-nightly-2022-11-13.nix
+++ b/manifests/forc-index-0.1.2-nightly-2022-11-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.2";
+  date = "2022-11-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4cc48c33699485eef3dbb186a1784aaadba761d2";
+  sha256 = "sha256-tXpEJzzNzDIs81yr5Z5nmA8j5g/HkUMiKxRroQvMwcs=";
+}

--- a/manifests/forc-index-0.1.2-nightly-2022-11-15.nix
+++ b/manifests/forc-index-0.1.2-nightly-2022-11-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.2";
+  date = "2022-11-15";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "77ff2e8622c9e7bd10113264b75c33ce0a604db7";
+  sha256 = "sha256-1sB0P2ZKZN1awdmMItW6rAeaRvomLvXXmBsM5YAVKHA=";
+}

--- a/manifests/forc-index-0.1.2.nix
+++ b/manifests/forc-index-0.1.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.2";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4a57dbd2bec8e51fb0999afc93542c64b42cba37";
+  sha256 = "sha256-lyAsROkqCSYli8oSaOgWHFWv6ulHQ4e/srTipjYhfsY=";
+}

--- a/manifests/forc-index-0.1.3.nix
+++ b/manifests/forc-index-0.1.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.3";
+  date = "2022-11-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "ffd5d2a0f14c67c6fefa24c13cfb39b6a1773d88";
+  sha256 = "sha256-+QxstgSt4c/SSN0tbBt1d1sZqGxdBeglNAjMCtPg76U=";
+}

--- a/manifests/forc-index-0.1.4-nightly-2022-11-17.nix
+++ b/manifests/forc-index-0.1.4-nightly-2022-11-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.4";
+  date = "2022-11-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cc976f902d1ae8007f8d3027a8abddca04b24426";
+  sha256 = "sha256-FDllKpSFYvro5Ydsm6lgiQXUu3sYD7xtYqwVT477Q6M=";
+}

--- a/manifests/forc-index-0.1.4-nightly-2022-11-18.nix
+++ b/manifests/forc-index-0.1.4-nightly-2022-11-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.4";
+  date = "2022-11-18";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "6df8d92b92fe87022e77da216652d41af2954639";
+  sha256 = "sha256-ktnUcvvkQuLUYOUT4K9D7EJy+sj661INNNWgGFEh0t0=";
+}

--- a/manifests/forc-index-0.1.4-nightly-2022-11-22.nix
+++ b/manifests/forc-index-0.1.4-nightly-2022-11-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.4";
+  date = "2022-11-22";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "b062536b65b168453cd26666df48465d20592a8c";
+  sha256 = "sha256-AkEdlUUHUKXbbTCOkivfIKO4MfJXIFFe0BIyRN3VeNc=";
+}

--- a/manifests/forc-index-0.1.4.nix
+++ b/manifests/forc-index-0.1.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.4";
+  date = "2022-11-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cc976f902d1ae8007f8d3027a8abddca04b24426";
+  sha256 = "sha256-FDllKpSFYvro5Ydsm6lgiQXUu3sYD7xtYqwVT477Q6M=";
+}

--- a/manifests/forc-index-0.1.5-nightly-2022-11-24.nix
+++ b/manifests/forc-index-0.1.5-nightly-2022-11-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.5";
+  date = "2022-11-24";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a5753c425798a787f4d8aec888f16e4a23d567d9";
+  sha256 = "sha256-+/LrZ7WD2zvwqxxPvwwpmr86leHZZA5T9wF9bt7Hl7Q=";
+}

--- a/manifests/forc-index-0.1.5.nix
+++ b/manifests/forc-index-0.1.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.5";
+  date = "2022-11-23";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a5753c425798a787f4d8aec888f16e4a23d567d9";
+  sha256 = "sha256-+/LrZ7WD2zvwqxxPvwwpmr86leHZZA5T9wF9bt7Hl7Q=";
+}

--- a/manifests/forc-index-0.1.6-nightly-2022-11-29.nix
+++ b/manifests/forc-index-0.1.6-nightly-2022-11-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.6";
+  date = "2022-11-29";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "f815314d8def8857db6b918cf1a4c72dfe03d7a0";
+  sha256 = "sha256-7D9Y0L3uDJKmydnDOcCKFjwRgJcpcOXmjVOkQImr7hA=";
+}

--- a/manifests/forc-index-0.1.6.nix
+++ b/manifests/forc-index-0.1.6.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.6";
+  date = "2022-11-28";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "f815314d8def8857db6b918cf1a4c72dfe03d7a0";
+  sha256 = "sha256-7D9Y0L3uDJKmydnDOcCKFjwRgJcpcOXmjVOkQImr7hA=";
+}

--- a/manifests/forc-index-0.1.7-nightly-2022-11-30.nix
+++ b/manifests/forc-index-0.1.7-nightly-2022-11-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.7";
+  date = "2022-11-30";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a0ab2354c5936a99fc9f00593e4e1d143a7b5097";
+  sha256 = "sha256-uAb5rhIc4eNTwr6e+0MtOZTTwGOpRV2lCldY65uz1F0=";
+}

--- a/manifests/forc-index-0.1.7-nightly-2022-12-01.nix
+++ b/manifests/forc-index-0.1.7-nightly-2022-12-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.7";
+  date = "2022-12-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "85cf7085428b11f7853c37b81b18cac1c25c9d3b";
+  sha256 = "sha256-VnQWyWaiYgROIwrJxDdC00bEli0tFQrGgXEbWw6ERcA=";
+}

--- a/manifests/forc-index-0.1.7.nix
+++ b/manifests/forc-index-0.1.7.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.7";
+  date = "2022-11-29";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "fa4723ae6a3ec5156c035a3288fb1474c1d36ea6";
+  sha256 = "sha256-ypqW/FZ+Uj2hywnx9xzTPHjhVvMkRDeL/mQ1P2sq6wU=";
+}

--- a/manifests/forc-index-0.1.8-nightly-2022-12-02.nix
+++ b/manifests/forc-index-0.1.8-nightly-2022-12-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.8";
+  date = "2022-12-02";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "5e291943b2ba2ac36e95d26571fec14321920159";
+  sha256 = "sha256-iBAp4kqxw9ueR419Ch4xhM9o+7Ln4EKYNuS29DslsCk=";
+}

--- a/manifests/forc-index-0.1.8-nightly-2022-12-03.nix
+++ b/manifests/forc-index-0.1.8-nightly-2022-12-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.8";
+  date = "2022-12-03";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "d731016595aadbb6678012eb075082479f084db7";
+  sha256 = "sha256-P/oLKqWZCt4WgokG9IMZiSwodm12xJWYOkIOSzxwngI=";
+}

--- a/manifests/forc-index-0.1.8.nix
+++ b/manifests/forc-index-0.1.8.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.8";
+  date = "2022-12-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "f28a2d7a14ee5472cc1ffc47d4423992aa68b273";
+  sha256 = "sha256-ZxDcvccwYoC08dKoHoFNWkhKtNM8hDKTkuMjgcONvSk=";
+}

--- a/manifests/forc-index-0.1.9-nightly-2022-12-06.nix
+++ b/manifests/forc-index-0.1.9-nightly-2022-12-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.9";
+  date = "2022-12-06";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "73f471ab9809dcac2105e045b44191eacf9564c0";
+  sha256 = "sha256-VWhwYnwXBSp4YzGLaWle6Z5zRkl7J00HmT3+DwQXqfw=";
+}

--- a/manifests/forc-index-0.1.9.nix
+++ b/manifests/forc-index-0.1.9.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.1.9";
+  date = "2022-12-05";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "44d608dcb60112d25957011575af4cb9cfc33f51";
+  sha256 = "sha256-pbJTyY9fZDy5KnAbVjdObrlAE5qcs4kRapRF1e0RXm4=";
+}

--- a/manifests/forc-index-0.2.0-nightly-2023-01-25.nix
+++ b/manifests/forc-index-0.2.0-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.0";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "1988cdacf4700fef2fd9f34af982e1339bef0b03";
+  sha256 = "sha256-wbrd77gBJKVzONEghyd0gW2g+Nsyi8FWj98UyvGrssU=";
+}

--- a/manifests/forc-index-0.2.0-nightly-2023-01-26.nix
+++ b/manifests/forc-index-0.2.0-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.0";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "ff89b2e12445f9e48ae623063f56ae2ecc9a0c6f";
+  sha256 = "sha256-exNB/d08pZWRNhjDYCGcouxETdZ2Or/IYmjScC5G69g=";
+}

--- a/manifests/forc-index-0.2.0-nightly-2023-01-27.nix
+++ b/manifests/forc-index-0.2.0-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.0";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "409b69b87e17573e8074bec9252f7ebe0cf750d3";
+  sha256 = "sha256-/P1PiAO02bBRCahEOD/VgN8uYpI7SYqvfsqFrHyyTbk=";
+}

--- a/manifests/forc-index-0.2.0.nix
+++ b/manifests/forc-index-0.2.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.0";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "d4cd64e8a1f4bfbffde2a48ea554f7be4629b8d3";
+  sha256 = "sha256-DfMwg7c+Euc7q9HuyNnkHSqFur4MaCIx/c8fe16aI28=";
+}

--- a/manifests/forc-index-0.2.1.nix
+++ b/manifests/forc-index-0.2.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "0859f1f544cd1fe97ad753abdd69d67dcaec3e95";
+  sha256 = "sha256-iw+N86+ytoqE7U3O7I6RZD1U3H9B6WoqJAv9Tk7bVIs=";
+}

--- a/manifests/forc-index-0.2.2-nightly-2023-01-28.nix
+++ b/manifests/forc-index-0.2.2-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.2";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "62e14444fc8eefcf21b9ab494b588430d4b1e25a";
+  sha256 = "sha256-WqWNRfXuIYoenIxv+1Dr8ELtdvm4TOLhr8MuhZrLTeo=";
+}

--- a/manifests/forc-index-0.2.2-nightly-2023-01-29.nix
+++ b/manifests/forc-index-0.2.2-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.2";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "d06c1a77d50a2be1438279681a5006a66d954689";
+  sha256 = "sha256-/O7nZENk1OSmRCPp+Lnyv+IfiXREBkiIhXNIPh6nRzg=";
+}

--- a/manifests/forc-index-0.2.2.nix
+++ b/manifests/forc-index-0.2.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.2";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "62e14444fc8eefcf21b9ab494b588430d4b1e25a";
+  sha256 = "sha256-WqWNRfXuIYoenIxv+1Dr8ELtdvm4TOLhr8MuhZrLTeo=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-01.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "926e64a76b53af0c76af0640f49a089225b7f6ba";
+  sha256 = "sha256-7KV4/u6Ej9t3U77hencL9AVtaiXUx63GqVwJxxkrrIA=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-02.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-02";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "d8a83fdaf2f743f33a6243ecabdbbe2f4f79baca";
+  sha256 = "sha256-w7x6aj9dWDE2GW8CT/QPC9GBa41s3tS47QFHq1h9Qxg=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-03.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-03";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "621cf75f5ec463cd997326483df1c6391dc32326";
+  sha256 = "sha256-QkTyo1Hx3i0OhmlwEEP9XD7Si1h8K3xeOe2nyQNoNkw=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-07.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-07";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "0a9c7f9a28f26ad42ede96dc9501f3b0596dd340";
+  sha256 = "sha256-eK2QVHynvn3yJQUdplGNm2s5ZaWI4Ywl3W+A/fW8kko=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-08.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-08";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "07ef8b9c86b650e34d992e1cee5f80173227118e";
+  sha256 = "sha256-5zls1LeBY8TLD9H+e6Rx2gwvfY3CXWnV+LPrKAcuvfE=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-09.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "b6ca31afce56f1590cb4fa295d654ec26972c470";
+  sha256 = "sha256-cUJAXxF0tPSDnJloFVmF5lBxvlvRxy8VIM/05W59WGM=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-13.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "c15c39e8f6f214d668ff4e1c10a307d8d3593dbc";
+  sha256 = "sha256-9dJE8ArkX4Q5j7kXt147mS5LKMlRV+bIzrdWSJDkUTE=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-15.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-15";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "63fe99453edb4d9631e7fc3e20ee5227c3f6050f";
+  sha256 = "sha256-rCxuPQytty9zF5qQtxRXFUNtPK6coUQSESFWAZBO05A=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-17.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a14d4af24c59831f387112cd61aa49a0d16d37c5";
+  sha256 = "sha256-L0/w5gB7C20FVAnk9fPsKKETUQRaH7ovyjLsPrj6uIE=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-24.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "019ab9aaba4e1fbafd42613f2f5d6eac6fe80969";
+  sha256 = "sha256-DgVKN4/40yh/0K0gzM5AgXFNhkil/yV8FZTuq/pYmBU=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-09-27.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "74f30fb3abf9709c74dd07d1cede44930077bc78";
+  sha256 = "sha256-ynRorDghwivXizDS3MUsdocrw7Uqc42xZAPVgby40WI=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-01.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "aa005ac2d506c4a13a15c7ea8aa64ed7f3694eb2";
+  sha256 = "sha256-afw3tHkNJL8RwMZ1B4jq8hoblAI+FGoyDvdN7kMvh1g=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-07.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "2ad8b2b73f1b3b26341e78cc83d93993340162a4";
+  sha256 = "sha256-SwBCh/VVpUWf8hOA6aPsJvGzHGAMuMf4r6HT/MhXMHE=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-09.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "0a92066f82fd13ee88606ab57c5fb2af18e89dbc";
+  sha256 = "sha256-vpT1CkYzNLpKIgb0qOaoFFFq5PLYnkcpWVLaCCoQ5uI=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-12.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "39cc18d028d66a330adba5edb778b87457d3255b";
+  sha256 = "sha256-mvfehXXJmruRjx3255j1PhB93k+Na2uu43iBBzH417w=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-13.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "2ce05f696a3bd01cd945b0c76450091d97f122bb";
+  sha256 = "sha256-ZOqLnGPvVw7v0wHUt95hyZjIO3UrJJvNtYKQmdp7INU=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-14.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "221197d01c4b9ef41149654614b93e346a2d8a3b";
+  sha256 = "sha256-SgexLcN7Dc6tYjIrj+GRyGvc4wDuNWcEU8ESeUiNYvQ=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-17.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "aea945cb8498800736a29807fb86f0139376a469";
+  sha256 = "sha256-2jOiStmbNoJfa1uz8K9shbw4axPN7ARLQ6cXefObhMQ=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-18.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "3ce2dd66bb245f36b29c150424d7db844558784b";
+  sha256 = "sha256-uaRHsv5auMwLSAGtNvxVWnLUVs7ZKrCY3/yIybeINe4=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-19.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "1bda330952782b1ec4768365015b52b7ee8cd4ce";
+  sha256 = "sha256-cfnn3BK625V0+M8mk3fW6Ope4y3UU6PtDSuDmm1zAWs=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-20.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-20";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "70c81e098cd070c359911e28cefe67bfe45bad2d";
+  sha256 = "sha256-F6JSy2F5lbsa/H/DLnpM1tCnOpcYaOXDcx4yEL23rFA=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-21.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "5ef73d25b23868282381bf8ca8843bc11191eac2";
+  sha256 = "sha256-0q70qRPq/9/sSp3m5jslVdUZ7mrP0HYOa4nUCxo/7Bk=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-22.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-22";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "fc01f6e86526a24a5787785e1b11e5b69bfe7de5";
+  sha256 = "sha256-XsPr1UhXiyLJYCagyl+WTGqmn+3Fjrcu2aMuzZhsJOc=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-23.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-23";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "3abd406744fff31d60c3248a4775b863eb96066f";
+  sha256 = "sha256-uK3sfABB/vy/h96cM8pm69MheADJ4LmfjRGqhyCAQCE=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-25.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "2be0075e03cf811b285b5b857210fea751430844";
+  sha256 = "sha256-iL2/3vbYbOq6b4wQFTf8PhPRrOPRlPtYlEVSdg/ZaLA=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-26.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-26";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "09985514674396e4c68a44941d26d2e314da48f3";
+  sha256 = "sha256-48DKmfta1MniADdEqXQVsgJdUTIdXaTNVp7gCqSOtk4=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-29.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-29";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "27ad86e9f4c552c5eb58ab7fabf8ee8b05027923";
+  sha256 = "sha256-u1hcwDqyQKxlPNUsS4NEW8Xpl/PQ4vTKKQA1kptrHaM=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-10-31.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-10-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "33d341d9335e4a6cb889c7b724846516731171eb";
+  sha256 = "sha256-/POIfDsSNJ5P7TwvZLMxzms5YnFZFtjWj+dYHYRwvXg=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-11-01.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "ccf3df7f5a51f2351e3f32b7951b53b80ac7fc8a";
+  sha256 = "sha256-IVV1h/eiev0/OpO1aFD3UtXYpka5dJ1CsFSDT/pH2T8=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-11-02.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "984be3a4707e33df7c911d623080d5e9f7cdedfb";
+  sha256 = "sha256-K+hl5A0gq909urG7I69gMAc8BWbuUCwvmG1mh3S1Nzo=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-11-03.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-11-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "55602585ecd5bcd7e597ae01101ba7a5a0627b4c";
+  sha256 = "sha256-TnybIZA2VvHaILzEg5KHrvWl8u6xX04yEL/gCz3P5W4=";
+}

--- a/manifests/fuel-indexer-0.0.0-nightly-2022-11-04.nix
+++ b/manifests/fuel-indexer-0.0.0-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.0.0";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "0522ce0e21b63af7c246449b4f6a09e66184255d";
+  sha256 = "sha256-Vf8Kw7Ecbj066FEBXkaqZ9s8lLs8bbZU+zcWTSR0wb0=";
+}

--- a/manifests/fuel-indexer-0.1.0.nix
+++ b/manifests/fuel-indexer-0.1.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cd2aaa2ef96163347ec86cb2f59114a95841ae4d";
+  sha256 = "sha256-+uVXLMbJsA3EdWi7VS9lvJmciCB1v5b0Uw8xw5OJ9pY=";
+}

--- a/manifests/fuel-indexer-0.1.1.nix
+++ b/manifests/fuel-indexer-0.1.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "522651e91bb09870f0791975cf547ae5596de403";
+  sha256 = "sha256-8iDZxmolZXC3gSmoZA1/SvuMliTC2dEbVA2iyiskZA0=";
+}

--- a/manifests/fuel-indexer-0.1.10-nightly-2022-12-07.nix
+++ b/manifests/fuel-indexer-0.1.10-nightly-2022-12-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.10";
+  date = "2022-12-07";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "b474f1d5ad34a938cf5d9c19d3c88cb15142f2dd";
+  sha256 = "sha256-2NFe1/Njx4qEKNtcH6WllM/g5/GkOrh6s2/pNR7rb4k=";
+}

--- a/manifests/fuel-indexer-0.1.10-nightly-2022-12-08.nix
+++ b/manifests/fuel-indexer-0.1.10-nightly-2022-12-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.10";
+  date = "2022-12-08";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a5dca28edd9f715cde5f1664bf9d08bfd8e284d6";
+  sha256 = "sha256-BsIMDMfq9gXpUDCyvMgzCQTQS/8BHAezWk2mezU4t5I=";
+}

--- a/manifests/fuel-indexer-0.1.10-nightly-2022-12-09.nix
+++ b/manifests/fuel-indexer-0.1.10-nightly-2022-12-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.10";
+  date = "2022-12-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "c94767a92f970cfe0a60d2a45070399ed3aa2873";
+  sha256 = "sha256-RYJie53HS1xCkvEFGrYOxBq8wuuFbNhgF3d9ZGUpEqU=";
+}

--- a/manifests/fuel-indexer-0.1.10-nightly-2022-12-10.nix
+++ b/manifests/fuel-indexer-0.1.10-nightly-2022-12-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.10";
+  date = "2022-12-10";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cddc972b524bb90bbfe4a334bf78d5c60c0c5bb8";
+  sha256 = "sha256-rsiQhLASHbp1tpucbcgVDYQdUNAnxTjUuWB/J3brNrE=";
+}

--- a/manifests/fuel-indexer-0.1.10.nix
+++ b/manifests/fuel-indexer-0.1.10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.10";
+  date = "2022-12-06";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "daef60d5a5ddfb1b50b638df1db9650553ca326a";
+  sha256 = "sha256-IN+0K8MeSg1nRpkjzrmQV9Ycir89iONiovam1rKB06Q=";
+}

--- a/manifests/fuel-indexer-0.1.11-nightly-2022-12-11.nix
+++ b/manifests/fuel-indexer-0.1.11-nightly-2022-12-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-11";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4300093aea4cc7ad4eff048493ce5272b75eeb19";
+  sha256 = "sha256-hMfwBiUInTyLCx/KTsXYCFaa6D3FpQi3w9WKekFVFZk=";
+}

--- a/manifests/fuel-indexer-0.1.11-nightly-2022-12-13.nix
+++ b/manifests/fuel-indexer-0.1.11-nightly-2022-12-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "24bc274af8e1953d3f311c7b406cad154a391a72";
+  sha256 = "sha256-W2LoqzLnxl2TaigPloVonpsc1hWI7UTdk/rnx6wTuQ0=";
+}

--- a/manifests/fuel-indexer-0.1.11-nightly-2022-12-14.nix
+++ b/manifests/fuel-indexer-0.1.11-nightly-2022-12-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cf64694f328a0c80a358d77bc6501112d8487666";
+  sha256 = "sha256-leHhwweWEuVTmjCClmXU8tpaiGWKZvy6OI/fFLKyFjU=";
+}

--- a/manifests/fuel-indexer-0.1.11-nightly-2022-12-15.nix
+++ b/manifests/fuel-indexer-0.1.11-nightly-2022-12-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-15";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "88c33f0ecc08da34b2c20d93f0c37d16e2bf2007";
+  sha256 = "sha256-XOEDtDDahHeOUPdAx9OVWQU0RhCYCujNKLh/jZT2Dmw=";
+}

--- a/manifests/fuel-indexer-0.1.11-nightly-2022-12-16.nix
+++ b/manifests/fuel-indexer-0.1.11-nightly-2022-12-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4f0923d1da9a34fde689ccbd6e517122e46c61ce";
+  sha256 = "sha256-OYr4OATf9LOodZKNrW+N3T6pQm1fNrA1FzStpD09C0s=";
+}

--- a/manifests/fuel-indexer-0.1.11-nightly-2022-12-17.nix
+++ b/manifests/fuel-indexer-0.1.11-nightly-2022-12-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "f440ce382103380ba840f28b4e93685b1f30ad1c";
+  sha256 = "sha256-QBp3Aps2Tl5LUDx1aocLOoNHifz9IAt/rXdypUlfV44=";
+}

--- a/manifests/fuel-indexer-0.1.11-nightly-2022-12-20.nix
+++ b/manifests/fuel-indexer-0.1.11-nightly-2022-12-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-20";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "93f1d4c4e127f9278d35314206e8b8362fdd02d0";
+  sha256 = "sha256-qMJbIUw6oB3tutaRwIXcmvxksiGehU9pxXnEsWmIDrs=";
+}

--- a/manifests/fuel-indexer-0.1.11-nightly-2022-12-21.nix
+++ b/manifests/fuel-indexer-0.1.11-nightly-2022-12-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4213eca3b05a131dfb66cfde7606fe91e77accc5";
+  sha256 = "sha256-hD2e/jzDJmww5iJVjXLWH9cWgt1szphdDKIfDMyrmgU=";
+}

--- a/manifests/fuel-indexer-0.1.11.nix
+++ b/manifests/fuel-indexer-0.1.11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.11";
+  date = "2022-12-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4300093aea4cc7ad4eff048493ce5272b75eeb19";
+  sha256 = "sha256-hMfwBiUInTyLCx/KTsXYCFaa6D3FpQi3w9WKekFVFZk=";
+}

--- a/manifests/fuel-indexer-0.1.12-nightly-2022-12-23.nix
+++ b/manifests/fuel-indexer-0.1.12-nightly-2022-12-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.12";
+  date = "2022-12-23";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "5f189e5eaad1d2191bd42ee8ca90b02fc9532494";
+  sha256 = "sha256-lVvOo7jHmGmEXUrRSKB1S6tRkaiKTqqXtPktMRQABPs=";
+}

--- a/manifests/fuel-indexer-0.1.12-nightly-2022-12-27.nix
+++ b/manifests/fuel-indexer-0.1.12-nightly-2022-12-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.12";
+  date = "2022-12-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "5716e33aa8b2b74ac66d44e31581f9757044d503";
+  sha256 = "sha256-/agfx51yKR3oA+JSghfw8szGaOrkADcC/1hYCM8zvfk=";
+}

--- a/manifests/fuel-indexer-0.1.12-nightly-2023-01-10.nix
+++ b/manifests/fuel-indexer-0.1.12-nightly-2023-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.12";
+  date = "2023-01-10";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "993051e96467c8227085548f3825ee9d86444903";
+  sha256 = "sha256-t2kRh2VnyTk/tiEFceL43tjq8WlcvIiT2DIQ+rOG9Fc=";
+}

--- a/manifests/fuel-indexer-0.1.12-nightly-2023-01-11.nix
+++ b/manifests/fuel-indexer-0.1.12-nightly-2023-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.12";
+  date = "2023-01-11";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a467e5e6af557cf0655f629cc3d5c2f81c480b81";
+  sha256 = "sha256-WgR3gWixrMKccu9xbWCjR+gZPYzp6p+SuMrXJqn3x4o=";
+}

--- a/manifests/fuel-indexer-0.1.12-nightly-2023-01-12.nix
+++ b/manifests/fuel-indexer-0.1.12-nightly-2023-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.12";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "8e398e3b73cc2ca38ba8c413904f1fd29c28838b";
+  sha256 = "sha256-ySczdi40TVXhVxgJ7TWHNNbCvY1mzQ/r4zo4xQmTxYw=";
+}

--- a/manifests/fuel-indexer-0.1.12.nix
+++ b/manifests/fuel-indexer-0.1.12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.12";
+  date = "2022-12-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4e3550248c95d3f71248f76b2fd11519d11eef1b";
+  sha256 = "sha256-NKaq5uTq0ir6Ik91zBep5HnvZPa52nSAQWZDLQt3YJ0=";
+}

--- a/manifests/fuel-indexer-0.1.13-nightly-2023-01-13.nix
+++ b/manifests/fuel-indexer-0.1.13-nightly-2023-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.13";
+  date = "2023-01-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "820575a12d79797526e1b73db7d7288a63599f14";
+  sha256 = "sha256-eJbYFMNSBtaGITr3jhwDBffX/0SNlqJzlK5hy+M+KYA=";
+}

--- a/manifests/fuel-indexer-0.1.13-nightly-2023-01-14.nix
+++ b/manifests/fuel-indexer-0.1.13-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.13";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "971afc8569b78c608cf0740ca6a5e8f3167e6c0a";
+  sha256 = "sha256-59hCW5/VXIIphYpsu2zi88WQMIUZbRSKbelD151UBac=";
+}

--- a/manifests/fuel-indexer-0.1.13-nightly-2023-01-19.nix
+++ b/manifests/fuel-indexer-0.1.13-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.13";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "da16a31f1f125092d3e475b37222d0b511d71743";
+  sha256 = "sha256-0iAbgKdGUSe46v2DNP548tJfrL9FR0LZYqoldfMJGpE=";
+}

--- a/manifests/fuel-indexer-0.1.13-nightly-2023-01-21.nix
+++ b/manifests/fuel-indexer-0.1.13-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.13";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "b78ba940ee47aeeac4a00e94a8434f6dec673754";
+  sha256 = "sha256-VTD0AtDBk3ijtvlOaobeqmjHJu+y/oL9IYBptcwnJDI=";
+}

--- a/manifests/fuel-indexer-0.1.13-nightly-2023-01-23.nix
+++ b/manifests/fuel-indexer-0.1.13-nightly-2023-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.13";
+  date = "2023-01-23";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "778aa6c149961c3c4dd07e236a3f32371486c740";
+  sha256 = "sha256-6m9tcd8vl7dm3zVFHorsD8VeIGnKQ7jN1yu8WPrYo64=";
+}

--- a/manifests/fuel-indexer-0.1.13-nightly-2023-01-24.nix
+++ b/manifests/fuel-indexer-0.1.13-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.13";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "aacd7119c64629f714f9949032f7532db8235fab";
+  sha256 = "sha256-1mKRyJQt9cQkYNnw9DWVJgD1OGw7ifU5qCW1YWC4tWY=";
+}

--- a/manifests/fuel-indexer-0.1.13.nix
+++ b/manifests/fuel-indexer-0.1.13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.13";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "c2425c8b63f01ef1b540ff3e5832ebdc018b951d";
+  sha256 = "sha256-qPyJScMVk2il14OJgxGe/qHsPY9mq09FFn1vT4DdNYQ=";
+}

--- a/manifests/fuel-indexer-0.1.2-nightly-2022-11-05.nix
+++ b/manifests/fuel-indexer-0.1.2-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.2";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4a57dbd2bec8e51fb0999afc93542c64b42cba37";
+  sha256 = "sha256-lyAsROkqCSYli8oSaOgWHFWv6ulHQ4e/srTipjYhfsY=";
+}

--- a/manifests/fuel-indexer-0.1.2-nightly-2022-11-09.nix
+++ b/manifests/fuel-indexer-0.1.2-nightly-2022-11-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.2";
+  date = "2022-11-09";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "612d4c387cc6c75848d4b029e80226d0b1bde683";
+  sha256 = "sha256-GSDzd7ZAHBX3EnhpZb1yuxtsR1YvB7m/h/9j4z48imc=";
+}

--- a/manifests/fuel-indexer-0.1.2-nightly-2022-11-11.nix
+++ b/manifests/fuel-indexer-0.1.2-nightly-2022-11-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.2";
+  date = "2022-11-11";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "568be2dda271e92c1ed5b23ae8a158b44aad544c";
+  sha256 = "sha256-arnQwXuIgQA5IkXOSruHS7RNEeqRJWPM/1XqfadPOA0=";
+}

--- a/manifests/fuel-indexer-0.1.2-nightly-2022-11-12.nix
+++ b/manifests/fuel-indexer-0.1.2-nightly-2022-11-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.2";
+  date = "2022-11-12";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "738d4add6e5f772797aaae6035b1f64ac688645e";
+  sha256 = "sha256-fGxvgrg95pqtg68TZwtFEsOZayKHOOWX3SYyE90qBWw=";
+}

--- a/manifests/fuel-indexer-0.1.2-nightly-2022-11-13.nix
+++ b/manifests/fuel-indexer-0.1.2-nightly-2022-11-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.2";
+  date = "2022-11-13";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4cc48c33699485eef3dbb186a1784aaadba761d2";
+  sha256 = "sha256-tXpEJzzNzDIs81yr5Z5nmA8j5g/HkUMiKxRroQvMwcs=";
+}

--- a/manifests/fuel-indexer-0.1.2-nightly-2022-11-15.nix
+++ b/manifests/fuel-indexer-0.1.2-nightly-2022-11-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.2";
+  date = "2022-11-15";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "77ff2e8622c9e7bd10113264b75c33ce0a604db7";
+  sha256 = "sha256-1sB0P2ZKZN1awdmMItW6rAeaRvomLvXXmBsM5YAVKHA=";
+}

--- a/manifests/fuel-indexer-0.1.2.nix
+++ b/manifests/fuel-indexer-0.1.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.2";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "4a57dbd2bec8e51fb0999afc93542c64b42cba37";
+  sha256 = "sha256-lyAsROkqCSYli8oSaOgWHFWv6ulHQ4e/srTipjYhfsY=";
+}

--- a/manifests/fuel-indexer-0.1.3.nix
+++ b/manifests/fuel-indexer-0.1.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.3";
+  date = "2022-11-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "ffd5d2a0f14c67c6fefa24c13cfb39b6a1773d88";
+  sha256 = "sha256-+QxstgSt4c/SSN0tbBt1d1sZqGxdBeglNAjMCtPg76U=";
+}

--- a/manifests/fuel-indexer-0.1.4-nightly-2022-11-17.nix
+++ b/manifests/fuel-indexer-0.1.4-nightly-2022-11-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.4";
+  date = "2022-11-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cc976f902d1ae8007f8d3027a8abddca04b24426";
+  sha256 = "sha256-FDllKpSFYvro5Ydsm6lgiQXUu3sYD7xtYqwVT477Q6M=";
+}

--- a/manifests/fuel-indexer-0.1.4-nightly-2022-11-18.nix
+++ b/manifests/fuel-indexer-0.1.4-nightly-2022-11-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.4";
+  date = "2022-11-18";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "6df8d92b92fe87022e77da216652d41af2954639";
+  sha256 = "sha256-ktnUcvvkQuLUYOUT4K9D7EJy+sj661INNNWgGFEh0t0=";
+}

--- a/manifests/fuel-indexer-0.1.4-nightly-2022-11-22.nix
+++ b/manifests/fuel-indexer-0.1.4-nightly-2022-11-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.4";
+  date = "2022-11-22";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "b062536b65b168453cd26666df48465d20592a8c";
+  sha256 = "sha256-AkEdlUUHUKXbbTCOkivfIKO4MfJXIFFe0BIyRN3VeNc=";
+}

--- a/manifests/fuel-indexer-0.1.4.nix
+++ b/manifests/fuel-indexer-0.1.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.4";
+  date = "2022-11-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "cc976f902d1ae8007f8d3027a8abddca04b24426";
+  sha256 = "sha256-FDllKpSFYvro5Ydsm6lgiQXUu3sYD7xtYqwVT477Q6M=";
+}

--- a/manifests/fuel-indexer-0.1.5-nightly-2022-11-24.nix
+++ b/manifests/fuel-indexer-0.1.5-nightly-2022-11-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.5";
+  date = "2022-11-24";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a5753c425798a787f4d8aec888f16e4a23d567d9";
+  sha256 = "sha256-+/LrZ7WD2zvwqxxPvwwpmr86leHZZA5T9wF9bt7Hl7Q=";
+}

--- a/manifests/fuel-indexer-0.1.5.nix
+++ b/manifests/fuel-indexer-0.1.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.5";
+  date = "2022-11-23";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a5753c425798a787f4d8aec888f16e4a23d567d9";
+  sha256 = "sha256-+/LrZ7WD2zvwqxxPvwwpmr86leHZZA5T9wF9bt7Hl7Q=";
+}

--- a/manifests/fuel-indexer-0.1.6-nightly-2022-11-29.nix
+++ b/manifests/fuel-indexer-0.1.6-nightly-2022-11-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.6";
+  date = "2022-11-29";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "f815314d8def8857db6b918cf1a4c72dfe03d7a0";
+  sha256 = "sha256-7D9Y0L3uDJKmydnDOcCKFjwRgJcpcOXmjVOkQImr7hA=";
+}

--- a/manifests/fuel-indexer-0.1.6.nix
+++ b/manifests/fuel-indexer-0.1.6.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.6";
+  date = "2022-11-28";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "f815314d8def8857db6b918cf1a4c72dfe03d7a0";
+  sha256 = "sha256-7D9Y0L3uDJKmydnDOcCKFjwRgJcpcOXmjVOkQImr7hA=";
+}

--- a/manifests/fuel-indexer-0.1.7-nightly-2022-11-30.nix
+++ b/manifests/fuel-indexer-0.1.7-nightly-2022-11-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.7";
+  date = "2022-11-30";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a0ab2354c5936a99fc9f00593e4e1d143a7b5097";
+  sha256 = "sha256-uAb5rhIc4eNTwr6e+0MtOZTTwGOpRV2lCldY65uz1F0=";
+}

--- a/manifests/fuel-indexer-0.1.7-nightly-2022-12-01.nix
+++ b/manifests/fuel-indexer-0.1.7-nightly-2022-12-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.7";
+  date = "2022-12-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "85cf7085428b11f7853c37b81b18cac1c25c9d3b";
+  sha256 = "sha256-VnQWyWaiYgROIwrJxDdC00bEli0tFQrGgXEbWw6ERcA=";
+}

--- a/manifests/fuel-indexer-0.1.7.nix
+++ b/manifests/fuel-indexer-0.1.7.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.7";
+  date = "2022-11-29";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "fa4723ae6a3ec5156c035a3288fb1474c1d36ea6";
+  sha256 = "sha256-ypqW/FZ+Uj2hywnx9xzTPHjhVvMkRDeL/mQ1P2sq6wU=";
+}

--- a/manifests/fuel-indexer-0.1.8-nightly-2022-12-02.nix
+++ b/manifests/fuel-indexer-0.1.8-nightly-2022-12-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.8";
+  date = "2022-12-02";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "5e291943b2ba2ac36e95d26571fec14321920159";
+  sha256 = "sha256-iBAp4kqxw9ueR419Ch4xhM9o+7Ln4EKYNuS29DslsCk=";
+}

--- a/manifests/fuel-indexer-0.1.8-nightly-2022-12-03.nix
+++ b/manifests/fuel-indexer-0.1.8-nightly-2022-12-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.8";
+  date = "2022-12-03";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "d731016595aadbb6678012eb075082479f084db7";
+  sha256 = "sha256-P/oLKqWZCt4WgokG9IMZiSwodm12xJWYOkIOSzxwngI=";
+}

--- a/manifests/fuel-indexer-0.1.8.nix
+++ b/manifests/fuel-indexer-0.1.8.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.8";
+  date = "2022-12-01";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "f28a2d7a14ee5472cc1ffc47d4423992aa68b273";
+  sha256 = "sha256-ZxDcvccwYoC08dKoHoFNWkhKtNM8hDKTkuMjgcONvSk=";
+}

--- a/manifests/fuel-indexer-0.1.9-nightly-2022-12-06.nix
+++ b/manifests/fuel-indexer-0.1.9-nightly-2022-12-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.9";
+  date = "2022-12-06";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "73f471ab9809dcac2105e045b44191eacf9564c0";
+  sha256 = "sha256-VWhwYnwXBSp4YzGLaWle6Z5zRkl7J00HmT3+DwQXqfw=";
+}

--- a/manifests/fuel-indexer-0.1.9.nix
+++ b/manifests/fuel-indexer-0.1.9.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.1.9";
+  date = "2022-12-05";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "44d608dcb60112d25957011575af4cb9cfc33f51";
+  sha256 = "sha256-pbJTyY9fZDy5KnAbVjdObrlAE5qcs4kRapRF1e0RXm4=";
+}

--- a/manifests/fuel-indexer-0.2.0-nightly-2023-01-25.nix
+++ b/manifests/fuel-indexer-0.2.0-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.0";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "1988cdacf4700fef2fd9f34af982e1339bef0b03";
+  sha256 = "sha256-wbrd77gBJKVzONEghyd0gW2g+Nsyi8FWj98UyvGrssU=";
+}

--- a/manifests/fuel-indexer-0.2.0-nightly-2023-01-26.nix
+++ b/manifests/fuel-indexer-0.2.0-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.0";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "ff89b2e12445f9e48ae623063f56ae2ecc9a0c6f";
+  sha256 = "sha256-exNB/d08pZWRNhjDYCGcouxETdZ2Or/IYmjScC5G69g=";
+}

--- a/manifests/fuel-indexer-0.2.0-nightly-2023-01-27.nix
+++ b/manifests/fuel-indexer-0.2.0-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.0";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "409b69b87e17573e8074bec9252f7ebe0cf750d3";
+  sha256 = "sha256-/P1PiAO02bBRCahEOD/VgN8uYpI7SYqvfsqFrHyyTbk=";
+}

--- a/manifests/fuel-indexer-0.2.0.nix
+++ b/manifests/fuel-indexer-0.2.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.0";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "d4cd64e8a1f4bfbffde2a48ea554f7be4629b8d3";
+  sha256 = "sha256-DfMwg7c+Euc7q9HuyNnkHSqFur4MaCIx/c8fe16aI28=";
+}

--- a/manifests/fuel-indexer-0.2.1.nix
+++ b/manifests/fuel-indexer-0.2.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "0859f1f544cd1fe97ad753abdd69d67dcaec3e95";
+  sha256 = "sha256-iw+N86+ytoqE7U3O7I6RZD1U3H9B6WoqJAv9Tk7bVIs=";
+}

--- a/manifests/fuel-indexer-0.2.2-nightly-2023-01-28.nix
+++ b/manifests/fuel-indexer-0.2.2-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.2";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "62e14444fc8eefcf21b9ab494b588430d4b1e25a";
+  sha256 = "sha256-WqWNRfXuIYoenIxv+1Dr8ELtdvm4TOLhr8MuhZrLTeo=";
+}

--- a/manifests/fuel-indexer-0.2.2-nightly-2023-01-29.nix
+++ b/manifests/fuel-indexer-0.2.2-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.2";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "d06c1a77d50a2be1438279681a5006a66d954689";
+  sha256 = "sha256-/O7nZENk1OSmRCPp+Lnyv+IfiXREBkiIhXNIPh6nRzg=";
+}

--- a/manifests/fuel-indexer-0.2.2.nix
+++ b/manifests/fuel-indexer-0.2.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.2";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "62e14444fc8eefcf21b9ab494b588430d4b1e25a";
+  sha256 = "sha256-WqWNRfXuIYoenIxv+1Dr8ELtdvm4TOLhr8MuhZrLTeo=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -264,7 +264,7 @@ in [
     patch = m: {
       nativeBuildInputs = (m.nativeBuildInputs or []) ++ [pkgs.pkg-config];
       buildAndTestSubdir = if pkgs.lib.hasPrefix "forc-" m.pname
-        then "plugins/forc-index"
+        then "plugins/${m.pname}"
         else "packages/${m.pname}";
       buildInputs =
         (m.buildInputs or [])

--- a/patches.nix
+++ b/patches.nix
@@ -263,7 +263,8 @@ in [
     condition = m: m.src.gitRepoUrl == "https://github.com/fuellabs/fuel-indexer";
     patch = m: {
       nativeBuildInputs = (m.nativeBuildInputs or []) ++ [pkgs.pkg-config];
-      buildAndTestSubdir = if pkgs.lib.hasPrefix "forc-" m.pname
+      buildAndTestSubdir =
+        if pkgs.lib.hasPrefix "forc-" m.pname
         then "plugins/${m.pname}"
         else "packages/${m.pname}";
       buildInputs =

--- a/patches.nix
+++ b/patches.nix
@@ -256,11 +256,16 @@ in [
     };
   }
 
-  # The fuel-indexer crate build requires postgresql and sqlx-cli.
+  # The fuel-indexer crates generally require postgresql and sqlx-cli.
+  # They're normally placed under `packages` directory with the exception of
+  # forc plugins.
   {
-    condition = m: m.pname == "fuel-indexer";
+    condition = m: m.src.gitRepoUrl == "https://github.com/fuellabs/fuel-indexer";
     patch = m: {
       nativeBuildInputs = (m.nativeBuildInputs or []) ++ [pkgs.pkg-config];
+      buildAndTestSubdir = if pkgs.lib.hasPrefix "forc-" m.pname
+        then "plugins/forc-index"
+        else "packages/${m.pname}";
       buildInputs =
         (m.buildInputs or [])
         ++ [

--- a/patches.nix
+++ b/patches.nix
@@ -255,4 +255,21 @@ in [
       rust = pkgs.rust-bin.stable."1.65.0".default;
     };
   }
+
+  # The fuel-indexer crate build requires postgresql and sqlx-cli.
+  {
+    condition = m: m.pname == "fuel-indexer";
+    patch = m: {
+      nativeBuildInputs = (m.nativeBuildInputs or []) ++ [pkgs.pkg-config];
+      buildInputs =
+        (m.buildInputs or [])
+        ++ [
+          pkgs.postgresql
+          pkgs.sqlx-cli
+        ];
+      doCheck = false; # Already tested at repo.
+      LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+      SQLX_OFFLINE = true;
+    };
+  }
 ]

--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -22,19 +22,12 @@ declare -A fuel_repos=(
     [forc-explorer]="https://github.com/fuellabs/forc-explorer"
     [forc-wallet]="https://github.com/fuellabs/forc-wallet"
     [fuel-core]="https://github.com/fuellabs/fuel-core"
+    [fuel-indexer]="https://github.com/fuellabs/fuel-indexer"
     [sway]="https://github.com/fuellabs/sway"
     [sway-vim]="https://github.com/fuellabs/sway.vim"
 )
 
 # The set of packages.
-declare -A pkg_fuel_core=(
-    [name]="fuel-core"
-    [repo]="${fuel_repos[fuel-core]}"
-)
-declare -A pkg_fuel_core_client=(
-    [name]="fuel-core-client"
-    [repo]="${fuel_repos[fuel-core]}"
-)
 declare -A pkg_forc=(
     [name]="forc"
     [repo]="${fuel_repos[sway]}"
@@ -66,6 +59,18 @@ declare -A pkg_forc_tx=(
 declare -A pkg_forc_wallet=(
     [name]="forc-wallet"
     [repo]="${fuel_repos[forc-wallet]}"
+)
+declare -A pkg_fuel_core=(
+    [name]="fuel-core"
+    [repo]="${fuel_repos[fuel-core]}"
+)
+declare -A pkg_fuel_core_client=(
+    [name]="fuel-core-client"
+    [repo]="${fuel_repos[fuel-core]}"
+)
+declare -A pkg_fuel_indexer=(
+    [name]="fuel-indexer"
+    [repo]="${fuel_repos[fuel-indexer]}"
 )
 
 # Create a temporary directory for cloning repositories.
@@ -215,8 +220,6 @@ function refresh {
     refresh_nightlies fpkg
 }
 
-refresh pkg_fuel_core
-refresh pkg_fuel_core_client
 refresh pkg_forc
 refresh pkg_forc_client
 refresh pkg_forc_doc
@@ -225,3 +228,6 @@ refresh pkg_forc_fmt
 refresh pkg_forc_lsp
 refresh pkg_forc_tx
 refresh pkg_forc_wallet
+refresh pkg_fuel_core
+refresh pkg_fuel_core_client
+refresh pkg_fuel_indexer

--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -48,6 +48,10 @@ declare -A pkg_forc_fmt=(
     [name]="forc-fmt"
     [repo]="${fuel_repos[sway]}"
 )
+declare -A pkg_forc_index=(
+    [name]="forc-index"
+    [repo]="${fuel_repos[fuel-indexer]}"
+)
 declare -A pkg_forc_lsp=(
     [name]="forc-lsp"
     [repo]="${fuel_repos[sway]}"
@@ -225,6 +229,7 @@ refresh pkg_forc_client
 refresh pkg_forc_doc
 refresh pkg_forc_explore
 refresh pkg_forc_fmt
+refresh pkg_forc_index
 refresh pkg_forc_lsp
 refresh pkg_forc_tx
 refresh pkg_forc_wallet


### PR DESCRIPTION
This includes all the binaries under the one package, i.e. `fuel-indexer`, `forc-index` and some others.

Also includes a `fuel-indexer-dev` `devShell` to make it easier to drop into an environment that is ready for developing within the fuel indexer repo. I haven't tried working through the examples yet so it might still be missing some runtime requirements (like POSTGRES env vars etc), but for now at least all the binaries appear to build and execute.