### PR TITLE
Add patch for `fuel-core v0.15.3` that uses old directory structure

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663902145,
-        "narHash": "sha256-wuDqTDcD+VtGOFyzrvsALZRw5MkCNPj7rPX6DKt6Pzo=",
+        "lastModified": 1674440843,
+        "narHash": "sha256-kMCGL1wADpbcgGiMgj1pcOxbLy2zfmzsn46YCMWwtIE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9e319dd18f7beadab4daaf2426466d4023c1d26f",
+        "rev": "57b363f390f031b8b8d26235c2d21b0ad5a84640",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {

--- a/manifests/forc-0.33.0-nightly-2023-01-18.nix
+++ b/manifests/forc-0.33.0-nightly-2023-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.0";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "555f34e4c94c2a2ea4ac2d5226d36772577d2ea6";
+  sha256 = "sha256-6tTFXnoOb+dO7sgXoAt22vNdswJZdmu1sDRRZx1OnPw=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-19.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0c99c8adad3f7adc3eef34a587298c063cf9f228";
+  sha256 = "sha256-woM4ot15CZj4Y2iFAjFaaf/PFDoluzinuJTz0mvw/bk=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-20.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "89c45ee845962d2b407521c1079bb519e7e954ac";
+  sha256 = "sha256-2JNNjlq9jSPQV/NvgQa2ocibXYePuc8WSv3/YCRpqxg=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-21.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5968792cd7bb8e0c117ff1cc47693503b7dd731e";
+  sha256 = "sha256-WSiRTAIDlvYUjZgAefoeN6ggfzz5bb2Il3ejj2lhYJs=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-22.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1506d92775262ad973630558f66b42d57de8fe9";
+  sha256 = "sha256-X3gQ/p2MEr8KwTKMZvrrwrxXTptbR+yLTw7eG0mSwao=";
+}

--- a/manifests/forc-0.33.1.nix
+++ b/manifests/forc-0.33.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "acd4c1e0fbdc406800a06c845430a80dd3560fcc";
+  sha256 = "sha256-00KVxZUcyCrE4RT2WrmHtxFFFyxLuiD6nJV9PoDzHng=";
+}

--- a/manifests/forc-client-0.33.0-nightly-2023-01-18.nix
+++ b/manifests/forc-client-0.33.0-nightly-2023-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.0";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "555f34e4c94c2a2ea4ac2d5226d36772577d2ea6";
+  sha256 = "sha256-6tTFXnoOb+dO7sgXoAt22vNdswJZdmu1sDRRZx1OnPw=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-19.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0c99c8adad3f7adc3eef34a587298c063cf9f228";
+  sha256 = "sha256-woM4ot15CZj4Y2iFAjFaaf/PFDoluzinuJTz0mvw/bk=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-20.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "89c45ee845962d2b407521c1079bb519e7e954ac";
+  sha256 = "sha256-2JNNjlq9jSPQV/NvgQa2ocibXYePuc8WSv3/YCRpqxg=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-21.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5968792cd7bb8e0c117ff1cc47693503b7dd731e";
+  sha256 = "sha256-WSiRTAIDlvYUjZgAefoeN6ggfzz5bb2Il3ejj2lhYJs=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-22.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1506d92775262ad973630558f66b42d57de8fe9";
+  sha256 = "sha256-X3gQ/p2MEr8KwTKMZvrrwrxXTptbR+yLTw7eG0mSwao=";
+}

--- a/manifests/forc-client-0.33.1.nix
+++ b/manifests/forc-client-0.33.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "acd4c1e0fbdc406800a06c845430a80dd3560fcc";
+  sha256 = "sha256-00KVxZUcyCrE4RT2WrmHtxFFFyxLuiD6nJV9PoDzHng=";
+}

