### PR TITLE
Add missing input hash for new git ethabi dependency in sway workspace

### DIFF
--- a/manifests/forc-0.33.0-nightly-2023-01-14.nix
+++ b/manifests/forc-0.33.0-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.0";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae";
+  sha256 = "sha256-fs9E1TUwu1xky6BIXFYNTuVmHHB3Emu56xU8fVivpwQ=";
+}

--- a/manifests/forc-client-0.33.0-nightly-2023-01-14.nix
+++ b/manifests/forc-client-0.33.0-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.0";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae";
+  sha256 = "sha256-fs9E1TUwu1xky6BIXFYNTuVmHHB3Emu56xU8fVivpwQ=";
+}

--- a/manifests/forc-fmt-0.33.0-nightly-2023-01-14.nix
+++ b/manifests/forc-fmt-0.33.0-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.0";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae";
+  sha256 = "sha256-fs9E1TUwu1xky6BIXFYNTuVmHHB3Emu56xU8fVivpwQ=";
+}

--- a/manifests/forc-lsp-0.33.0-nightly-2023-01-14.nix
+++ b/manifests/forc-lsp-0.33.0-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.0";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae";
+  sha256 = "sha256-fs9E1TUwu1xky6BIXFYNTuVmHHB3Emu56xU8fVivpwQ=";
+}

--- a/manifests/fuel-core-0.14.2-nightly-2023-01-14.nix
+++ b/manifests/fuel-core-0.14.2-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.14.2";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "9a63100cd0e408f6a2444d309e1bcea7e6fb6b61";
+  sha256 = "sha256-SdXo2d6HAyyo+3wy2ib8v8Aou57TpqNv+XDAHvAFVpg=";
+}

--- a/manifests/fuel-core-client-0.14.2-nightly-2023-01-14.nix
+++ b/manifests/fuel-core-client-0.14.2-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.14.2";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "9a63100cd0e408f6a2444d309e1bcea7e6fb6b61";
+  sha256 = "sha256-SdXo2d6HAyyo+3wy2ib8v8Aou57TpqNv+XDAHvAFVpg=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -206,4 +206,23 @@
       buildAndTestSubdir = "bin/fuel-core-client";
     };
   }
+
+  # From around version 0.33.0 (roughly 2023-01-14), the Sway repo had a
+  # workspace-level patch for `mdbook` that pointed to a git repo. This patch
+  # provides that git repo's output hash to ensure deterministic builds for
+  # commits within that range.
+  {
+    condition = m:
+      m.src.gitRepoUrl
+      == "https://github.com/fuellabs/sway"
+      && pkgs.lib.versionAtLeast m.version "0.33.0"
+      && (m.date >= "2023-01-14" || m.src.rev == "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae");
+    patch = m: {
+      cargoLock.outputHashes =
+        (m.cargoLock.outputHashes or {})
+        // {
+          "ethabi-18.0.0" = "sha256-N5bjuJoGYzcnfQg5pe79joUI2gOPAd9tcSvrBOYv5rc=";
+        };
+    };
+  }
 ]


### PR DESCRIPTION
Fixes the recent failure in the refresh-manifests job here: https://github.com/FuelLabs/fuel.nix/actions/runs/3915857625/jobs/6694412087#step:9:32. This PR also adds the manifests that didn't make it in.