### PR TITLE
Fix CI `refresh-manifests` workflow issue with `forc-fmt`

### DIFF
--- a/manifests/forc-0.33.1-nightly-2023-01-24.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3998c10760f338d7f900b0253ff27cb5b9db53e5";
+  sha256 = "sha256-v8F1Q9r1N8lu/qdlE74V/dLiA2ssrR2/R7GB9iLHQeE=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-25.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0a3beae92e6faed5e8ca35da5a8071e58f4a43d1";
+  sha256 = "sha256-9YOhtE24W14fBYmRyNMNl/ETcqr17FtjW2CuHE80jCk=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-26.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "74979e091b947ee219e5f34eafb8a60d1f2cff13";
+  sha256 = "sha256-syGOb3kja6W7E1p05bb3ll+jPRyT9kSBB0YGMTB2U8c=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-27.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "46f92f280b3289f45f3ec181af8046da329dcc89";
+  sha256 = "sha256-KofK4fpsH+ovCZzZGS+kaqWQQSxFDcty2fPywJkjFGc=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-28.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "97190861deda5958921c6cecbc81d9141179fd22";
+  sha256 = "sha256-vf7HixoPlPUOvEsPas5B9PZ2wK+4APQjV0m/HjzMRNg=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-29.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dd8b2f62442288e71153a3a701cd96491c5bcb8c";
+  sha256 = "sha256-pdjcWnsjb7HpHFRrB42kjMBBM0DmqTUBzf7rG6c9EKA=";
+}

--- a/manifests/forc-0.33.1-nightly-2023-01-30.nix
+++ b/manifests/forc-0.33.1-nightly-2023-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.33.1";
+  date = "2023-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3c0c024c397a290d7576e6d6e589fbbcbc61775f";
+  sha256 = "sha256-+sR31fVHmu82PHOZDARUYEyGyJTXLwQMEsFbha6TBmY=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-24.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3998c10760f338d7f900b0253ff27cb5b9db53e5";
+  sha256 = "sha256-v8F1Q9r1N8lu/qdlE74V/dLiA2ssrR2/R7GB9iLHQeE=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-25.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0a3beae92e6faed5e8ca35da5a8071e58f4a43d1";
+  sha256 = "sha256-9YOhtE24W14fBYmRyNMNl/ETcqr17FtjW2CuHE80jCk=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-26.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "74979e091b947ee219e5f34eafb8a60d1f2cff13";
+  sha256 = "sha256-syGOb3kja6W7E1p05bb3ll+jPRyT9kSBB0YGMTB2U8c=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-27.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "46f92f280b3289f45f3ec181af8046da329dcc89";
+  sha256 = "sha256-KofK4fpsH+ovCZzZGS+kaqWQQSxFDcty2fPywJkjFGc=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-28.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "97190861deda5958921c6cecbc81d9141179fd22";
+  sha256 = "sha256-vf7HixoPlPUOvEsPas5B9PZ2wK+4APQjV0m/HjzMRNg=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-29.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dd8b2f62442288e71153a3a701cd96491c5bcb8c";
+  sha256 = "sha256-pdjcWnsjb7HpHFRrB42kjMBBM0DmqTUBzf7rG6c9EKA=";
+}

--- a/manifests/forc-client-0.33.1-nightly-2023-01-30.nix
+++ b/manifests/forc-client-0.33.1-nightly-2023-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.33.1";
+  date = "2023-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3c0c024c397a290d7576e6d6e589fbbcbc61775f";
+  sha256 = "sha256-+sR31fVHmu82PHOZDARUYEyGyJTXLwQMEsFbha6TBmY=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-24.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3998c10760f338d7f900b0253ff27cb5b9db53e5";
+  sha256 = "sha256-v8F1Q9r1N8lu/qdlE74V/dLiA2ssrR2/R7GB9iLHQeE=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-25.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0a3beae92e6faed5e8ca35da5a8071e58f4a43d1";
+  sha256 = "sha256-9YOhtE24W14fBYmRyNMNl/ETcqr17FtjW2CuHE80jCk=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-26.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "74979e091b947ee219e5f34eafb8a60d1f2cff13";
+  sha256 = "sha256-syGOb3kja6W7E1p05bb3ll+jPRyT9kSBB0YGMTB2U8c=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-27.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "46f92f280b3289f45f3ec181af8046da329dcc89";
+  sha256 = "sha256-KofK4fpsH+ovCZzZGS+kaqWQQSxFDcty2fPywJkjFGc=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-28.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "97190861deda5958921c6cecbc81d9141179fd22";
+  sha256 = "sha256-vf7HixoPlPUOvEsPas5B9PZ2wK+4APQjV0m/HjzMRNg=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-29.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dd8b2f62442288e71153a3a701cd96491c5bcb8c";
+  sha256 = "sha256-pdjcWnsjb7HpHFRrB42kjMBBM0DmqTUBzf7rG6c9EKA=";
+}