--- a/manifests/forc-fmt-0.33.0-nightly-2023-01-18.nix
+++ b/manifests/forc-fmt-0.33.0-nightly-2023-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.0";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "555f34e4c94c2a2ea4ac2d5226d36772577d2ea6";
+  sha256 = "sha256-6tTFXnoOb+dO7sgXoAt22vNdswJZdmu1sDRRZx1OnPw=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-19.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0c99c8adad3f7adc3eef34a587298c063cf9f228";
+  sha256 = "sha256-woM4ot15CZj4Y2iFAjFaaf/PFDoluzinuJTz0mvw/bk=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-20.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "89c45ee845962d2b407521c1079bb519e7e954ac";
+  sha256 = "sha256-2JNNjlq9jSPQV/NvgQa2ocibXYePuc8WSv3/YCRpqxg=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-21.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5968792cd7bb8e0c117ff1cc47693503b7dd731e";
+  sha256 = "sha256-WSiRTAIDlvYUjZgAefoeN6ggfzz5bb2Il3ejj2lhYJs=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-22.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1506d92775262ad973630558f66b42d57de8fe9";
+  sha256 = "sha256-X3gQ/p2MEr8KwTKMZvrrwrxXTptbR+yLTw7eG0mSwao=";
+}

--- a/manifests/forc-fmt-0.33.1.nix
+++ b/manifests/forc-fmt-0.33.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "acd4c1e0fbdc406800a06c845430a80dd3560fcc";
+  sha256 = "sha256-00KVxZUcyCrE4RT2WrmHtxFFFyxLuiD6nJV9PoDzHng=";
+}

--- a/manifests/forc-lsp-0.33.0-nightly-2023-01-18.nix
+++ b/manifests/forc-lsp-0.33.0-nightly-2023-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.0";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "555f34e4c94c2a2ea4ac2d5226d36772577d2ea6";
+  sha256 = "sha256-6tTFXnoOb+dO7sgXoAt22vNdswJZdmu1sDRRZx1OnPw=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-19.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0c99c8adad3f7adc3eef34a587298c063cf9f228";
+  sha256 = "sha256-woM4ot15CZj4Y2iFAjFaaf/PFDoluzinuJTz0mvw/bk=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-20.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "89c45ee845962d2b407521c1079bb519e7e954ac";
+  sha256 = "sha256-2JNNjlq9jSPQV/NvgQa2ocibXYePuc8WSv3/YCRpqxg=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-21.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5968792cd7bb8e0c117ff1cc47693503b7dd731e";
+  sha256 = "sha256-WSiRTAIDlvYUjZgAefoeN6ggfzz5bb2Il3ejj2lhYJs=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-22.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1506d92775262ad973630558f66b42d57de8fe9";
+  sha256 = "sha256-X3gQ/p2MEr8KwTKMZvrrwrxXTptbR+yLTw7eG0mSwao=";
+}

--- a/manifests/forc-lsp-0.33.1.nix
+++ b/manifests/forc-lsp-0.33.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "acd4c1e0fbdc406800a06c845430a80dd3560fcc";
+  sha256 = "sha256-00KVxZUcyCrE4RT2WrmHtxFFFyxLuiD6nJV9PoDzHng=";
+}

