### PR TITLE
Fix bug in `fuel-dev` due to `forc-explore-nightly` not yet being available. Check `nix develop` in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,12 @@ on:
     branches:
       - master
 
-jobs:
-  cancel-previous-runs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   nix-fmt-check:
-    needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
@@ -30,7 +25,6 @@ jobs:
       - run: nix fmt -- --check ./
 
   nix-build:
-    needs: cancel-previous-runs
     strategy:
       matrix:
         package: [fuel, fuel-nightly, sway-vim]
@@ -46,3 +40,19 @@ jobs:
           name: mitchmindtree-fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
+
+  nix-develop:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v10
+        with:
+          name: mitchmindtree-fuellabs
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix develop --print-build-logs --no-update-lock-file .#fuel-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
 
   nix-develop:
+    needs: nix-build
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -44,6 +44,8 @@ jobs:
         run: nix build --print-build-logs --no-update-lock-file .#fuel
       - name: Build fuel-nightly
         run: nix build --print-build-logs --no-update-lock-file .#fuel-nightly
+      - name: Develop fuel-dev
+        run: nix develop --print-build-logs --no-update-lock-file .#fuel-dev
       - name: Push changes
         if: steps.commit.outcome == 'success'
         uses: ad-m/github-push-action@master

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -22,7 +22,7 @@ jobs:
           name: mitchmindtree-fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Refresh manifests
-        timeout-minutes: 5
+        timeout-minutes: 20
         run: nix run .#refresh-manifests
       - name: Check and commit changes
         id: commit

--- a/flake.nix
+++ b/flake.nix
@@ -203,13 +203,14 @@
 
       sway-dev = pkgs.mkShell {
         name = "sway-dev";
-        inputsFrom = with fuelpkgs; [
-          forc-nightly
-          forc-client-nightly
-          forc-explore-nightly
-          forc-fmt-nightly
-          forc-lsp-nightly
-        ];
+        inputsFrom = with fuelpkgs;
+          [
+            forc-nightly
+            forc-client-nightly
+            forc-fmt-nightly
+            forc-lsp-nightly
+          ]
+          ++ pkgs.lib.optional (builtins.hasAttr "forc-explore-nightly" fuelpkgs) fuelpkgs.forc-explore-nightly;
         buildInputs = with fuelpkgs; [fuel-core fuel-gql-cli];
       };
 


### PR DESCRIPTION
No commits have been made to forc-explore since including adding it to the Nix flake - as a result, no nightly package has been made available. This makes the forc-explore-nightly inclusion optional and dependent on whether or not a nightly actually exists.

This slipped through as during CI we'd only build the packages, however the `devShell`s were never checked. This adds another job to the PR CI that checks the `fuel-dev` `devShell` on both macOS and Linux. Also adds a similar step to the refresh-manifests CI to catch any unexpected breakage there too.

Also closes #38.