--- a/manifests/forc-fmt-0.33.1-nightly-2023-01-30.nix
+++ b/manifests/forc-fmt-0.33.1-nightly-2023-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.33.1";
+  date = "2023-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3c0c024c397a290d7576e6d6e589fbbcbc61775f";
+  sha256 = "sha256-+sR31fVHmu82PHOZDARUYEyGyJTXLwQMEsFbha6TBmY=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-24.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3998c10760f338d7f900b0253ff27cb5b9db53e5";
+  sha256 = "sha256-v8F1Q9r1N8lu/qdlE74V/dLiA2ssrR2/R7GB9iLHQeE=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-25.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0a3beae92e6faed5e8ca35da5a8071e58f4a43d1";
+  sha256 = "sha256-9YOhtE24W14fBYmRyNMNl/ETcqr17FtjW2CuHE80jCk=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-26.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "74979e091b947ee219e5f34eafb8a60d1f2cff13";
+  sha256 = "sha256-syGOb3kja6W7E1p05bb3ll+jPRyT9kSBB0YGMTB2U8c=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-27.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "46f92f280b3289f45f3ec181af8046da329dcc89";
+  sha256 = "sha256-KofK4fpsH+ovCZzZGS+kaqWQQSxFDcty2fPywJkjFGc=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-28.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "97190861deda5958921c6cecbc81d9141179fd22";
+  sha256 = "sha256-vf7HixoPlPUOvEsPas5B9PZ2wK+4APQjV0m/HjzMRNg=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-29.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dd8b2f62442288e71153a3a701cd96491c5bcb8c";
+  sha256 = "sha256-pdjcWnsjb7HpHFRrB42kjMBBM0DmqTUBzf7rG6c9EKA=";
+}

--- a/manifests/forc-lsp-0.33.1-nightly-2023-01-30.nix
+++ b/manifests/forc-lsp-0.33.1-nightly-2023-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.33.1";
+  date = "2023-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3c0c024c397a290d7576e6d6e589fbbcbc61775f";
+  sha256 = "sha256-+sR31fVHmu82PHOZDARUYEyGyJTXLwQMEsFbha6TBmY=";
+}

--- a/manifests/forc-wallet-0.1.2-nightly-2023-01-24.nix
+++ b/manifests/forc-wallet-0.1.2-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.2";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "a73f1b81681ab07da4da9596e58d44ea95a46bff";
+  sha256 = "sha256-MyJfAVpXTtKcHABc88j+1Y13lcQ2/vRoVgpHa7kGPyc=";
+}

--- a/manifests/forc-wallet-0.1.2-nightly-2023-01-25.nix
+++ b/manifests/forc-wallet-0.1.2-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.2";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "543bc1f4d7badd569c22dff88db2a988adee9d4e";
+  sha256 = "sha256-vKlzplyPUZ9JohIk4bMJTF2YKv0sTQyLrWZ5ntJVDBo=";
+}

--- a/manifests/forc-wallet-0.1.3.nix
+++ b/manifests/forc-wallet-0.1.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.3";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "543bc1f4d7badd569c22dff88db2a988adee9d4e";
+  sha256 = "sha256-vKlzplyPUZ9JohIk4bMJTF2YKv0sTQyLrWZ5ntJVDBo=";
+}

--- a/manifests/fuel-core-0.15.3-nightly-2023-01-24.nix
+++ b/manifests/fuel-core-0.15.3-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.3";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "99a7d1cce1b0cb98d370a73189f4ff1048c294e9";
+  sha256 = "sha256-CXE7s/yklZDqqRK5d8C0LPsNwYug849KaRVg8TmAziI=";
+}

--- a/manifests/fuel-core-0.15.3-nightly-2023-01-25.nix
+++ b/manifests/fuel-core-0.15.3-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.3";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1b8c82f85dbeebed0d6aa325cce68d5efa56f69d";
+  sha256 = "sha256-Qwulilk6o2UH3bG9j55f/fY/Cz/7G3Bu17uFD47+dzI=";
+}

--- a/manifests/fuel-core-0.15.3-nightly-2023-01-26.nix
+++ b/manifests/fuel-core-0.15.3-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.3";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "356e6d020ae587ecf1d5e8b625775b44d5879945";
+  sha256 = "sha256-AQ849VdmvcuObovqQxNXXaFPyWD3rhPdqPtTQ8pCZSA=";
+}

--- a/manifests/fuel-core-0.15.3-nightly-2023-01-27.nix
+++ b/manifests/fuel-core-0.15.3-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.15.3";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1542d931a120738acbd5b744c0c849cb3ae42ae4";
+  sha256 = "sha256-77Ck4ykc3Upci14+/lxZN0qlS2x5utgbswBH1hBx8+I=";
+}