--- a/manifests/forc-wallet-0.1.2-nightly-2023-01-21.nix
+++ b/manifests/forc-wallet-0.1.2-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.2";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "b5975691bafb1fecef845dbea61597699cd2d37a";
+  sha256 = "sha256-wV26dmGjyMaDKTBHONLD01kcTmnX++Dx4V0Ks3FL/f8=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2022-12-16.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2022-12-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2022-12-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "5cb31209f07bfa0da85a7f4b7b45f95da2f4313c";
+  sha256 = "sha256-fJzPF4rTGD6OqcM/+yQsjMOlteBdEZPdYshv3CvC3Mo=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2022-12-18.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2022-12-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2022-12-18";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "07a2888f2ae45bebab83c7219b717f3e30a1990e";
+  sha256 = "sha256-xiNMTeAUWzJeGvPF78Y0Kx7va4oXFZ3iHOZ532fo3ys=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2022-12-22.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2022-12-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2022-12-22";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4a38e787788846f44e9ab86c10017ec13bdd6c1f";
+  sha256 = "sha256-322V0R06U2J07ekFBVaEpZs7oLKSJv+NdNa2zvA7poE=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2022-12-23.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2022-12-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2022-12-23";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "d5cad9382c1ab88282f079b5bad3c07ec55fe928";
+  sha256 = "sha256-XttnrINc0rnhJgRTt4mzz1VXiGnJCaNsXTP8hhJXk4c=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2022-12-24.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2022-12-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2022-12-24";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a3f584f12bb3e160aa00e08616a27c81734ebd02";
+  sha256 = "sha256-0wHbeW9nJ3hs6aWtxC1d08R928iWnMEdTaEo3MJ/cvk=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2023-01-04.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2023-01-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2023-01-04";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "eb576abde11020edab411863ce9c7217982aac95";
+  sha256 = "sha256-1MvX8wLZOFzNytGqujfUKFHNd73btOlEhbD1ZlaxjcA=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2023-01-05.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2023-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2023-01-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "81d9ef8c0818d911bea7b6edc84e5fcae21fc923";
+  sha256 = "sha256-HfuYL9JhnX/gw2Ld4f0WEvQlUWrdj3SC9GGTbVNokQs=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2023-01-06.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2023-01-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2023-01-06";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a5514420e53fbd09fa0eb4d8de8f65822c18f660";
+  sha256 = "sha256-naKgt91davSPsGxsPrNnDcLQUWT9QACpxCfHncfqCjA=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2023-01-12.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2023-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "7d5bcf1ffe3116d5eb085321fc2f4180b0fd40e7";
+  sha256 = "sha256-U6zIPHVEg0hOMii4hwjCyEgdWFEUQy6dqqxm6y2snzk=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2023-01-13.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2023-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2023-01-13";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a31a2f1ad686c9b72061b3f66a014973b7704386";
+  sha256 = "sha256-P/X1hALGa88F12rkt/f6XzU+dXoZ6r4JcRXWjV5dUsI=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2023-01-14.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "9a63100cd0e408f6a2444d309e1bcea7e6fb6b61";
+  sha256 = "sha256-SdXo2d6HAyyo+3wy2ib8v8Aou57TpqNv+XDAHvAFVpg=";
+}

--- a/manifests/fuel-core-0.15.1-nightly-2023-01-15.nix
+++ b/manifests/fuel-core-0.15.1-nightly-2023-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.1";
+  date = "2023-01-15";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "8575ee011c1afa08df742d9c1bcee48e54555732";
+  sha256 = "sha256-7gwrD6U/Iux2E2i6wMVBRi9Tazj/jywaMiZq4wIk2lQ=";
+}

--- a/manifests/fuel-core-0.15.3-nightly-2023-01-20.nix
+++ b/manifests/fuel-core-0.15.3-nightly-2023-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.3";
+  date = "2023-01-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2301e1529a0edc213cb8ca7d594ff57287aa8f3e";
+  sha256 = "sha256-jp42Pinzlcu06dmw8h/NXDN++Hus9a83Ze4OXY2Yjhk=";
+}

--- a/manifests/fuel-core-0.15.3-nightly-2023-01-21.nix
+++ b/manifests/fuel-core-0.15.3-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.3";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "7279c344e104ddbe4b6656e2bb78723880cf494d";
+  sha256 = "sha256-1/61nvuQM5sTqld2549sXKzRHJbEsNwLASmBYzE1054=";
+}

--- a/manifests/fuel-core-0.15.3-nightly-2023-01-22.nix
+++ b/manifests/fuel-core-0.15.3-nightly-2023-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.3";
+  date = "2023-01-22";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1d2c75f8b409ceda2ca88662aa5b4c427ac2e745";
+  sha256 = "sha256-xhgVHg3tBJjP9wMq1hUZp0lpQZIsyqHZu/RTt8GiHg0=";
+}

--- a/manifests/fuel-core-0.15.3.nix
+++ b/manifests/fuel-core-0.15.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.3";
+  date = "2023-01-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "49e4305fea691bbf293c606334e7b282a54393b3";
+  sha256 = "sha256-WBR2KBiV2PFMKpFit6LgXG57F6aGgGYfhiQsAg7+nfk=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2022-12-16.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2022-12-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2022-12-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "5cb31209f07bfa0da85a7f4b7b45f95da2f4313c";
+  sha256 = "sha256-fJzPF4rTGD6OqcM/+yQsjMOlteBdEZPdYshv3CvC3Mo=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2022-12-18.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2022-12-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2022-12-18";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "07a2888f2ae45bebab83c7219b717f3e30a1990e";
+  sha256 = "sha256-xiNMTeAUWzJeGvPF78Y0Kx7va4oXFZ3iHOZ532fo3ys=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2022-12-22.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2022-12-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2022-12-22";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "4a38e787788846f44e9ab86c10017ec13bdd6c1f";
+  sha256 = "sha256-322V0R06U2J07ekFBVaEpZs7oLKSJv+NdNa2zvA7poE=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2022-12-23.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2022-12-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2022-12-23";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "d5cad9382c1ab88282f079b5bad3c07ec55fe928";
+  sha256 = "sha256-XttnrINc0rnhJgRTt4mzz1VXiGnJCaNsXTP8hhJXk4c=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2022-12-24.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2022-12-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2022-12-24";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a3f584f12bb3e160aa00e08616a27c81734ebd02";
+  sha256 = "sha256-0wHbeW9nJ3hs6aWtxC1d08R928iWnMEdTaEo3MJ/cvk=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2023-01-04.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2023-01-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2023-01-04";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "eb576abde11020edab411863ce9c7217982aac95";
+  sha256 = "sha256-1MvX8wLZOFzNytGqujfUKFHNd73btOlEhbD1ZlaxjcA=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2023-01-05.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2023-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2023-01-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "81d9ef8c0818d911bea7b6edc84e5fcae21fc923";
+  sha256 = "sha256-HfuYL9JhnX/gw2Ld4f0WEvQlUWrdj3SC9GGTbVNokQs=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2023-01-06.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2023-01-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2023-01-06";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a5514420e53fbd09fa0eb4d8de8f65822c18f660";
+  sha256 = "sha256-naKgt91davSPsGxsPrNnDcLQUWT9QACpxCfHncfqCjA=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2023-01-12.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2023-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "7d5bcf1ffe3116d5eb085321fc2f4180b0fd40e7";
+  sha256 = "sha256-U6zIPHVEg0hOMii4hwjCyEgdWFEUQy6dqqxm6y2snzk=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2023-01-13.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2023-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2023-01-13";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a31a2f1ad686c9b72061b3f66a014973b7704386";
+  sha256 = "sha256-P/X1hALGa88F12rkt/f6XzU+dXoZ6r4JcRXWjV5dUsI=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2023-01-14.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "9a63100cd0e408f6a2444d309e1bcea7e6fb6b61";
+  sha256 = "sha256-SdXo2d6HAyyo+3wy2ib8v8Aou57TpqNv+XDAHvAFVpg=";
+}

--- a/manifests/fuel-core-client-0.15.1-nightly-2023-01-15.nix
+++ b/manifests/fuel-core-client-0.15.1-nightly-2023-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.1";
+  date = "2023-01-15";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "8575ee011c1afa08df742d9c1bcee48e54555732";
+  sha256 = "sha256-7gwrD6U/Iux2E2i6wMVBRi9Tazj/jywaMiZq4wIk2lQ=";
+}

--- a/manifests/fuel-core-client-0.15.3-nightly-2023-01-20.nix
+++ b/manifests/fuel-core-client-0.15.3-nightly-2023-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.3";
+  date = "2023-01-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2301e1529a0edc213cb8ca7d594ff57287aa8f3e";
+  sha256 = "sha256-jp42Pinzlcu06dmw8h/NXDN++Hus9a83Ze4OXY2Yjhk=";
+}

--- a/manifests/fuel-core-client-0.15.3-nightly-2023-01-21.nix
+++ b/manifests/fuel-core-client-0.15.3-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.3";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "7279c344e104ddbe4b6656e2bb78723880cf494d";
+  sha256 = "sha256-1/61nvuQM5sTqld2549sXKzRHJbEsNwLASmBYzE1054=";
+}