--- a/manifests/fuel-core-0.16.1-nightly-2023-01-28.nix
+++ b/manifests/fuel-core-0.16.1-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.16.1";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "443acaccaec9ca7220441f10c1b956787c833787";
+  sha256 = "sha256-ZyalumRIOi835uSoXk7iGpJkQHnElQ05ASpQlAAnHxY=";
+}

--- a/manifests/fuel-core-0.16.1-nightly-2023-01-29.nix
+++ b/manifests/fuel-core-0.16.1-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.16.1";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "f01067a88b22513ab3bf38d14f069e780bc37b14";
+  sha256 = "sha256-bRCxvhPz4TOG1EJmvioJxTFen5nyTZdLIHeIfHhu+08=";
+}

--- a/manifests/fuel-core-0.16.1.nix
+++ b/manifests/fuel-core-0.16.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.16.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "443acaccaec9ca7220441f10c1b956787c833787";
+  sha256 = "sha256-ZyalumRIOi835uSoXk7iGpJkQHnElQ05ASpQlAAnHxY=";
+}

--- a/manifests/fuel-core-client-0.15.3-nightly-2023-01-24.nix
+++ b/manifests/fuel-core-client-0.15.3-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.3";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "99a7d1cce1b0cb98d370a73189f4ff1048c294e9";
+  sha256 = "sha256-CXE7s/yklZDqqRK5d8C0LPsNwYug849KaRVg8TmAziI=";
+}

--- a/manifests/fuel-core-client-0.15.3-nightly-2023-01-25.nix
+++ b/manifests/fuel-core-client-0.15.3-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.3";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1b8c82f85dbeebed0d6aa325cce68d5efa56f69d";
+  sha256 = "sha256-Qwulilk6o2UH3bG9j55f/fY/Cz/7G3Bu17uFD47+dzI=";
+}

--- a/manifests/fuel-core-client-0.15.3-nightly-2023-01-26.nix
+++ b/manifests/fuel-core-client-0.15.3-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.3";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "356e6d020ae587ecf1d5e8b625775b44d5879945";
+  sha256 = "sha256-AQ849VdmvcuObovqQxNXXaFPyWD3rhPdqPtTQ8pCZSA=";
+}

--- a/manifests/fuel-core-client-0.15.3-nightly-2023-01-27.nix
+++ b/manifests/fuel-core-client-0.15.3-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.15.3";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "1542d931a120738acbd5b744c0c849cb3ae42ae4";
+  sha256 = "sha256-77Ck4ykc3Upci14+/lxZN0qlS2x5utgbswBH1hBx8+I=";
+}

--- a/manifests/fuel-core-client-0.16.1-nightly-2023-01-28.nix
+++ b/manifests/fuel-core-client-0.16.1-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.16.1";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "443acaccaec9ca7220441f10c1b956787c833787";
+  sha256 = "sha256-ZyalumRIOi835uSoXk7iGpJkQHnElQ05ASpQlAAnHxY=";
+}

--- a/manifests/fuel-core-client-0.16.1-nightly-2023-01-29.nix
+++ b/manifests/fuel-core-client-0.16.1-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.16.1";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "f01067a88b22513ab3bf38d14f069e780bc37b14";
+  sha256 = "sha256-bRCxvhPz4TOG1EJmvioJxTFen5nyTZdLIHeIfHhu+08=";
+}

--- a/manifests/fuel-core-client-0.16.1.nix
+++ b/manifests/fuel-core-client-0.16.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.16.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "443acaccaec9ca7220441f10c1b956787c833787";
+  sha256 = "sha256-ZyalumRIOi835uSoXk7iGpJkQHnElQ05ASpQlAAnHxY=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -74,7 +74,7 @@
   # Some `forc-pkg` and some crates that depend on it require openssl, so add
   # the required packages.
   {
-    condition = m: pkgs.lib.any (n: m.pname == n) ["forc" "forc-client" "forc-lsp"];
+    condition = m: pkgs.lib.any (n: m.pname == n) ["forc" "forc-client" "forc-fmt" "forc-lsp"];
     patch = m: {
       nativeBuildInputs =
         (m.nativeBuildInputs or [])
@@ -184,7 +184,7 @@
   # that are unpermitted in Nix's sandbox during a build. These tests are run
   # at `forc`'s repo CI, so it's fine to disable the check here.
   {
-    condition = m: pkgs.lib.any (n: m.pname == n) ["forc" "forc-client" "forc-lsp"] && m.date >= "2022-10-31";
+    condition = m: pkgs.lib.any (n: m.pname == n) ["forc" "forc-client" "forc-fmt" "forc-lsp"] && m.date >= "2022-10-31";
     patch = m: {
       doCheck = false; # Already tested at repo.
     };


### PR DESCRIPTION
This ensures that `openssl` and `perl` are in scope for the `openssl-sys` pkg that is depended on via `forc-pkg` -> `git`.

Also disables running the tests when building `forc-fmt` as tests are already run at the Sway repo.

Includes a run of `refresh-manifests` to include nightlies that have been missed since the CI failure began.