--- a/manifests/fuel-core-client-0.15.3-nightly-2023-01-22.nix
+++ b/manifests/fuel-core-client-0.15.3-nightly-2023-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.3";
+  date = "2023-01-22";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1d2c75f8b409ceda2ca88662aa5b4c427ac2e745";
+  sha256 = "sha256-xhgVHg3tBJjP9wMq1hUZp0lpQZIsyqHZu/RTt8GiHg0=";
+}

--- a/manifests/fuel-core-client-0.15.3.nix
+++ b/manifests/fuel-core-client-0.15.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.3";
+  date = "2023-01-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "49e4305fea691bbf293c606334e7b282a54393b3";
+  sha256 = "sha256-WBR2KBiV2PFMKpFit6LgXG57F6aGgGYfhiQsAg7+nfk=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -191,8 +191,14 @@
   }
 
   # As of 2022-12-17 the fuel-core exe was moved into the `bin` subdirectory.
+  # Version 0.15.3 (rev 49e4305fea691bbf293c606334e7b282a54393b3) retains the
+  # old directory structure.
   {
-    condition = m: m.pname == "fuel-core" && m.date >= "2022-12-17";
+    condition = m:
+      m.pname
+      == "fuel-core"
+      && m.date >= "2022-12-17"
+      && m.src.rev != "49e4305fea691bbf293c606334e7b282a54393b3";
     patch = m: {
       buildAndTestSubdir = "bin/fuel-core";
     };
@@ -200,10 +206,15 @@
 
   # As of 2022-12-17 the fuel-core-client exe was renamed and moved into the `bin`
   # subdirectory.
+  # Version 0.15.3 (rev 49e4305fea691bbf293c606334e7b282a54393b3) retains the
+  # old directory structure.
   {
     condition = m: m.pname == "fuel-core-client";
     patch = m: {
-      buildAndTestSubdir = "bin/fuel-core-client";
+      buildAndTestSubdir =
+        if m.src.rev == "49e4305fea691bbf293c606334e7b282a54393b3"
+        then "fuel-client"
+        else "bin/fuel-core-client";
     };
   }
 

--- a/patches.nix
+++ b/patches.nix
@@ -236,4 +236,15 @@
         };
     };
   }
+
+  # `fuel-storage` needs Rust 1.65 as of
+  # cc11d3184c78401436d984e660748c9a9ed3df88 due to its use of generic
+  # associated types. This changes the Rust used for all pkgs to 1.65 from the
+  # day of the commit.
+  {
+    condition = m: m.date >= "2023-01-13";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.65.0".default;
+    };
+  }
 ]

--- a/patches.nix
+++ b/patches.nix
@@ -218,16 +218,16 @@
     };
   }
 
-  # From around version 0.33.0 (roughly 2023-01-14), the Sway repo had a
-  # workspace-level patch for `mdbook` that pointed to a git repo. This patch
-  # provides that git repo's output hash to ensure deterministic builds for
-  # commits within that range.
+  # For a short while around version 0.33.0 (roughly 2023-01-14 to 2023-01-18),
+  # the Sway repo had a git dependency on the ethabi-18.0.0 crate. This was
+  # removed in favour of using our own crate.
   {
     condition = m:
       m.src.gitRepoUrl
       == "https://github.com/fuellabs/sway"
       && pkgs.lib.versionAtLeast m.version "0.33.0"
-      && (m.date >= "2023-01-14" || m.src.rev == "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae");
+      && (m.date >= "2023-01-14" || m.src.rev == "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae")
+      && m.date < "2023-01-18";
     patch = m: {
       cargoLock.outputHashes =
         (m.cargoLock.outputHashes or {})


### PR DESCRIPTION
Previously we built all versions after a certain date with the fuel- core repo's new directory structure. The latest patch release however uses the old structure so we update the patch to check for the 0.15.3 commit rev.

Also includes refreshed manifests since the failure began.

Edit: Also adds an end date for recent patch for Sway's git dependency as it has since been removed.