### PR TITLE
Update the `nixpkgs` pin (2022-08-15 -> 2023-01-25). Add the `forc-doc` and `forc-tx` plugins.

### DIFF
--- a/filters.nix
+++ b/filters.nix
@@ -11,8 +11,10 @@ with pkgs.lib; [
   (m: m.pname != "fuel-gql-cli" || (versionAtLeast m.version "0.9.0" && m.date < "2022-12-17"))
   (m: m.pname != "forc" || versionAtLeast m.version "0.19.0")
   (m: m.pname != "forc-client" || versionAtLeast m.version "0.19.0")
+  (m: m.pname != "forc-doc" || versionAtLeast m.version "0.29.0")
   (m: m.pname != "forc-explore" || versionAtLeast m.version "0.19.0")
   (m: m.pname != "forc-fmt" || versionAtLeast m.version "0.19.0")
   (m: m.pname != "forc-lsp" || versionAtLeast m.version "0.19.0")
+  (m: m.pname != "forc-tx" || versionAtLeast m.version "0.33.1")
   (m: m.pname != "forc-wallet" || versionAtLeast m.version "0.1.0")
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660574513,
-        "narHash": "sha256-nkMQ1TKIIAYIVbbUzjxfjPn3H1zZFW20TrHUFAjwvNU=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af9e00071d0971eb292fd5abef334e66eda3cb69",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -207,8 +207,10 @@
           [
             forc-nightly
             forc-client-nightly
+            forc-doc-nightly
             forc-fmt-nightly
             forc-lsp-nightly
+            forc-tx-nightly
           ]
           ++ pkgs.lib.optional (builtins.hasAttr "forc-explore-nightly" fuelpkgs) fuelpkgs.forc-explore-nightly;
         buildInputs = with fuelpkgs; [fuel-core fuel-gql-cli];

--- a/manifests/forc-doc-0.0.1.nix
+++ b/manifests/forc-doc-0.0.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.0.1";
+  date = "2021-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c9781a1acca6eea8a1f2f30607466ae40d76de65";
+  sha256 = "sha256-g6pSdahytTJQJ1rgLCku4289C2dnCLqzvSH8Mq8y26I=";
+}

--- a/manifests/forc-doc-0.0.2.nix
+++ b/manifests/forc-doc-0.0.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.0.2";
+  date = "2021-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0c043bc9463eb266aaf111ff86b8c911602e053";
+  sha256 = "sha256-LwGYEtKpb5eEts1K0TkRPwlWPu7EQLJbtaK8dAFexTk=";
+}

--- a/manifests/forc-doc-0.0.3.nix
+++ b/manifests/forc-doc-0.0.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.0.3";
+  date = "2021-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ce7692d119fa9010dd0937b5f10cf5728fe72393";
+  sha256 = "sha256-ygyqjapnGH+tznuYu5x9vnvhfHaoQ82vlyi90s/ZTCU=";
+}

--- a/manifests/forc-doc-0.0.4.nix
+++ b/manifests/forc-doc-0.0.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.0.4";
+  date = "2021-11-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d40239e7d49793c7d3d23e0d3de6595e40b89e11";
+  sha256 = "sha256-Udtk0i4LfiXYMWLZtRiDbjXseqiTs83BJgqHaMvJGLA=";
+}

--- a/manifests/forc-doc-0.1.0.nix
+++ b/manifests/forc-doc-0.1.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.0";
+  date = "2021-12-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "90c9b56a7fc313321fcc7580314284080d00078f";
+  sha256 = "sha256-5VgXmm63O89wp6mayRf6ihMiK/JrXECfkmpo17MPEk4=";
+}

--- a/manifests/forc-doc-0.1.1.nix
+++ b/manifests/forc-doc-0.1.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.1";
+  date = "2021-12-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a37329cb1848efdeb46e2be1bfdb940b7750262";
+  sha256 = "sha256-Ci4OJGp+iqmojxmf4Cg9m/2WG8jtKOPMDr2z6LDsOdU=";
+}

--- a/manifests/forc-doc-0.1.2.nix
+++ b/manifests/forc-doc-0.1.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.2";
+  date = "2021-12-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2431af753ed8fc0a76df53fc72172cb4bdb5d4b9";
+  sha256 = "sha256-FYwNTSaaZdtDGbOQ5/Tk4+lvyZ3PCJBtnNLE6+PuEng=";
+}

--- a/manifests/forc-doc-0.1.3.nix
+++ b/manifests/forc-doc-0.1.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.3";
+  date = "2021-12-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d30d3225a30c46a9675ca5db270597190cc228bc";
+  sha256 = "sha256-3kvkiTVQ5qSLqBPb3kl2VakJfQlCOYaTY9aonRgN6AY=";
+}

--- a/manifests/forc-doc-0.1.4.nix
+++ b/manifests/forc-doc-0.1.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.4";
+  date = "2021-12-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "46305882aa552be287b28e55606ba74b81070460";
+  sha256 = "sha256-/sFiQmmk/L+qqK9J/BrhPahg0no7YculAbB+TyB9s+Y=";
+}

--- a/manifests/forc-doc-0.1.5.nix
+++ b/manifests/forc-doc-0.1.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.5";
+  date = "2021-12-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1923f44784e6d450796b10addd447aeb3325d519";
+  sha256 = "sha256-X/c/HRNrZu3s/wKU2l9pkuuXpqPFZvqeeziW/9iloK4=";
+}

--- a/manifests/forc-doc-0.1.6.nix
+++ b/manifests/forc-doc-0.1.6.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.6";
+  date = "2021-12-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a38a89a042f7ef13ddf67cc7661b37eac96aad8f";
+  sha256 = "sha256-6HM7WTQsYaOXSvu8Jr0lh6KDQFpFJI+XybvzU8jFEic=";
+}

--- a/manifests/forc-doc-0.1.7.nix
+++ b/manifests/forc-doc-0.1.7.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.7";
+  date = "2021-12-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4038415bf9f681fca220bcf3951230b0e9129ba6";
+  sha256 = "sha256-gcKYLveFcyiZtPxGjtk8W9dYCVdVUSsUMTW071WavX0=";
+}

--- a/manifests/forc-doc-0.1.8.nix
+++ b/manifests/forc-doc-0.1.8.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.8";
+  date = "2021-12-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6fd0bc0b6ecf22f3b334a0c8da86e776a7e2b87d";
+  sha256 = "sha256-2M3FGiWEq++cQIkxECjSHabbVuMTkuvCx0eFIuOSeU0=";
+}

--- a/manifests/forc-doc-0.1.9.nix
+++ b/manifests/forc-doc-0.1.9.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.1.9";
+  date = "2021-12-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6fe6354eb96fa9b85c10e89f628bdf7ee525059d";
+  sha256 = "sha256-Bwn4w93PqCxMquIz52cWQ3u0xtZCXf5TzkKzQvnV15M=";
+}

--- a/manifests/forc-doc-0.10.0.nix
+++ b/manifests/forc-doc-0.10.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.10.0";
+  date = "2022-04-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a88ea439c95d9fb2701d6479ce496dc6571e92c2";
+  sha256 = "sha256-YdU+xBfyQ6M4UVl/bgp5ba0byVUY7BMwryIZnradFNs=";
+}

--- a/manifests/forc-doc-0.10.1.nix
+++ b/manifests/forc-doc-0.10.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.10.1";
+  date = "2022-04-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5c85d2b712975669d238233297443557969dec43";
+  sha256 = "sha256-8ocDTtJL468H3PpkQu5b9+lZtfjFP3MDK8YE2LtPYy4=";
+}

--- a/manifests/forc-doc-0.10.2.nix
+++ b/manifests/forc-doc-0.10.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.10.2";
+  date = "2022-04-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "443abbffd520f0f964e837fbc784641741fd7950";
+  sha256 = "sha256-qnU5g9Oxusr67zIIei9cAUqT7VVkA2VDXbarM1abOgc=";
+}

--- a/manifests/forc-doc-0.10.3.nix
+++ b/manifests/forc-doc-0.10.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.10.3";
+  date = "2022-04-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7676db6f4ebc7a3885f87514d16a703a99410d7";
+  sha256 = "sha256-/pWNhRZm+ev48LgpQhjGWuXG2TLvZSTpPHsZPLHcMiw=";
+}

--- a/manifests/forc-doc-0.11.0.nix
+++ b/manifests/forc-doc-0.11.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.11.0";
+  date = "2022-04-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "95816e4e41aae1d3425ba6ff5e7266076d8400fa";
+  sha256 = "sha256-2XvtFdkQwUVlUVSjQeTUHlEROQ8r1GOcG8uCPM3uDTc=";
+}

--- a/manifests/forc-doc-0.12.1.nix
+++ b/manifests/forc-doc-0.12.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.12.1";
+  date = "2022-05-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a03a5d1c068a91779e5ce08eead6c4626de2eb0d";
+  sha256 = "sha256-nE10IRpnOkNHXfLfYhFhucjJ3JgdPW6AuNneLL14ymI=";
+}

--- a/manifests/forc-doc-0.12.2.nix
+++ b/manifests/forc-doc-0.12.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.12.2";
+  date = "2022-05-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2b6e9384f06692ec627293ae5db5e2f748fe2c30";
+  sha256 = "sha256-HTo5eP8jZP5tzesGGA1i5YUmofsWxFJGKw0oMfvWv0c=";
+}

--- a/manifests/forc-doc-0.13.0.nix
+++ b/manifests/forc-doc-0.13.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.13.0";
+  date = "2022-05-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6eef7ab750cd3282f08b6014960cbc02afae717a";
+  sha256 = "sha256-iT90TBcMgmKTl/2MHR37Vtk7LcOshVMSshlU3BLhAG0=";
+}

--- a/manifests/forc-doc-0.13.1.nix
+++ b/manifests/forc-doc-0.13.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.13.1";
+  date = "2022-05-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d73d9d2b4b547e2035ddfe085d439de56ccee1f0";
+  sha256 = "sha256-jbuvLymTQb8g4ERJeu0K24z2OIw8aDlkBPF+YjiUkIE=";
+}

--- a/manifests/forc-doc-0.13.2.nix
+++ b/manifests/forc-doc-0.13.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.13.2";
+  date = "2022-05-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dac1b96419a6ed46a4c531492ae5e794a270d4a1";
+  sha256 = "sha256-LBuJ2ukkK1FosaLcZ10ds8/7ybN1UU/o0d9dRmbG5a4=";
+}

--- a/manifests/forc-doc-0.14.0.nix
+++ b/manifests/forc-doc-0.14.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.14.0";
+  date = "2022-05-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "953dad9cad0defe50ffe04e4031207fd247b63f1";
+  sha256 = "sha256-/z+nNctB9t1qLKiemsg+QuV2jBnuYgd0tCe3cEkI1OU=";
+}

--- a/manifests/forc-doc-0.14.1.nix
+++ b/manifests/forc-doc-0.14.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.14.1";
+  date = "2022-05-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "02ef7d10b6bf883d73fc1fd23034dc814dfffea2";
+  sha256 = "sha256-8Uh2gbZb1R1llk3h+DeCF3heBO2Ec3nJNqI6hpSTfq8=";
+}

--- a/manifests/forc-doc-0.14.2.nix
+++ b/manifests/forc-doc-0.14.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.14.2";
+  date = "2022-05-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6fc5c69f29a5aab0b6ca677d9384d0d5eaffb232";
+  sha256 = "sha256-JGicorHY6HfSWoZa2nFOnx45qDrnXmORzHOOKHk/6sM=";
+}

--- a/manifests/forc-doc-0.14.3.nix
+++ b/manifests/forc-doc-0.14.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.14.3";
+  date = "2022-05-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "17f856bfa0d500e06fff2c470e8e6113533faf97";
+  sha256 = "sha256-VfyRHFmz89GT7UP/JCR8lPZY5vxhfxnyyWheQdWSRn0=";
+}

--- a/manifests/forc-doc-0.14.4.nix
+++ b/manifests/forc-doc-0.14.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.14.4";
+  date = "2022-05-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b067a7dd64b26bd763eca268fef3849c2c77028d";
+  sha256 = "sha256-VJGi0FlI+majMW66lo4Sxyo9NaaO+LgFyg7hHwckD1k=";
+}

--- a/manifests/forc-doc-0.14.5.nix
+++ b/manifests/forc-doc-0.14.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.14.5";
+  date = "2022-06-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "60c626cf486d5c53c44d84db1ec81cb90174cad3";
+  sha256 = "sha256-3zI62Q+jaZYml3PjHn5Xsx635ARfUPsXBpOGDc0QzVM=";
+}

--- a/manifests/forc-doc-0.15.0.nix
+++ b/manifests/forc-doc-0.15.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.15.0";
+  date = "2022-06-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ee7822c411a3d6135ea590bbc5c85527c4ede6d7";
+  sha256 = "sha256-7qdjLcxcKCHt+RNrVU9WRK+DUepB0G/5RkScHHWRFJQ=";
+}

--- a/manifests/forc-doc-0.15.1.nix
+++ b/manifests/forc-doc-0.15.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.15.1";
+  date = "2022-06-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a34b4b99fcdd065d559f6cbb9dec0697c3f5edd1";
+  sha256 = "sha256-kR1NJqI6fOyDne1zvwIG2M92+dSOn+6Hby+Q4iMJAAQ=";
+}

--- a/manifests/forc-doc-0.15.2.nix
+++ b/manifests/forc-doc-0.15.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.15.2";
+  date = "2022-06-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "eab07e48bc6dbd0c80aedc1e363bb63a6d5f0e28";
+  sha256 = "sha256-vE29EiJYF4T6FW/1odNJyZOc5HKHR5sC10bASSFcmuc=";
+}

--- a/manifests/forc-doc-0.16.0.nix
+++ b/manifests/forc-doc-0.16.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.16.0";
+  date = "2022-06-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "948f7aba42b4138433fb5b61c698c8f4a60db424";
+  sha256 = "sha256-5yPftMl1LJkub2yeGHF1BrLZZSYzg82IYFVpVWG0v48=";
+}

--- a/manifests/forc-doc-0.16.1.nix
+++ b/manifests/forc-doc-0.16.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.16.1";
+  date = "2022-06-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dcf22453aeb054335d96ef810da9d4f756d869b7";
+  sha256 = "sha256-kAZVbgkf7ganCs+sBPL0eMmR3MDCm6s+qL8d1CfHL8U=";
+}

--- a/manifests/forc-doc-0.16.2.nix
+++ b/manifests/forc-doc-0.16.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.16.2";
+  date = "2022-06-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7920330d34c97cf418b6d0e1561f978068158228";
+  sha256 = "sha256-NpCpZYxgJeUcgw5QqnAhzVmEkMrR7cs2Sj6aW6Rm6JU=";
+}

--- a/manifests/forc-doc-0.17.0.nix
+++ b/manifests/forc-doc-0.17.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.17.0";
+  date = "2022-07-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b81bcd9652d4fc9908d1971c9215a7cfdde39adc";
+  sha256 = "sha256-cOyJXvwyZbZeTLfw9xoAtY1rsHN29VXLkRsEeCZyDmI=";
+}

--- a/manifests/forc-doc-0.18.0.nix
+++ b/manifests/forc-doc-0.18.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.18.0";
+  date = "2022-07-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada0d294a68e5ca3070e3c46eb89619e7d87caf2";
+  sha256 = "sha256-9a39KoLnQ7urf7pBwxFy8B2+SELuhhx6JDZjyZo2rSQ=";
+}

--- a/manifests/forc-doc-0.18.1.nix
+++ b/manifests/forc-doc-0.18.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.18.1";
+  date = "2022-07-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3bd8eaf4a0f11a3009c9421100cc06c2e897b6c2";
+  sha256 = "sha256-WI7srBdT5WAMZ6OfUWAcihZcpxbn/ogfVE3LaoQptcM=";
+}

--- a/manifests/forc-doc-0.19.0.nix
+++ b/manifests/forc-doc-0.19.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.19.0";
+  date = "2022-07-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5c716e1ba55d755555ed5aa186c883f73c4f90dc";
+  sha256 = "sha256-DKB7ykAHVte8Dt566iNdY6CIkvs06zRxCWT50LoQRBk=";
+}

--- a/manifests/forc-doc-0.19.1.nix
+++ b/manifests/forc-doc-0.19.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.19.1";
+  date = "2022-08-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1202e790c119ff9f04c847ecaab3411cfaf32f94";
+  sha256 = "sha256-jFtMg6C861fIWZBmX5SbSsvQwPUr+KWQOcQnPDweWUo=";
+}

--- a/manifests/forc-doc-0.19.2.nix
+++ b/manifests/forc-doc-0.19.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.19.2";
+  date = "2022-08-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6808861389966f99887f71476918a562a9edd90e";
+  sha256 = "sha256-LL5jMwMvw//bN8SkI5K/tNF+7NKuuOXpcMGezEmrQ4g=";
+}

--- a/manifests/forc-doc-0.2.0.nix
+++ b/manifests/forc-doc-0.2.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.2.0";
+  date = "2022-01-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "38479274e0c50518e20c919682b8173ae4a555d3";
+  sha256 = "sha256-48BfRiY2evrKlcz1bXBWoWQgRtkk4jc2r3GZRj28sPo=";
+}

--- a/manifests/forc-doc-0.2.1.nix
+++ b/manifests/forc-doc-0.2.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.2.1";
+  date = "2022-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a790fd729b2021f837be924c7b8b21099b9f6c12";
+  sha256 = "sha256-TUQQa1uE9JuZzEnXxrOAeBplNkzt9MRWzPjxZdECZg8=";
+}

--- a/manifests/forc-doc-0.20.0.nix
+++ b/manifests/forc-doc-0.20.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.20.0";
+  date = "2022-08-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fc3a05d87d1178e937fc5e4742b13fcca490057d";
+  sha256 = "sha256-gJaLWboU9LNEn9Xu+0AIveFvG3wCTMH1P95H+DVJCRw=";
+}

--- a/manifests/forc-doc-0.20.1.nix
+++ b/manifests/forc-doc-0.20.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.20.1";
+  date = "2022-08-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "21887f4b321bfacb16c7a6602071e3b6ea1c8df1";
+  sha256 = "sha256-mO7vojv7gEfBJaEmBW2uQTo1ecLNoTL6E1o1d68saBQ=";
+}

--- a/manifests/forc-doc-0.20.2.nix
+++ b/manifests/forc-doc-0.20.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.20.2";
+  date = "2022-08-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6a8116fcee71aa960217b1672bac0c35d1fce42c";
+  sha256 = "sha256-JfjHda4vRGPiZ2EhJbGMzpSJ24bFFS3WlPxtXmI3mno=";
+}

--- a/manifests/forc-doc-0.21.0-nightly-2022-09-01.nix
+++ b/manifests/forc-doc-0.21.0-nightly-2022-09-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.21.0";
+  date = "2022-09-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "11fd90a14d48ab363a297cec267b3f91327502f5";
+  sha256 = "sha256-B7ExtUjq1hgmXlqjvQSyFFeOC94j5ODYt29OtOcAsEk=";
+}

--- a/manifests/forc-doc-0.21.0.nix
+++ b/manifests/forc-doc-0.21.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.21.0";
+  date = "2022-08-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "32b5b142b54d3d38ae1f7df69f465138e86de82d";
+  sha256 = "sha256-joWJifoFBzzK9FdhQwyYwVuDU4/8hQzmrUgD7+2BSJY=";
+}

--- a/manifests/forc-doc-0.22.0.nix
+++ b/manifests/forc-doc-0.22.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.22.0";
+  date = "2022-08-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6e1fbca21f0979d226efd7ceea5b6d71696536cd";
+  sha256 = "sha256-cK7YReHEq3Z/wVV6bxTohdHI9c2zSz53Sej8GCWSIrI=";
+}

--- a/manifests/forc-doc-0.22.1-nightly-2022-09-02.nix
+++ b/manifests/forc-doc-0.22.1-nightly-2022-09-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.22.1";
+  date = "2022-09-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ecf537a5c892ddab7997a34d9a128007cfdd91fc";
+  sha256 = "sha256-BuKsDcrqSOE41InAcyFBqR02m6iEjb9cr7J3omF6Hao=";
+}

--- a/manifests/forc-doc-0.22.1-nightly-2022-09-03.nix
+++ b/manifests/forc-doc-0.22.1-nightly-2022-09-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.22.1";
+  date = "2022-09-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b696495c8fb9b207626a3dafbee0550407198d12";
+  sha256 = "sha256-2X0wu0De384uIBy5KxiR/lbD9bzGYKmdBqnhWpDzCt0=";
+}

--- a/manifests/forc-doc-0.22.1.nix
+++ b/manifests/forc-doc-0.22.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.22.1";
+  date = "2022-08-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c486eabc3ed4d8c53b63735188f2c1db5d17703c";
+  sha256 = "sha256-fChGs4bPxg82noIJooec6Tk908T8BrDUWH6YQNvAuhg=";
+}

--- a/manifests/forc-doc-0.23.0-nightly-2022-09-04.nix
+++ b/manifests/forc-doc-0.23.0-nightly-2022-09-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.23.0";
+  date = "2022-09-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4712e5b26c6c0f778d7771ef1b35a229fe3a371d";
+  sha256 = "sha256-ZdH69u5DOe/fjARXWpJe0J21K/rVL4YJD5/qHQdlr50=";
+}

--- a/manifests/forc-doc-0.23.0-nightly-2022-09-05.nix
+++ b/manifests/forc-doc-0.23.0-nightly-2022-09-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.23.0";
+  date = "2022-09-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "36aa76d3e1572d2d3054483be59345797ce04b36";
+  sha256 = "sha256-A4NYsyilLbJeqGkOtR67wrIUEWsqwtW4RsY4asNXScM=";
+}

--- a/manifests/forc-doc-0.23.0-nightly-2022-09-06.nix
+++ b/manifests/forc-doc-0.23.0-nightly-2022-09-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.23.0";
+  date = "2022-09-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a989e6ca0caf6ace4630cd72a2ff8c875c141a43";
+  sha256 = "sha256-5xMmLJ0aMfPJwfscUtVH88pOLTsnCeX2yW0VGGVwYyM=";
+}

--- a/manifests/forc-doc-0.23.0.nix
+++ b/manifests/forc-doc-0.23.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.23.0";
+  date = "2022-09-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4712e5b26c6c0f778d7771ef1b35a229fe3a371d";
+  sha256 = "sha256-ZdH69u5DOe/fjARXWpJe0J21K/rVL4YJD5/qHQdlr50=";
+}

--- a/manifests/forc-doc-0.24.0-nightly-2022-09-07.nix
+++ b/manifests/forc-doc-0.24.0-nightly-2022-09-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.0";
+  date = "2022-09-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8200174bb35f2dc7131238b2930130a5b4ec7c1c";
+  sha256 = "sha256-Tgo+l8EhUnxzVmMnDHylk62p62W8rW0062I7alLTdoY=";
+}

--- a/manifests/forc-doc-0.24.0.nix
+++ b/manifests/forc-doc-0.24.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.0";
+  date = "2022-09-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ea4f1b7885248c2b4c4d0da394c2cc50ea1583e8";
+  sha256 = "sha256-2DwlfRw+aw9g4E2wPeomlGH/qe6O0kKha3Vu3+HY4AI=";
+}

--- a/manifests/forc-doc-0.24.1-nightly-2022-09-08.nix
+++ b/manifests/forc-doc-0.24.1-nightly-2022-09-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.1";
+  date = "2022-09-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "54e1a340e6c0c9a675e8a66aab03f579d5d6b39b";
+  sha256 = "sha256-t/VFaYCANGY5CM2FFrLhNiBB5eAL/CFCZvIzigr3d1I=";
+}

--- a/manifests/forc-doc-0.24.1-nightly-2022-09-09.nix
+++ b/manifests/forc-doc-0.24.1-nightly-2022-09-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.1";
+  date = "2022-09-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "095bfe030934f31ea85c7c85e3f0e47dc51c11bd";
+  sha256 = "sha256-U04I1XLtQlaOIjJrwcndkXCNp8m6RINumrhhtuQpLZ8=";
+}

--- a/manifests/forc-doc-0.24.1.nix
+++ b/manifests/forc-doc-0.24.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.1";
+  date = "2022-09-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "54e1a340e6c0c9a675e8a66aab03f579d5d6b39b";
+  sha256 = "sha256-t/VFaYCANGY5CM2FFrLhNiBB5eAL/CFCZvIzigr3d1I=";
+}

--- a/manifests/forc-doc-0.24.2-nightly-2022-09-10.nix
+++ b/manifests/forc-doc-0.24.2-nightly-2022-09-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.2";
+  date = "2022-09-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "719dca1bd0ec8cc58e651d7327fb0e16276eb69e";
+  sha256 = "sha256-iGn796XsI8yEZi6dJNAdfvekDr97DOq03DOOVUvFCi0=";
+}

--- a/manifests/forc-doc-0.24.2.nix
+++ b/manifests/forc-doc-0.24.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.2";
+  date = "2022-09-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "057e83aee87d17c3812f223f5fc7884cf6d3468a";
+  sha256 = "sha256-XQePJ7tvPqjAAnqdpavkUxuCtH8MmaiXSDrhIUpjVQo=";
+}

--- a/manifests/forc-doc-0.24.3-nightly-2022-09-13.nix
+++ b/manifests/forc-doc-0.24.3-nightly-2022-09-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.3";
+  date = "2022-09-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "9aeb723b732741e1211c4fb78195f2e60d262f42";
+  sha256 = "sha256-ylhVuNFQ6ckZlRl3cBrAc7AWCSX68Ar1wUAfN2JQENw=";
+}

--- a/manifests/forc-doc-0.24.3-nightly-2022-09-15.nix
+++ b/manifests/forc-doc-0.24.3-nightly-2022-09-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.3";
+  date = "2022-09-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0b69f4d4920febbbe3149efe2aa520d57b0ffdbc";
+  sha256 = "sha256-oMFE41zjmnoPCulMvEf8ZK/vcteVQecSbwv9gRXSIps=";
+}

--- a/manifests/forc-doc-0.24.3-nightly-2022-09-16.nix
+++ b/manifests/forc-doc-0.24.3-nightly-2022-09-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.3";
+  date = "2022-09-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "68351a542386c41892064e86b3eca857f414c8ce";
+  sha256 = "sha256-6Qgz0X+jo07Ee3UzCvRW0yrS11nIGuhpjnQymXWo520=";
+}

--- a/manifests/forc-doc-0.24.3.nix
+++ b/manifests/forc-doc-0.24.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.3";
+  date = "2022-09-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "95cd150cacef407a1f30c89899c539b0d57f099d";
+  sha256 = "sha256-oWQpD2HohdjQ0lcnOjipT0oTIX68KnoWy13FeXYKi7E=";
+}

--- a/manifests/forc-doc-0.24.4-nightly-2022-09-17.nix
+++ b/manifests/forc-doc-0.24.4-nightly-2022-09-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.4";
+  date = "2022-09-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5c5399ebe258c5cb3f7c1962fbbe42a3e063e3e4";
+  sha256 = "sha256-NM1Yc9xTnaTbz/pj4wbJR4YnJt/x3u1RFW3G8nsIOs8=";
+}

--- a/manifests/forc-doc-0.24.4-nightly-2022-09-18.nix
+++ b/manifests/forc-doc-0.24.4-nightly-2022-09-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.4";
+  date = "2022-09-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "df9d5c031ddee0ca8b05eddbcf274aac14c0589e";
+  sha256 = "sha256-2JxH1LA/Qe97MZj5lmK1mjxPQpvImgiRJc3A8+KHrDQ=";
+}

--- a/manifests/forc-doc-0.24.4-nightly-2022-09-20.nix
+++ b/manifests/forc-doc-0.24.4-nightly-2022-09-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.4";
+  date = "2022-09-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "315cae6fd111d3c3cb61b2ecd37085372e690475";
+  sha256 = "sha256-HxWKV/dFuAwBb+qy2jhgkS2w9mPNRiF9VWN3nAstfTA=";
+}

--- a/manifests/forc-doc-0.24.4-nightly-2022-09-21.nix
+++ b/manifests/forc-doc-0.24.4-nightly-2022-09-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.4";
+  date = "2022-09-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "17d61c9ff348e812d2f25122836b173c7c350927";
+  sha256 = "sha256-QCOL2/eCWF6OylH+WxvXlitrR6eY2Qe/iveKDXqjui4=";
+}

--- a/manifests/forc-doc-0.24.4-nightly-2022-09-22.nix
+++ b/manifests/forc-doc-0.24.4-nightly-2022-09-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.4";
+  date = "2022-09-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a324023d4c1e0047618dcdaad486061e34920f64";
+  sha256 = "sha256-LJLH7ezwX6kp+4bH9FHbPby733DLkR0/m8vOjkQwxds=";
+}

--- a/manifests/forc-doc-0.24.4-nightly-2022-09-23.nix
+++ b/manifests/forc-doc-0.24.4-nightly-2022-09-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.4";
+  date = "2022-09-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "56dc0f4105a456ae1311405368c57a3caab3490e";
+  sha256 = "sha256-wfl9MD5qnXCeotcIZ/THA67vzE3Ob0aGqc8GPOtLYlw=";
+}

--- a/manifests/forc-doc-0.24.4-nightly-2022-09-24.nix
+++ b/manifests/forc-doc-0.24.4-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.4";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7d000fff4dc27c2ce0ca779a6e204fb0d4e720c";
+  sha256 = "sha256-qtbxzFic0c9x6fbu4t8hdDkKXP9QTF5QcY9hZ+8qYv0=";
+}

--- a/manifests/forc-doc-0.24.4.nix
+++ b/manifests/forc-doc-0.24.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.4";
+  date = "2022-09-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7800e18979dd8e4c8d672b8e7aae1758c2edb88";
+  sha256 = "sha256-jRqUQv7nsv0xq+CNrEYCnt0yfiVycTUF3eYOMt/DCdQ=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-09-25.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-09-27.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "535174be2759db62d0838957cf4f89f2c9d8ec71";
+  sha256 = "sha256-nqO6tKI6liTYLXHVIyImfFWeBmu2Z70jEMGAjT7WAic=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-09-28.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5e543382e00a843adb2f64d03eea8576e4c1d53";
+  sha256 = "sha256-nm4FY6pisendzf+hgCm9zDieqVAyRtDNDXjZca79brM=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-09-29.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e6afd8987ead0d453efb5f35e29ce7ba1a0cd070";
+  sha256 = "sha256-Xo8OXRT9UtkEvZvbMAteolHsPKjtx7kl9CZaCuGhV/w=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-09-30.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "076e95fcdb9efc4052dec827418274681d26b00e";
+  sha256 = "sha256-89ZfhctqiTKbwCEz03r9A1AYJ/l+UHsKdCt5mnl6WvM=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-10-01.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e15d71c176359844341e2621a0431f58dfd13c2e";
+  sha256 = "sha256-IAkBhCN7hPGVTBHquhAt0+nEB+0yLM6smnc8pghO/wA=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-10-02.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7b9a022df54ed75832d93833587855af0d08fa";
+  sha256 = "sha256-GJzUqffmvc1CH5K9TeAHvwLs6FyA6/2YSg1RUnpgYio=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-10-03.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-10-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe47d44458c1433140afd30a304e2723d1805b5";
+  sha256 = "sha256-sBYTj7BwGyvdw4FTQt331Y/I7XrZVTgrTJIJ/FgPc70=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-10-04.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-10-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-10-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a917c66ff1d402c7350664c648e8704b50085281";
+  sha256 = "sha256-jCHeqg6SIP8fnAHm3ZeQt9CdEDz1Cr81NcapE4jQx70=";
+}

--- a/manifests/forc-doc-0.24.5-nightly-2022-10-05.nix
+++ b/manifests/forc-doc-0.24.5-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a8f0c39d0bb3e0424a5cdabf0b625b73c90667c";
+  sha256 = "sha256-8Y1IUqYWk29szUFWBwrk4fGDRvIKcC9XY2Zu/h89Jng=";
+}

--- a/manifests/forc-doc-0.24.5.nix
+++ b/manifests/forc-doc-0.24.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.24.5";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-doc-0.25.0-nightly-2022-10-06.nix
+++ b/manifests/forc-doc-0.25.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-doc-0.25.0.nix
+++ b/manifests/forc-doc-0.25.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.0";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-doc-0.25.1-nightly-2022-10-07.nix
+++ b/manifests/forc-doc-0.25.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4740fb2f9b9c4c4d6e8ba2110831604b40ccc645";
+  sha256 = "sha256-czP0vMoQE3ZjXFcLHNRKntBkbpJb7yPaMsIwxny+xPM=";
+}

--- a/manifests/forc-doc-0.25.1.nix
+++ b/manifests/forc-doc-0.25.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.1";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
+  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
+}

--- a/manifests/forc-doc-0.25.2-nightly-2022-10-08.nix
+++ b/manifests/forc-doc-0.25.2-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.2";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e8a28b5867234a6391bf99ddc55db41957096480";
+  sha256 = "sha256-pw0Zs2LX5D6kyScWDuOz3dobkhRQ5DgySirK4Tj+fBU=";
+}

--- a/manifests/forc-doc-0.25.2-nightly-2022-10-09.nix
+++ b/manifests/forc-doc-0.25.2-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.2";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "61d6d659b22c25a606f1437a122176474293180d";
+  sha256 = "sha256-Ch+iPSPFlnzL9JlZXPHhr7fWTJqNIAP0TfKdyQieQ0M=";
+}

--- a/manifests/forc-doc-0.25.2-nightly-2022-10-10.nix
+++ b/manifests/forc-doc-0.25.2-nightly-2022-10-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.2";
+  date = "2022-10-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "71999d3774ec617e4b1167d891cadb1e6e9f38af";
+  sha256 = "sha256-jVrjARMBQSgfBJTSfL9xUBB0NjjbSAX0m7uaROG5urA=";
+}

--- a/manifests/forc-doc-0.25.2-nightly-2022-10-11.nix
+++ b/manifests/forc-doc-0.25.2-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.2";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb0a5be05549a7a01df684380eaf0c2ec7f46241";
+  sha256 = "sha256-EUmVdkCM6EIL/imd6Xn4/cGp2RyRDcjJ6QjI7BjQNVI=";
+}

--- a/manifests/forc-doc-0.25.2-nightly-2022-10-12.nix
+++ b/manifests/forc-doc-0.25.2-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.2";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7554760ba1cde24db5075183ddc9c3f1359066";
+  sha256 = "sha256-uycMRo7+vIkHKQdcCpxh+eGdpBnuq1b674Aw6TXYgU8=";
+}

--- a/manifests/forc-doc-0.25.2-nightly-2022-10-13.nix
+++ b/manifests/forc-doc-0.25.2-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.2";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "205073dc30db355f065c29db41d591bfc166f3fa";
+  sha256 = "sha256-c3eAp7XB0ziwC4NLCyQeHgflBuwftCv+gy0P/RwJID0=";
+}

--- a/manifests/forc-doc-0.25.2.nix
+++ b/manifests/forc-doc-0.25.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.25.2";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
+  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-14.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-15.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a9eaef219282566e99d57ff993c613317a9143a9";
+  sha256 = "sha256-noZchaj5q6Y5rp1t6VOfmV96ggJZDNdNMtEmdsbK0cg=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-16.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a1d40f58883e3fe8d23140fbf922d263f17b7c20";
+  sha256 = "sha256-3WPBVNfM/lkyA44mVqqR05t0pBfgI5vnBIOGJSMfeW8=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-17.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "314648f8448cefad534f129431ebd15f06e8b418";
+  sha256 = "sha256-zXLLLvftB+aTX4ZFbjfQ/1YLBLCX70ASZ8U6Z1ppXH8=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-18.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dbd6b9211fd3c4ceeb34b3f6aedb0a7b9f0e6ef8";
+  sha256 = "sha256-Qhf/QDTkb68kX4feeTtdMjSTt34xKhNeRAlhgxGF6wU=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-19.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a2395b4c99c299cf246f1b1ef59785345c94641e";
+  sha256 = "sha256-GvqPVs1EtRuygKA8kEdZyImxlM835AVMKgK74rnX2wk=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-21.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0e84d98a06d32a036d88198505e0d6868c985f25";
+  sha256 = "sha256-38yHKfdmro4oDIYQy2HiSgTP3w4soKLiLPRJBUWa4Pg=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-22.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "aaf7c8833ed3f5949dc501c741014b640b426889";
+  sha256 = "sha256-3n0ewjyJl6HVS++MDTBgtUMMoJt6KhFb2iypBJDm7xw=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-23.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ef8088ab8282a14579bde6af7fec9314435b4a9d";
+  sha256 = "sha256-DpoMWFk+Jhou3I6khR77I5X0Zmt+bxq94XgtvSLHWmo=";
+}

--- a/manifests/forc-doc-0.26.0-nightly-2022-10-24.nix
+++ b/manifests/forc-doc-0.26.0-nightly-2022-10-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3270118703b3516bffc1b2ae6f99c11aed7b1130";
+  sha256 = "sha256-Y8cJ8RYDjkVFGqJ++ZNNehS4QESC/cpqLI8N1bkjwc4=";
+}

--- a/manifests/forc-doc-0.26.0.nix
+++ b/manifests/forc-doc-0.26.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.26.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-doc-0.27.0-nightly-2022-10-25.nix
+++ b/manifests/forc-doc-0.27.0-nightly-2022-10-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.27.0";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8ae44c2ea0eb154f77e769ef3f69d7f1ab0116b9";
+  sha256 = "sha256-5yuILUm2XiRpou8bTKdfyXOYGkoKpxJ/YhsqXyJPtlk=";
+}

--- a/manifests/forc-doc-0.27.0.nix
+++ b/manifests/forc-doc-0.27.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.27.0";
+  date = "2022-10-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "40f1e79de08af109f2ebb066f51704f36094ed1e";
+  sha256 = "sha256-qIso6YBCs4HKu1fAqM0fgq0vcaOqgGeZ2CY0ZLjTm+o=";
+}

--- a/manifests/forc-doc-0.28.0.nix
+++ b/manifests/forc-doc-0.28.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.28.0";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a7978381effcf999adc5726587bf8f711f04e414";
+  sha256 = "sha256-3xqbdGXjWIfdZV7po64bp+N79MGfEkL0fRyKcel0A2s=";
+}

--- a/manifests/forc-doc-0.28.1-nightly-2022-10-26.nix
+++ b/manifests/forc-doc-0.28.1-nightly-2022-10-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.28.1";
+  date = "2022-10-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "203b59053c713574007a94663923411f18c501ef";
+  sha256 = "sha256-bnVLOvj+NkTapIe47m3zLcZsLuBHQ3thSzUkiuHUddc=";
+}

--- a/manifests/forc-doc-0.28.1-nightly-2022-10-27.nix
+++ b/manifests/forc-doc-0.28.1-nightly-2022-10-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.28.1";
+  date = "2022-10-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "18a9eb235a8d8255cf90faa25989a563ccf99d12";
+  sha256 = "sha256-7QTYA/vscSnJfGfaiKd/KfxvtG0ny0r8It8lqaJHtoM=";
+}

--- a/manifests/forc-doc-0.28.1-nightly-2022-10-28.nix
+++ b/manifests/forc-doc-0.28.1-nightly-2022-10-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.28.1";
+  date = "2022-10-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c0880ebce66b625352222cd737361e9574c6681c";
+  sha256 = "sha256-UXM7jrrVSKj+h5UDo3hG7iBsEaFRGs0Kv/hBFneYkr8=";
+}

--- a/manifests/forc-doc-0.28.1-nightly-2022-10-29.nix
+++ b/manifests/forc-doc-0.28.1-nightly-2022-10-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.28.1";
+  date = "2022-10-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "51987a96a6f0ac23f4102478290e0bc1736b2af6";
+  sha256 = "sha256-qTgRMNueyU9NtCI6KHumAjrFYqJ2xqWEqW8py1okZsU=";
+}

--- a/manifests/forc-doc-0.28.1-nightly-2022-10-30.nix
+++ b/manifests/forc-doc-0.28.1-nightly-2022-10-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.28.1";
+  date = "2022-10-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "03ded848a6281930714a4b97a74364697705baf2";
+  sha256 = "sha256-sztgZklxQotgNRvJs0wbmP4n+Rty0kb6/I15nOEDoxU=";
+}

--- a/manifests/forc-doc-0.28.1-nightly-2022-10-31.nix
+++ b/manifests/forc-doc-0.28.1-nightly-2022-10-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.28.1";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1668ee5d01a83267a77e1b759178874d525ef726";
+  sha256 = "sha256-o00OwNerNsWhF2eKbd1ukKNDVG667y9WRyMUnZrA1IU=";
+}

--- a/manifests/forc-doc-0.28.1.nix
+++ b/manifests/forc-doc-0.28.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.28.1";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "84f9aad376760cd9c8eacc8a4848bffeb25bf9a5";
+  sha256 = "sha256-S5sB6ahI7P2Qv4Rh3GTE7lkYcEAbp1znpW/hlkyuh9U=";
+}

--- a/manifests/forc-doc-0.29.0-nightly-2022-11-01.nix
+++ b/manifests/forc-doc-0.29.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.29.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bdc3160d92539dee21378633b24475b6d6666e0c";
+  sha256 = "sha256-za7htSCITOpeMWCM/duj9JDIK6UXUedIRs4ydhtJJKM=";
+}

--- a/manifests/forc-doc-0.29.0-nightly-2022-11-02.nix
+++ b/manifests/forc-doc-0.29.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.29.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b0f05c4c1c30d691c34b828c50ff641415eb2530";
+  sha256 = "sha256-EJJGk6iCFwcEEsGYHVsUx+Y2OAjdE98pCCgyqeweD9Q=";
+}

--- a/manifests/forc-doc-0.29.0.nix
+++ b/manifests/forc-doc-0.29.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.29.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
+  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
+}

--- a/manifests/forc-doc-0.3.0.nix
+++ b/manifests/forc-doc-0.3.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.3.0";
+  date = "2022-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b81eee7d23af71958ba1a3276855949277902a57";
+  sha256 = "sha256-25ZOELcJchuJapvGZFigzsl3BPEUW/R3f5NhvoXBKeE=";
+}

--- a/manifests/forc-doc-0.3.1.nix
+++ b/manifests/forc-doc-0.3.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.3.1";
+  date = "2022-01-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d9b5a1103a1f37672d6f09c8dae34b813872d44b";
+  sha256 = "sha256-eYVjjBkg6Gxc7mKMl7oaK3Ws2XVDHWAt+z3WIjGM3Xs=";
+}

--- a/manifests/forc-doc-0.3.2.nix
+++ b/manifests/forc-doc-0.3.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.3.2";
+  date = "2022-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3012191420362e9ba1df0324b2a9e80eeded7e1d";
+  sha256 = "sha256-5AirUGidtaNFfVf4uSutfrEvs2wd/ROiDyudYHb2EWQ=";
+}

--- a/manifests/forc-doc-0.3.3.nix
+++ b/manifests/forc-doc-0.3.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.3.3";
+  date = "2022-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "441ab123839f2eb4f5dd1b055fdbe5a5b26a6736";
+  sha256 = "sha256-QI8nqWfKr+/yGP96NnNdpKGwHHzA6UxEyQvjwQLgcSU=";
+}

--- a/manifests/forc-doc-0.30.0-nightly-2022-11-03.nix
+++ b/manifests/forc-doc-0.30.0-nightly-2022-11-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ff747c226b7bebcdf62960f2040550cec33666c6";
+  sha256 = "sha256-NXzLpC1IxRqF+TvJKwO8bxww9rKpFCjbo+Ou+fMquXY=";
+}

--- a/manifests/forc-doc-0.30.0-nightly-2022-11-04.nix
+++ b/manifests/forc-doc-0.30.0-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.0";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4a5e93f5fc66168d70a0f11f0a3ef1ee4ff11c31";
+  sha256 = "sha256-vVMlYw7BAWfOZ2n/n4wtVNZXd1ehsppQLyux3nVNpAA=";
+}

--- a/manifests/forc-doc-0.30.0.nix
+++ b/manifests/forc-doc-0.30.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "37deaee8fccf5804d78a003cf64f14fac654fc41";
+  sha256 = "sha256-BIVBDX3i2ym6d/90AuK/I/ATtJqUFZS9OdltCdBtqI0=";
+}

--- a/manifests/forc-doc-0.30.1-nightly-2022-11-05.nix
+++ b/manifests/forc-doc-0.30.1-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.1";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-doc-0.30.1-nightly-2022-11-06.nix
+++ b/manifests/forc-doc-0.30.1-nightly-2022-11-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.1";
+  date = "2022-11-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "eee52c7438c11d28a2c9fcc25f1b06b2b80b0c51";
+  sha256 = "sha256-jKVys7ECF2WKzMgLwrfl82CZ6f0rSoglHfRo98x1yeo=";
+}

--- a/manifests/forc-doc-0.30.1-nightly-2022-11-07.nix
+++ b/manifests/forc-doc-0.30.1-nightly-2022-11-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.1";
+  date = "2022-11-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "18c35232a1d81f347e96a0d9351e03d84cb49f2e";
+  sha256 = "sha256-t97QbtnAHlioRfmbz7OGkJmFKcf7BzW1iuqUPc1MG24=";
+}

--- a/manifests/forc-doc-0.30.1-nightly-2022-11-08.nix
+++ b/manifests/forc-doc-0.30.1-nightly-2022-11-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.1";
+  date = "2022-11-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "aa56f73056ab0bf58555717d41e676e3a35250d4";
+  sha256 = "sha256-Bc+9qEf4EsCJQasNsfTOOXwpX8xIYrnuG+4epLoFMjk=";
+}

--- a/manifests/forc-doc-0.30.1-nightly-2022-11-09.nix
+++ b/manifests/forc-doc-0.30.1-nightly-2022-11-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.1";
+  date = "2022-11-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7f4bd3b61b1085913da1b918cc7256dcdf94ad3";
+  sha256 = "sha256-1WDIPnDoxe56KZmXoFvvre7fdWU2NFFyfS3QcwLsZl4=";
+}

--- a/manifests/forc-doc-0.30.1-nightly-2022-11-10.nix
+++ b/manifests/forc-doc-0.30.1-nightly-2022-11-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.1";
+  date = "2022-11-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "94f73b2b7645dc029890aca6d4f9779e7bb72f5d";
+  sha256 = "sha256-mWd7wxAUvhFz5aScr9VdOkDwm9ZzVdU1V5akkwyd/RI=";
+}

--- a/manifests/forc-doc-0.30.1.nix
+++ b/manifests/forc-doc-0.30.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.30.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-doc-0.31.0-nightly-2022-11-11.nix
+++ b/manifests/forc-doc-0.31.0-nightly-2022-11-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.0";
+  date = "2022-11-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "29d70dde3e29067c01152e5f52fabead75034cfa";
+  sha256 = "sha256-yGZgI9Gqj4uVM80v0+XpVWLzeeRWIJcxye78aF4abTc=";
+}

--- a/manifests/forc-doc-0.31.0-nightly-2022-11-12.nix
+++ b/manifests/forc-doc-0.31.0-nightly-2022-11-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.0";
+  date = "2022-11-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ca7c1a480314a826ef89831c1a3c582b19bca4a3";
+  sha256 = "sha256-aDMen4oyrDA+/erat7ZQ5COksqVR1iPZL13riiDfQXE=";
+}

--- a/manifests/forc-doc-0.31.0.nix
+++ b/manifests/forc-doc-0.31.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.0";
+  date = "2022-11-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7a389ddb35bae051938e5441c8ef4a8b63dd269c";
+  sha256 = "sha256-fRGQtZxDPD0sPfpt6xKYOaR9Ty1NDqR8El6rRIuU83M=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-13.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c32b0759d25c0b515cbf535f9fb9b8e6fda38ff2";
+  sha256 = "sha256-5GlH4fTix4r+b66tsE1vx/iyJCsNPnWjfuY7Iu36234=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-15.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe5a388ed894aca00e4a3995e085d63bdab169c";
+  sha256 = "sha256-rYSo5OCSswN7YZL0NipM1wTkC/wAyVRZplJATfSPIt0=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-17.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f86e24747a50f80992f94adcac4abd9f33fb819";
+  sha256 = "sha256-Brnbq/JbQh/jr30z4Zuc6CTY1nLCZfq+M3xschI3gI0=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-22.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dd4a52153aab6de8fdd1e2c0bd215fafa56230b9";
+  sha256 = "sha256-3cBbaZJFOtlmy4sKOVDt0iS6ZVOklJXyLGW7Z5N+QiI=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-23.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f581909b377c6beecc8b2558d71bd3067b1c0205";
+  sha256 = "sha256-UmkTIHMPLQfobnKRBFf+nutxz9+U34Fikq9/SfBxO2Q=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-24.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "43c4307898de06832e8f0ceaabcec74cc1edcbdb";
+  sha256 = "sha256-z5rz4wBUyNobicpIf3lfxbFsLMzgUNs+hjyoNQTQWp0=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-25.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "412a4cd9741e63a384ba227da6f01f92913fae60";
+  sha256 = "sha256-02huSg2ap6iWtGAB9J9AT1kfsXpGX0ifo/FIES1wuZY=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-26.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "47423bf97be06c815bd4e0c882046be986911629";
+  sha256 = "sha256-p6nSrB8QnQktN/UrjUd99+UtwudH30QCGoLCy1rvHTs=";
+}

--- a/manifests/forc-doc-0.31.1-nightly-2022-11-29.nix
+++ b/manifests/forc-doc-0.31.1-nightly-2022-11-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e1e6fe74c8d5577219e908681582062ad5bbdbae";
+  sha256 = "sha256-TWyRV1OMui6dKx4JhzNS/8Fwbi65Oh4oiGTP7stW/zI=";
+}

--- a/manifests/forc-doc-0.31.1.nix
+++ b/manifests/forc-doc-0.31.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.1";
+  date = "2022-11-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c32b0759d25c0b515cbf535f9fb9b8e6fda38ff2";
+  sha256 = "sha256-5GlH4fTix4r+b66tsE1vx/iyJCsNPnWjfuY7Iu36234=";
+}

--- a/manifests/forc-doc-0.31.2-nightly-2022-11-30.nix
+++ b/manifests/forc-doc-0.31.2-nightly-2022-11-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.2";
+  date = "2022-11-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "12239f7d57441a75b0979f2f34d5151a777a5c0a";
+  sha256 = "sha256-9qHs1OatcgPBSLToDkCvTfTXxeAOTjrM1jABQZxqUaI=";
+}

--- a/manifests/forc-doc-0.31.2.nix
+++ b/manifests/forc-doc-0.31.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.2";
+  date = "2022-11-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "12239f7d57441a75b0979f2f34d5151a777a5c0a";
+  sha256 = "sha256-9qHs1OatcgPBSLToDkCvTfTXxeAOTjrM1jABQZxqUaI=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-01.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "12ad8423811d566972dd75fbb954cdb95afde8d8";
+  sha256 = "sha256-vsRRV7NAxSQw+NlZr7dUe2g0Hd8LSjkyXxDiygVfb54=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-02.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2188c1bf686a59c1815120fee888953a1d03ccea";
+  sha256 = "sha256-eYi3lLFgmLCOMnSnR/3trgGfZL50VbHFrjbeHQAzFp0=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-03.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "487770f695ee46be38d43e84ef87e7366a49a916";
+  sha256 = "sha256-OpLBWrpnSFyjczil6zvnLQHvgnG++rIjYuETawANhMo=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-04.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ec819e606e39607534cf82ce39f05b2ae51e7b2e";
+  sha256 = "sha256-eZbcUTekYI0xYkrGRzgVqT8Rgyx39jZb7TxfAU/kzsU=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-06.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3e6f8cf625e1f31f7c9fb20e1564dc09d14eb8f3";
+  sha256 = "sha256-q6io3Fjln0wWVGRsCjvnGL2ILJdLt2enMvl8iLTCDu0=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-07.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d605418bacb4c7f328c8d6689a709a9b82cb497b";
+  sha256 = "sha256-hOzuAm0Rij/BlmiMFBHt0eERqRfi8/5SsIgjRdBwSzA=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-08.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1b75006f3806191bd012f763853b926646fbd0ec";
+  sha256 = "sha256-AwY0FHhKFtygydXCjkWdhUeuCdIvIWez9Cz9WAy+xrY=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-09.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b44442262b08f635643de8fa0a821bb89c51c1d0";
+  sha256 = "sha256-XJd7cx8MXBiDBvi95FBz9fgFy4hqztGa2AG1YG84Udk=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-10.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3bd7118a34444ab2e6747d956f7271b77b610d43";
+  sha256 = "sha256-We5WcW8vFnXH+2FLfOu3D0bFjUuLpP+dR3h+d/OX4Ns=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-11.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4264e2f3ef2ade9bc7483e9b4eb86ac08949d59b";
+  sha256 = "sha256-ffBT+TgrHwG2f0OlRZzJ9FhDcFqlTc2mT9wJAjwQJ1s=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-12.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0550c195bec81c9c529512b81fcdd1f04da7f5a";
+  sha256 = "sha256-NRmU0+JaXvsEoggbyd2/4I7+vglap9nafO/dkJ61KM8=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-13.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2b6189fe282db7e433d92c31a6ac74561e210160";
+  sha256 = "sha256-j21CvjQbJpNbDptGankS1zYAa/ya07i2Ur4CTFnxxXg=";
+}

--- a/manifests/forc-doc-0.31.3-nightly-2022-12-14.nix
+++ b/manifests/forc-doc-0.31.3-nightly-2022-12-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "949dfb98bd8ad0d89c5a59a33b391892e665a760";
+  sha256 = "sha256-3e5IYyeyQWynIViLkD2JmKawKofvG+BxhQO7eRQQafc=";
+}

--- a/manifests/forc-doc-0.31.3.nix
+++ b/manifests/forc-doc-0.31.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.31.3";
+  date = "2022-11-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "12ad8423811d566972dd75fbb954cdb95afde8d8";
+  sha256 = "sha256-vsRRV7NAxSQw+NlZr7dUe2g0Hd8LSjkyXxDiygVfb54=";
+}

--- a/manifests/forc-doc-0.32.0-nightly-2022-12-15.nix
+++ b/manifests/forc-doc-0.32.0-nightly-2022-12-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.0";
+  date = "2022-12-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ed1610a2f6bce5fba39ec53fe7da1ba2f05da4ce";
+  sha256 = "sha256-ZteML6BecCLkj7w5fVJcRVxRYpZocpgNXuNRjDszEYc=";
+}

--- a/manifests/forc-doc-0.32.0.nix
+++ b/manifests/forc-doc-0.32.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.0";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ed1610a2f6bce5fba39ec53fe7da1ba2f05da4ce";
+  sha256 = "sha256-ZteML6BecCLkj7w5fVJcRVxRYpZocpgNXuNRjDszEYc=";
+}

--- a/manifests/forc-doc-0.32.1-nightly-2022-12-16.nix
+++ b/manifests/forc-doc-0.32.1-nightly-2022-12-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.1";
+  date = "2022-12-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "581b44ed124a2ac409cdf4e7a90622451b0d5d5e";
+  sha256 = "sha256-vykM7yK8hN+zh8oyO3vF4SLqQb+AszKJsw6nb9qY6mQ=";
+}

--- a/manifests/forc-doc-0.32.1.nix
+++ b/manifests/forc-doc-0.32.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.1";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "50c1b6c858c044acf88760cb7eb1b39d076f322d";
+  sha256 = "sha256-GnF8eHwhcCC0Yr73jNVjyZUh1lOU9YmFslFzeZnSqHo=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-17.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1b46df8a4d21117a3cf0124ba95744a9ad9b67f4";
+  sha256 = "sha256-ZUIaUDWIsKfLw6n9FAn8EkCgyihOfyGWaCbTVI90RSk=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-18.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c511ccd347e6560ca5cc2ee37887498a30d181f2";
+  sha256 = "sha256-G6RacNQAcME6aOvtF5rjTtRnL/wgTCfa70necg9WKOo=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-19.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "98a5c9bdfa278c0319730f677692616d532e975f";
+  sha256 = "sha256-5RKxMhxcUGBZncTMK0nv2POTMggPAre/xGpwRtc9WwU=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-20.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "495ad00b734b19cb21234a7e03042a4e11ca763c";
+  sha256 = "sha256-mupDuokCCRwZG4JntQttzQ6YlKI75s9vhrgzKy4/1b8=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-21.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "de2706684fcc752bc309d51af7f72e9bac65d545";
+  sha256 = "sha256-uOrfMJfu1n96e791QGvGdmF6ON36JwYjGid4VGPo5XE=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-22.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cdfc56c700ab32eefb84f75ed3048bd2a0ea22d2";
+  sha256 = "sha256-Ue19bzrUMgOdj9ziVu0mX1hGdWn/sZuIOYxMhFd0/9Q=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-23.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "153ef7a8db2f2bf8a2718d32c1ad1f0af23bc0fd";
+  sha256 = "sha256-CSfpr8aCl0goLlIMUcVAEI25A4TpzWixxrWMmIhQnlo=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-24.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0ac0a0a94ee39e8ef8c92695ce37b484dbf5a51c";
+  sha256 = "sha256-dInIy1s0EH8fPWbwzqKHJTTxoKAkXA3JLoJahQtGys8=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-25.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "41af03e888f43562fd7103e80bb813bae87e416d";
+  sha256 = "sha256-7235lOjmzxGod5UQEkTDvVyUV9XwFFL7VGQ4tVfa9q8=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-28.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2faff70d3d452181dee771b0c2c82cee48b33c6c";
+  sha256 = "sha256-BUCNexRuNGbWPol95Pfhjl8ywaMNxYQI67+DUOVi8VE=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-29.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fefc1e9cac3c7db40691fca3bc6c37da30bc2f0a";
+  sha256 = "sha256-gbvOc3BBJnLCsrSfCLvJBOgybybAJV30d4wqtzgESCs=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2022-12-31.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2022-12-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "9a0e658ed70b429c5fe39537620ef6f9d11d4729";
+  sha256 = "sha256-CFjEqYUmYoAqBUPOkEOnoHqLlgpDzoR3qUGag2yviLE=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2023-01-03.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2023-01-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2023-01-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "76f56534825ef6ff609684f274c5160d30911ec7";
+  sha256 = "sha256-SzfyiGYqv3N2gw1KYxmJziI02R2Aue4BQTIkELpderE=";
+}

--- a/manifests/forc-doc-0.32.2-nightly-2023-01-05.nix
+++ b/manifests/forc-doc-0.32.2-nightly-2023-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2023-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "77bb26ecd1c01328474e34f83372c8879405a98a";
+  sha256 = "sha256-faE1SJxPMv5etdYW1NNQmUG3tm/DrhjJoogc/4NC3kM=";
+}

--- a/manifests/forc-doc-0.32.2.nix
+++ b/manifests/forc-doc-0.32.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.32.2";
+  date = "2022-12-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b9996f13463c324e256014935c053c334b880ab5";
+  sha256 = "sha256-ZCAsObQ50XJnsc64XFB/6ia8fjX3vi4rHug6FuC2ySc=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-06.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5a4d064d2ad094f66836c540ab5f997592916816";
+  sha256 = "sha256-XrAtYskpxR0eG5guX+lUbVsm0FYGKovxfBdDkMDA0RA=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-07.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "536cb99af62b7f0051df750a4d6fe042f9e78a61";
+  sha256 = "sha256-SR0GSNlyFDM0vJpEHhDVkhcILY7t11gStw2XC2rpD50=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-08.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4547574777de6e8ff9befce2210fdd6bde260ad1";
+  sha256 = "sha256-CqnbrK1hPgvcvbK5diInRuB5KMjnUTPEBwlHOXKDSbs=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-10.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dcf3e32f79e42090475867fdbac81c16c72003e5";
+  sha256 = "sha256-2F2xCBs+p2wqdcbDZPO3Wybqq6RoRYqcFZaCp6x0Xj4=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-11.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f14d6ef1c99eb16196dfb3a37933556ad8b24769";
+  sha256 = "sha256-eKUdFlWV6iaxAJVATOPhcLMoZq1NTxOIlR3t2xTBNLY=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-12.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c2898502974c3a2d9e2782e904a02e42c8d5836f";
+  sha256 = "sha256-vJ3zAXBGrEe5LcSftJO4/3qu1/Fj7Pz1tyUEJOXLEWI=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-13.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d9f6f8ab2699b8370cb81e13567b7e3c3734db65";
+  sha256 = "sha256-Ly5eBmiVqKsObanzYDTJgqHf6Q/rhhjq/gzFO1XgLeA=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-14.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae";
+  sha256 = "sha256-fs9E1TUwu1xky6BIXFYNTuVmHHB3Emu56xU8fVivpwQ=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-15.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "26eeef0fc690238e90edde9e677c81c9fbbe0af0";
+  sha256 = "sha256-ntfqhRRTZV95awGBRUeRwBoKmZb1b5fXhInOgVzzqqU=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-16.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "847cbccd32ba0a1a5cc6399e837f43b9b0e4726c";
+  sha256 = "sha256-UTJq5EJ+cnNkaj4blNadmdG/NVws2YVAnXR2Ou1fnfI=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-17.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2b6f72fabb85c768e82c6c546a0a7115091e2106";
+  sha256 = "sha256-VYkteK6Mz88fKf12bRgN7+B/vCjk+bWMKM07POxsolI=";
+}

--- a/manifests/forc-doc-0.33.0-nightly-2023-01-18.nix
+++ b/manifests/forc-doc-0.33.0-nightly-2023-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "555f34e4c94c2a2ea4ac2d5226d36772577d2ea6";
+  sha256 = "sha256-6tTFXnoOb+dO7sgXoAt22vNdswJZdmu1sDRRZx1OnPw=";
+}

--- a/manifests/forc-doc-0.33.0.nix
+++ b/manifests/forc-doc-0.33.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.0";
+  date = "2023-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2b2b4b117c4f6a5e762e368af0dfc6896fa31e7d";
+  sha256 = "sha256-K/RT9WFv1uGpBbwckvhcvXPdEnNjluSd2f7CNdjeGhQ=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-19.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0c99c8adad3f7adc3eef34a587298c063cf9f228";
+  sha256 = "sha256-woM4ot15CZj4Y2iFAjFaaf/PFDoluzinuJTz0mvw/bk=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-20.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "89c45ee845962d2b407521c1079bb519e7e954ac";
+  sha256 = "sha256-2JNNjlq9jSPQV/NvgQa2ocibXYePuc8WSv3/YCRpqxg=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-21.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5968792cd7bb8e0c117ff1cc47693503b7dd731e";
+  sha256 = "sha256-WSiRTAIDlvYUjZgAefoeN6ggfzz5bb2Il3ejj2lhYJs=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-22.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1506d92775262ad973630558f66b42d57de8fe9";
+  sha256 = "sha256-X3gQ/p2MEr8KwTKMZvrrwrxXTptbR+yLTw7eG0mSwao=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-24.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3998c10760f338d7f900b0253ff27cb5b9db53e5";
+  sha256 = "sha256-v8F1Q9r1N8lu/qdlE74V/dLiA2ssrR2/R7GB9iLHQeE=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-25.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0a3beae92e6faed5e8ca35da5a8071e58f4a43d1";
+  sha256 = "sha256-9YOhtE24W14fBYmRyNMNl/ETcqr17FtjW2CuHE80jCk=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-26.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "74979e091b947ee219e5f34eafb8a60d1f2cff13";
+  sha256 = "sha256-syGOb3kja6W7E1p05bb3ll+jPRyT9kSBB0YGMTB2U8c=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-27.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "46f92f280b3289f45f3ec181af8046da329dcc89";
+  sha256 = "sha256-KofK4fpsH+ovCZzZGS+kaqWQQSxFDcty2fPywJkjFGc=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-28.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "97190861deda5958921c6cecbc81d9141179fd22";
+  sha256 = "sha256-vf7HixoPlPUOvEsPas5B9PZ2wK+4APQjV0m/HjzMRNg=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-29.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dd8b2f62442288e71153a3a701cd96491c5bcb8c";
+  sha256 = "sha256-pdjcWnsjb7HpHFRrB42kjMBBM0DmqTUBzf7rG6c9EKA=";
+}

--- a/manifests/forc-doc-0.33.1-nightly-2023-01-30.nix
+++ b/manifests/forc-doc-0.33.1-nightly-2023-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3c0c024c397a290d7576e6d6e589fbbcbc61775f";
+  sha256 = "sha256-+sR31fVHmu82PHOZDARUYEyGyJTXLwQMEsFbha6TBmY=";
+}

--- a/manifests/forc-doc-0.33.1.nix
+++ b/manifests/forc-doc-0.33.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.33.1";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "acd4c1e0fbdc406800a06c845430a80dd3560fcc";
+  sha256 = "sha256-00KVxZUcyCrE4RT2WrmHtxFFFyxLuiD6nJV9PoDzHng=";
+}

--- a/manifests/forc-doc-0.4.0.nix
+++ b/manifests/forc-doc-0.4.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.4.0";
+  date = "2022-02-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6332f9ad955e1f8e744cc87e07d028092874e0d5";
+  sha256 = "sha256-lDyAgfNC5ezqptxuM7lycuVEofI5W62hzY011MzXUt8=";
+}

--- a/manifests/forc-doc-0.5.0.nix
+++ b/manifests/forc-doc-0.5.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.5.0";
+  date = "2022-02-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5c58c09ffba1719b187a3e1112639eec649eab5e";
+  sha256 = "sha256-11OIZruYjYrylHv8zQOfLW9Fzs0p7aGOWQfq7UQN+5w=";
+}

--- a/manifests/forc-doc-0.6.0.nix
+++ b/manifests/forc-doc-0.6.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.6.0";
+  date = "2022-03-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "35e5a2f12e137953b82470e9637e4969ca064e4a";
+  sha256 = "sha256-HKmNBduWtyIoaUwkj2Nu9GznUOoZFctcaRhFJOnTWLY=";
+}

--- a/manifests/forc-doc-0.6.1.nix
+++ b/manifests/forc-doc-0.6.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.6.1";
+  date = "2022-03-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3268092ce50e5058b11a5ea2e7f35c6e19352d68";
+  sha256 = "sha256-JOH4UosK8x7FmMqx2qkEqWnyO+z9XPl1C/BrnXWz4uw=";
+}

--- a/manifests/forc-doc-0.7.0.nix
+++ b/manifests/forc-doc-0.7.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.7.0";
+  date = "2022-03-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7dd186041fbd2d4040b9a374fedc9a0cbed9eecb";
+  sha256 = "sha256-B37FgsnDop9Vyn5t7aSn2RceGG3pdLxrHUJHZ2s53d8=";
+}

--- a/manifests/forc-doc-0.8.0.nix
+++ b/manifests/forc-doc-0.8.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.8.0";
+  date = "2022-03-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "04d26d6924788875fb01fa4fe58fe969849dcfc5";
+  sha256 = "sha256-MTQlnuP9WVHL/rNHsMdmYqvIgHL5IJmIjUF9WqM55M0=";
+}

--- a/manifests/forc-doc-0.9.0.nix
+++ b/manifests/forc-doc-0.9.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.9.0";
+  date = "2022-03-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fdebe28e2803ef32238e6b39693748b6bdf6f34e";
+  sha256 = "sha256-dzEkvJ+nP6+Xzp+nVz+VKy0RmfN/UkX/JlP/0cXqaY0=";
+}

--- a/manifests/forc-doc-0.9.1.nix
+++ b/manifests/forc-doc-0.9.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.9.1";
+  date = "2022-03-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "72aa51d6da3d49b1bad2e6d6fffe6d4b3e331380";
+  sha256 = "sha256-Mu3niggbgovHWhm6GtU/hhWqANm5YWFvdsrDExUPKYc=";
+}

--- a/manifests/forc-doc-0.9.2.nix
+++ b/manifests/forc-doc-0.9.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.9.2";
+  date = "2022-03-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4905aa0b2b6cb7178d6229e7bed94c241a418c26";
+  sha256 = "sha256-C+1vF48WryCdT2X09E8RwcY8LRHxGX3ncRkc2MtNnY4=";
+}

--- a/manifests/forc-tx-0.0.1.nix
+++ b/manifests/forc-tx-0.0.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.0.1";
+  date = "2021-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c9781a1acca6eea8a1f2f30607466ae40d76de65";
+  sha256 = "sha256-g6pSdahytTJQJ1rgLCku4289C2dnCLqzvSH8Mq8y26I=";
+}

--- a/manifests/forc-tx-0.0.2.nix
+++ b/manifests/forc-tx-0.0.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.0.2";
+  date = "2021-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0c043bc9463eb266aaf111ff86b8c911602e053";
+  sha256 = "sha256-LwGYEtKpb5eEts1K0TkRPwlWPu7EQLJbtaK8dAFexTk=";
+}

--- a/manifests/forc-tx-0.0.3.nix
+++ b/manifests/forc-tx-0.0.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.0.3";
+  date = "2021-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ce7692d119fa9010dd0937b5f10cf5728fe72393";
+  sha256 = "sha256-ygyqjapnGH+tznuYu5x9vnvhfHaoQ82vlyi90s/ZTCU=";
+}

--- a/manifests/forc-tx-0.0.4.nix
+++ b/manifests/forc-tx-0.0.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.0.4";
+  date = "2021-11-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d40239e7d49793c7d3d23e0d3de6595e40b89e11";
+  sha256 = "sha256-Udtk0i4LfiXYMWLZtRiDbjXseqiTs83BJgqHaMvJGLA=";
+}

--- a/manifests/forc-tx-0.1.0.nix
+++ b/manifests/forc-tx-0.1.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.0";
+  date = "2021-12-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "90c9b56a7fc313321fcc7580314284080d00078f";
+  sha256 = "sha256-5VgXmm63O89wp6mayRf6ihMiK/JrXECfkmpo17MPEk4=";
+}

--- a/manifests/forc-tx-0.1.1.nix
+++ b/manifests/forc-tx-0.1.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.1";
+  date = "2021-12-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a37329cb1848efdeb46e2be1bfdb940b7750262";
+  sha256 = "sha256-Ci4OJGp+iqmojxmf4Cg9m/2WG8jtKOPMDr2z6LDsOdU=";
+}

--- a/manifests/forc-tx-0.1.2.nix
+++ b/manifests/forc-tx-0.1.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.2";
+  date = "2021-12-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2431af753ed8fc0a76df53fc72172cb4bdb5d4b9";
+  sha256 = "sha256-FYwNTSaaZdtDGbOQ5/Tk4+lvyZ3PCJBtnNLE6+PuEng=";
+}

--- a/manifests/forc-tx-0.1.3.nix
+++ b/manifests/forc-tx-0.1.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.3";
+  date = "2021-12-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d30d3225a30c46a9675ca5db270597190cc228bc";
+  sha256 = "sha256-3kvkiTVQ5qSLqBPb3kl2VakJfQlCOYaTY9aonRgN6AY=";
+}

--- a/manifests/forc-tx-0.1.4.nix
+++ b/manifests/forc-tx-0.1.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.4";
+  date = "2021-12-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "46305882aa552be287b28e55606ba74b81070460";
+  sha256 = "sha256-/sFiQmmk/L+qqK9J/BrhPahg0no7YculAbB+TyB9s+Y=";
+}

--- a/manifests/forc-tx-0.1.5.nix
+++ b/manifests/forc-tx-0.1.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.5";
+  date = "2021-12-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1923f44784e6d450796b10addd447aeb3325d519";
+  sha256 = "sha256-X/c/HRNrZu3s/wKU2l9pkuuXpqPFZvqeeziW/9iloK4=";
+}

--- a/manifests/forc-tx-0.1.6.nix
+++ b/manifests/forc-tx-0.1.6.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.6";
+  date = "2021-12-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a38a89a042f7ef13ddf67cc7661b37eac96aad8f";
+  sha256 = "sha256-6HM7WTQsYaOXSvu8Jr0lh6KDQFpFJI+XybvzU8jFEic=";
+}

--- a/manifests/forc-tx-0.1.7.nix
+++ b/manifests/forc-tx-0.1.7.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.7";
+  date = "2021-12-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4038415bf9f681fca220bcf3951230b0e9129ba6";
+  sha256 = "sha256-gcKYLveFcyiZtPxGjtk8W9dYCVdVUSsUMTW071WavX0=";
+}

--- a/manifests/forc-tx-0.1.8.nix
+++ b/manifests/forc-tx-0.1.8.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.8";
+  date = "2021-12-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6fd0bc0b6ecf22f3b334a0c8da86e776a7e2b87d";
+  sha256 = "sha256-2M3FGiWEq++cQIkxECjSHabbVuMTkuvCx0eFIuOSeU0=";
+}

--- a/manifests/forc-tx-0.1.9.nix
+++ b/manifests/forc-tx-0.1.9.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.1.9";
+  date = "2021-12-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6fe6354eb96fa9b85c10e89f628bdf7ee525059d";
+  sha256 = "sha256-Bwn4w93PqCxMquIz52cWQ3u0xtZCXf5TzkKzQvnV15M=";
+}

--- a/manifests/forc-tx-0.10.0.nix
+++ b/manifests/forc-tx-0.10.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.10.0";
+  date = "2022-04-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a88ea439c95d9fb2701d6479ce496dc6571e92c2";
+  sha256 = "sha256-YdU+xBfyQ6M4UVl/bgp5ba0byVUY7BMwryIZnradFNs=";
+}

--- a/manifests/forc-tx-0.10.1.nix
+++ b/manifests/forc-tx-0.10.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.10.1";
+  date = "2022-04-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5c85d2b712975669d238233297443557969dec43";
+  sha256 = "sha256-8ocDTtJL468H3PpkQu5b9+lZtfjFP3MDK8YE2LtPYy4=";
+}

--- a/manifests/forc-tx-0.10.2.nix
+++ b/manifests/forc-tx-0.10.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.10.2";
+  date = "2022-04-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "443abbffd520f0f964e837fbc784641741fd7950";
+  sha256 = "sha256-qnU5g9Oxusr67zIIei9cAUqT7VVkA2VDXbarM1abOgc=";
+}

--- a/manifests/forc-tx-0.10.3.nix
+++ b/manifests/forc-tx-0.10.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.10.3";
+  date = "2022-04-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7676db6f4ebc7a3885f87514d16a703a99410d7";
+  sha256 = "sha256-/pWNhRZm+ev48LgpQhjGWuXG2TLvZSTpPHsZPLHcMiw=";
+}

--- a/manifests/forc-tx-0.11.0.nix
+++ b/manifests/forc-tx-0.11.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.11.0";
+  date = "2022-04-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "95816e4e41aae1d3425ba6ff5e7266076d8400fa";
+  sha256 = "sha256-2XvtFdkQwUVlUVSjQeTUHlEROQ8r1GOcG8uCPM3uDTc=";
+}

--- a/manifests/forc-tx-0.12.1.nix
+++ b/manifests/forc-tx-0.12.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.12.1";
+  date = "2022-05-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a03a5d1c068a91779e5ce08eead6c4626de2eb0d";
+  sha256 = "sha256-nE10IRpnOkNHXfLfYhFhucjJ3JgdPW6AuNneLL14ymI=";
+}

--- a/manifests/forc-tx-0.12.2.nix
+++ b/manifests/forc-tx-0.12.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.12.2";
+  date = "2022-05-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2b6e9384f06692ec627293ae5db5e2f748fe2c30";
+  sha256 = "sha256-HTo5eP8jZP5tzesGGA1i5YUmofsWxFJGKw0oMfvWv0c=";
+}

--- a/manifests/forc-tx-0.13.0.nix
+++ b/manifests/forc-tx-0.13.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.13.0";
+  date = "2022-05-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6eef7ab750cd3282f08b6014960cbc02afae717a";
+  sha256 = "sha256-iT90TBcMgmKTl/2MHR37Vtk7LcOshVMSshlU3BLhAG0=";
+}

--- a/manifests/forc-tx-0.13.1.nix
+++ b/manifests/forc-tx-0.13.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.13.1";
+  date = "2022-05-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d73d9d2b4b547e2035ddfe085d439de56ccee1f0";
+  sha256 = "sha256-jbuvLymTQb8g4ERJeu0K24z2OIw8aDlkBPF+YjiUkIE=";
+}

--- a/manifests/forc-tx-0.13.2.nix
+++ b/manifests/forc-tx-0.13.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.13.2";
+  date = "2022-05-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dac1b96419a6ed46a4c531492ae5e794a270d4a1";
+  sha256 = "sha256-LBuJ2ukkK1FosaLcZ10ds8/7ybN1UU/o0d9dRmbG5a4=";
+}

--- a/manifests/forc-tx-0.14.0.nix
+++ b/manifests/forc-tx-0.14.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.14.0";
+  date = "2022-05-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "953dad9cad0defe50ffe04e4031207fd247b63f1";
+  sha256 = "sha256-/z+nNctB9t1qLKiemsg+QuV2jBnuYgd0tCe3cEkI1OU=";
+}

--- a/manifests/forc-tx-0.14.1.nix
+++ b/manifests/forc-tx-0.14.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.14.1";
+  date = "2022-05-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "02ef7d10b6bf883d73fc1fd23034dc814dfffea2";
+  sha256 = "sha256-8Uh2gbZb1R1llk3h+DeCF3heBO2Ec3nJNqI6hpSTfq8=";
+}

--- a/manifests/forc-tx-0.14.2.nix
+++ b/manifests/forc-tx-0.14.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.14.2";
+  date = "2022-05-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6fc5c69f29a5aab0b6ca677d9384d0d5eaffb232";
+  sha256 = "sha256-JGicorHY6HfSWoZa2nFOnx45qDrnXmORzHOOKHk/6sM=";
+}

--- a/manifests/forc-tx-0.14.3.nix
+++ b/manifests/forc-tx-0.14.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.14.3";
+  date = "2022-05-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "17f856bfa0d500e06fff2c470e8e6113533faf97";
+  sha256 = "sha256-VfyRHFmz89GT7UP/JCR8lPZY5vxhfxnyyWheQdWSRn0=";
+}

--- a/manifests/forc-tx-0.14.4.nix
+++ b/manifests/forc-tx-0.14.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.14.4";
+  date = "2022-05-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b067a7dd64b26bd763eca268fef3849c2c77028d";
+  sha256 = "sha256-VJGi0FlI+majMW66lo4Sxyo9NaaO+LgFyg7hHwckD1k=";
+}

--- a/manifests/forc-tx-0.14.5.nix
+++ b/manifests/forc-tx-0.14.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.14.5";
+  date = "2022-06-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "60c626cf486d5c53c44d84db1ec81cb90174cad3";
+  sha256 = "sha256-3zI62Q+jaZYml3PjHn5Xsx635ARfUPsXBpOGDc0QzVM=";
+}

--- a/manifests/forc-tx-0.15.0.nix
+++ b/manifests/forc-tx-0.15.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.15.0";
+  date = "2022-06-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ee7822c411a3d6135ea590bbc5c85527c4ede6d7";
+  sha256 = "sha256-7qdjLcxcKCHt+RNrVU9WRK+DUepB0G/5RkScHHWRFJQ=";
+}

--- a/manifests/forc-tx-0.15.1.nix
+++ b/manifests/forc-tx-0.15.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.15.1";
+  date = "2022-06-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a34b4b99fcdd065d559f6cbb9dec0697c3f5edd1";
+  sha256 = "sha256-kR1NJqI6fOyDne1zvwIG2M92+dSOn+6Hby+Q4iMJAAQ=";
+}

--- a/manifests/forc-tx-0.15.2.nix
+++ b/manifests/forc-tx-0.15.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.15.2";
+  date = "2022-06-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "eab07e48bc6dbd0c80aedc1e363bb63a6d5f0e28";
+  sha256 = "sha256-vE29EiJYF4T6FW/1odNJyZOc5HKHR5sC10bASSFcmuc=";
+}

--- a/manifests/forc-tx-0.16.0.nix
+++ b/manifests/forc-tx-0.16.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.16.0";
+  date = "2022-06-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "948f7aba42b4138433fb5b61c698c8f4a60db424";
+  sha256 = "sha256-5yPftMl1LJkub2yeGHF1BrLZZSYzg82IYFVpVWG0v48=";
+}

--- a/manifests/forc-tx-0.16.1.nix
+++ b/manifests/forc-tx-0.16.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.16.1";
+  date = "2022-06-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dcf22453aeb054335d96ef810da9d4f756d869b7";
+  sha256 = "sha256-kAZVbgkf7ganCs+sBPL0eMmR3MDCm6s+qL8d1CfHL8U=";
+}

--- a/manifests/forc-tx-0.16.2.nix
+++ b/manifests/forc-tx-0.16.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.16.2";
+  date = "2022-06-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7920330d34c97cf418b6d0e1561f978068158228";
+  sha256 = "sha256-NpCpZYxgJeUcgw5QqnAhzVmEkMrR7cs2Sj6aW6Rm6JU=";
+}

--- a/manifests/forc-tx-0.17.0.nix
+++ b/manifests/forc-tx-0.17.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.17.0";
+  date = "2022-07-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b81bcd9652d4fc9908d1971c9215a7cfdde39adc";
+  sha256 = "sha256-cOyJXvwyZbZeTLfw9xoAtY1rsHN29VXLkRsEeCZyDmI=";
+}

--- a/manifests/forc-tx-0.18.0.nix
+++ b/manifests/forc-tx-0.18.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.18.0";
+  date = "2022-07-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada0d294a68e5ca3070e3c46eb89619e7d87caf2";
+  sha256 = "sha256-9a39KoLnQ7urf7pBwxFy8B2+SELuhhx6JDZjyZo2rSQ=";
+}

--- a/manifests/forc-tx-0.18.1.nix
+++ b/manifests/forc-tx-0.18.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.18.1";
+  date = "2022-07-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3bd8eaf4a0f11a3009c9421100cc06c2e897b6c2";
+  sha256 = "sha256-WI7srBdT5WAMZ6OfUWAcihZcpxbn/ogfVE3LaoQptcM=";
+}

--- a/manifests/forc-tx-0.19.0.nix
+++ b/manifests/forc-tx-0.19.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.19.0";
+  date = "2022-07-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5c716e1ba55d755555ed5aa186c883f73c4f90dc";
+  sha256 = "sha256-DKB7ykAHVte8Dt566iNdY6CIkvs06zRxCWT50LoQRBk=";
+}

--- a/manifests/forc-tx-0.19.1.nix
+++ b/manifests/forc-tx-0.19.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.19.1";
+  date = "2022-08-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1202e790c119ff9f04c847ecaab3411cfaf32f94";
+  sha256 = "sha256-jFtMg6C861fIWZBmX5SbSsvQwPUr+KWQOcQnPDweWUo=";
+}

--- a/manifests/forc-tx-0.19.2.nix
+++ b/manifests/forc-tx-0.19.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.19.2";
+  date = "2022-08-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6808861389966f99887f71476918a562a9edd90e";
+  sha256 = "sha256-LL5jMwMvw//bN8SkI5K/tNF+7NKuuOXpcMGezEmrQ4g=";
+}

--- a/manifests/forc-tx-0.2.0.nix
+++ b/manifests/forc-tx-0.2.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.2.0";
+  date = "2022-01-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "38479274e0c50518e20c919682b8173ae4a555d3";
+  sha256 = "sha256-48BfRiY2evrKlcz1bXBWoWQgRtkk4jc2r3GZRj28sPo=";
+}

--- a/manifests/forc-tx-0.2.1.nix
+++ b/manifests/forc-tx-0.2.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.2.1";
+  date = "2022-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a790fd729b2021f837be924c7b8b21099b9f6c12";
+  sha256 = "sha256-TUQQa1uE9JuZzEnXxrOAeBplNkzt9MRWzPjxZdECZg8=";
+}

--- a/manifests/forc-tx-0.20.0.nix
+++ b/manifests/forc-tx-0.20.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.20.0";
+  date = "2022-08-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fc3a05d87d1178e937fc5e4742b13fcca490057d";
+  sha256 = "sha256-gJaLWboU9LNEn9Xu+0AIveFvG3wCTMH1P95H+DVJCRw=";
+}

--- a/manifests/forc-tx-0.20.1.nix
+++ b/manifests/forc-tx-0.20.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.20.1";
+  date = "2022-08-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "21887f4b321bfacb16c7a6602071e3b6ea1c8df1";
+  sha256 = "sha256-mO7vojv7gEfBJaEmBW2uQTo1ecLNoTL6E1o1d68saBQ=";
+}

--- a/manifests/forc-tx-0.20.2.nix
+++ b/manifests/forc-tx-0.20.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.20.2";
+  date = "2022-08-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6a8116fcee71aa960217b1672bac0c35d1fce42c";
+  sha256 = "sha256-JfjHda4vRGPiZ2EhJbGMzpSJ24bFFS3WlPxtXmI3mno=";
+}

--- a/manifests/forc-tx-0.21.0-nightly-2022-09-01.nix
+++ b/manifests/forc-tx-0.21.0-nightly-2022-09-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.21.0";
+  date = "2022-09-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "11fd90a14d48ab363a297cec267b3f91327502f5";
+  sha256 = "sha256-B7ExtUjq1hgmXlqjvQSyFFeOC94j5ODYt29OtOcAsEk=";
+}

--- a/manifests/forc-tx-0.21.0.nix
+++ b/manifests/forc-tx-0.21.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.21.0";
+  date = "2022-08-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "32b5b142b54d3d38ae1f7df69f465138e86de82d";
+  sha256 = "sha256-joWJifoFBzzK9FdhQwyYwVuDU4/8hQzmrUgD7+2BSJY=";
+}

--- a/manifests/forc-tx-0.22.0.nix
+++ b/manifests/forc-tx-0.22.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.22.0";
+  date = "2022-08-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6e1fbca21f0979d226efd7ceea5b6d71696536cd";
+  sha256 = "sha256-cK7YReHEq3Z/wVV6bxTohdHI9c2zSz53Sej8GCWSIrI=";
+}

--- a/manifests/forc-tx-0.22.1-nightly-2022-09-02.nix
+++ b/manifests/forc-tx-0.22.1-nightly-2022-09-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.22.1";
+  date = "2022-09-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ecf537a5c892ddab7997a34d9a128007cfdd91fc";
+  sha256 = "sha256-BuKsDcrqSOE41InAcyFBqR02m6iEjb9cr7J3omF6Hao=";
+}

--- a/manifests/forc-tx-0.22.1-nightly-2022-09-03.nix
+++ b/manifests/forc-tx-0.22.1-nightly-2022-09-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.22.1";
+  date = "2022-09-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b696495c8fb9b207626a3dafbee0550407198d12";
+  sha256 = "sha256-2X0wu0De384uIBy5KxiR/lbD9bzGYKmdBqnhWpDzCt0=";
+}

--- a/manifests/forc-tx-0.22.1.nix
+++ b/manifests/forc-tx-0.22.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.22.1";
+  date = "2022-08-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c486eabc3ed4d8c53b63735188f2c1db5d17703c";
+  sha256 = "sha256-fChGs4bPxg82noIJooec6Tk908T8BrDUWH6YQNvAuhg=";
+}

--- a/manifests/forc-tx-0.23.0-nightly-2022-09-04.nix
+++ b/manifests/forc-tx-0.23.0-nightly-2022-09-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.23.0";
+  date = "2022-09-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4712e5b26c6c0f778d7771ef1b35a229fe3a371d";
+  sha256 = "sha256-ZdH69u5DOe/fjARXWpJe0J21K/rVL4YJD5/qHQdlr50=";
+}

--- a/manifests/forc-tx-0.23.0-nightly-2022-09-05.nix
+++ b/manifests/forc-tx-0.23.0-nightly-2022-09-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.23.0";
+  date = "2022-09-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "36aa76d3e1572d2d3054483be59345797ce04b36";
+  sha256 = "sha256-A4NYsyilLbJeqGkOtR67wrIUEWsqwtW4RsY4asNXScM=";
+}

--- a/manifests/forc-tx-0.23.0-nightly-2022-09-06.nix
+++ b/manifests/forc-tx-0.23.0-nightly-2022-09-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.23.0";
+  date = "2022-09-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a989e6ca0caf6ace4630cd72a2ff8c875c141a43";
+  sha256 = "sha256-5xMmLJ0aMfPJwfscUtVH88pOLTsnCeX2yW0VGGVwYyM=";
+}

--- a/manifests/forc-tx-0.23.0.nix
+++ b/manifests/forc-tx-0.23.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.23.0";
+  date = "2022-09-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4712e5b26c6c0f778d7771ef1b35a229fe3a371d";
+  sha256 = "sha256-ZdH69u5DOe/fjARXWpJe0J21K/rVL4YJD5/qHQdlr50=";
+}

--- a/manifests/forc-tx-0.24.0-nightly-2022-09-07.nix
+++ b/manifests/forc-tx-0.24.0-nightly-2022-09-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.0";
+  date = "2022-09-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8200174bb35f2dc7131238b2930130a5b4ec7c1c";
+  sha256 = "sha256-Tgo+l8EhUnxzVmMnDHylk62p62W8rW0062I7alLTdoY=";
+}

--- a/manifests/forc-tx-0.24.0.nix
+++ b/manifests/forc-tx-0.24.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.0";
+  date = "2022-09-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ea4f1b7885248c2b4c4d0da394c2cc50ea1583e8";
+  sha256 = "sha256-2DwlfRw+aw9g4E2wPeomlGH/qe6O0kKha3Vu3+HY4AI=";
+}

--- a/manifests/forc-tx-0.24.1-nightly-2022-09-08.nix
+++ b/manifests/forc-tx-0.24.1-nightly-2022-09-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.1";
+  date = "2022-09-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "54e1a340e6c0c9a675e8a66aab03f579d5d6b39b";
+  sha256 = "sha256-t/VFaYCANGY5CM2FFrLhNiBB5eAL/CFCZvIzigr3d1I=";
+}

--- a/manifests/forc-tx-0.24.1-nightly-2022-09-09.nix
+++ b/manifests/forc-tx-0.24.1-nightly-2022-09-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.1";
+  date = "2022-09-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "095bfe030934f31ea85c7c85e3f0e47dc51c11bd";
+  sha256 = "sha256-U04I1XLtQlaOIjJrwcndkXCNp8m6RINumrhhtuQpLZ8=";
+}

--- a/manifests/forc-tx-0.24.1.nix
+++ b/manifests/forc-tx-0.24.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.1";
+  date = "2022-09-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "54e1a340e6c0c9a675e8a66aab03f579d5d6b39b";
+  sha256 = "sha256-t/VFaYCANGY5CM2FFrLhNiBB5eAL/CFCZvIzigr3d1I=";
+}

--- a/manifests/forc-tx-0.24.2-nightly-2022-09-10.nix
+++ b/manifests/forc-tx-0.24.2-nightly-2022-09-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.2";
+  date = "2022-09-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "719dca1bd0ec8cc58e651d7327fb0e16276eb69e";
+  sha256 = "sha256-iGn796XsI8yEZi6dJNAdfvekDr97DOq03DOOVUvFCi0=";
+}

--- a/manifests/forc-tx-0.24.2.nix
+++ b/manifests/forc-tx-0.24.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.2";
+  date = "2022-09-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "057e83aee87d17c3812f223f5fc7884cf6d3468a";
+  sha256 = "sha256-XQePJ7tvPqjAAnqdpavkUxuCtH8MmaiXSDrhIUpjVQo=";
+}

--- a/manifests/forc-tx-0.24.3-nightly-2022-09-13.nix
+++ b/manifests/forc-tx-0.24.3-nightly-2022-09-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.3";
+  date = "2022-09-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "9aeb723b732741e1211c4fb78195f2e60d262f42";
+  sha256 = "sha256-ylhVuNFQ6ckZlRl3cBrAc7AWCSX68Ar1wUAfN2JQENw=";
+}

--- a/manifests/forc-tx-0.24.3-nightly-2022-09-15.nix
+++ b/manifests/forc-tx-0.24.3-nightly-2022-09-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.3";
+  date = "2022-09-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0b69f4d4920febbbe3149efe2aa520d57b0ffdbc";
+  sha256 = "sha256-oMFE41zjmnoPCulMvEf8ZK/vcteVQecSbwv9gRXSIps=";
+}

--- a/manifests/forc-tx-0.24.3-nightly-2022-09-16.nix
+++ b/manifests/forc-tx-0.24.3-nightly-2022-09-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.3";
+  date = "2022-09-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "68351a542386c41892064e86b3eca857f414c8ce";
+  sha256 = "sha256-6Qgz0X+jo07Ee3UzCvRW0yrS11nIGuhpjnQymXWo520=";
+}

--- a/manifests/forc-tx-0.24.3.nix
+++ b/manifests/forc-tx-0.24.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.3";
+  date = "2022-09-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "95cd150cacef407a1f30c89899c539b0d57f099d";
+  sha256 = "sha256-oWQpD2HohdjQ0lcnOjipT0oTIX68KnoWy13FeXYKi7E=";
+}

--- a/manifests/forc-tx-0.24.4-nightly-2022-09-17.nix
+++ b/manifests/forc-tx-0.24.4-nightly-2022-09-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.4";
+  date = "2022-09-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5c5399ebe258c5cb3f7c1962fbbe42a3e063e3e4";
+  sha256 = "sha256-NM1Yc9xTnaTbz/pj4wbJR4YnJt/x3u1RFW3G8nsIOs8=";
+}

--- a/manifests/forc-tx-0.24.4-nightly-2022-09-18.nix
+++ b/manifests/forc-tx-0.24.4-nightly-2022-09-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.4";
+  date = "2022-09-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "df9d5c031ddee0ca8b05eddbcf274aac14c0589e";
+  sha256 = "sha256-2JxH1LA/Qe97MZj5lmK1mjxPQpvImgiRJc3A8+KHrDQ=";
+}

--- a/manifests/forc-tx-0.24.4-nightly-2022-09-20.nix
+++ b/manifests/forc-tx-0.24.4-nightly-2022-09-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.4";
+  date = "2022-09-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "315cae6fd111d3c3cb61b2ecd37085372e690475";
+  sha256 = "sha256-HxWKV/dFuAwBb+qy2jhgkS2w9mPNRiF9VWN3nAstfTA=";
+}

--- a/manifests/forc-tx-0.24.4-nightly-2022-09-21.nix
+++ b/manifests/forc-tx-0.24.4-nightly-2022-09-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.4";
+  date = "2022-09-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "17d61c9ff348e812d2f25122836b173c7c350927";
+  sha256 = "sha256-QCOL2/eCWF6OylH+WxvXlitrR6eY2Qe/iveKDXqjui4=";
+}

--- a/manifests/forc-tx-0.24.4-nightly-2022-09-22.nix
+++ b/manifests/forc-tx-0.24.4-nightly-2022-09-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.4";
+  date = "2022-09-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a324023d4c1e0047618dcdaad486061e34920f64";
+  sha256 = "sha256-LJLH7ezwX6kp+4bH9FHbPby733DLkR0/m8vOjkQwxds=";
+}

--- a/manifests/forc-tx-0.24.4-nightly-2022-09-23.nix
+++ b/manifests/forc-tx-0.24.4-nightly-2022-09-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.4";
+  date = "2022-09-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "56dc0f4105a456ae1311405368c57a3caab3490e";
+  sha256 = "sha256-wfl9MD5qnXCeotcIZ/THA67vzE3Ob0aGqc8GPOtLYlw=";
+}

--- a/manifests/forc-tx-0.24.4-nightly-2022-09-24.nix
+++ b/manifests/forc-tx-0.24.4-nightly-2022-09-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.4";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7d000fff4dc27c2ce0ca779a6e204fb0d4e720c";
+  sha256 = "sha256-qtbxzFic0c9x6fbu4t8hdDkKXP9QTF5QcY9hZ+8qYv0=";
+}

--- a/manifests/forc-tx-0.24.4.nix
+++ b/manifests/forc-tx-0.24.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.4";
+  date = "2022-09-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f7800e18979dd8e4c8d672b8e7aae1758c2edb88";
+  sha256 = "sha256-jRqUQv7nsv0xq+CNrEYCnt0yfiVycTUF3eYOMt/DCdQ=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-09-25.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-09-27.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-09-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-09-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "535174be2759db62d0838957cf4f89f2c9d8ec71";
+  sha256 = "sha256-nqO6tKI6liTYLXHVIyImfFWeBmu2Z70jEMGAjT7WAic=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-09-28.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5e543382e00a843adb2f64d03eea8576e4c1d53";
+  sha256 = "sha256-nm4FY6pisendzf+hgCm9zDieqVAyRtDNDXjZca79brM=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-09-29.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e6afd8987ead0d453efb5f35e29ce7ba1a0cd070";
+  sha256 = "sha256-Xo8OXRT9UtkEvZvbMAteolHsPKjtx7kl9CZaCuGhV/w=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-09-30.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-09-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-09-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "076e95fcdb9efc4052dec827418274681d26b00e";
+  sha256 = "sha256-89ZfhctqiTKbwCEz03r9A1AYJ/l+UHsKdCt5mnl6WvM=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-10-01.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e15d71c176359844341e2621a0431f58dfd13c2e";
+  sha256 = "sha256-IAkBhCN7hPGVTBHquhAt0+nEB+0yLM6smnc8pghO/wA=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-10-02.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7b9a022df54ed75832d93833587855af0d08fa";
+  sha256 = "sha256-GJzUqffmvc1CH5K9TeAHvwLs6FyA6/2YSg1RUnpgYio=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-10-03.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-10-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-10-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe47d44458c1433140afd30a304e2723d1805b5";
+  sha256 = "sha256-sBYTj7BwGyvdw4FTQt331Y/I7XrZVTgrTJIJ/FgPc70=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-10-04.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-10-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-10-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a917c66ff1d402c7350664c648e8704b50085281";
+  sha256 = "sha256-jCHeqg6SIP8fnAHm3ZeQt9CdEDz1Cr81NcapE4jQx70=";
+}

--- a/manifests/forc-tx-0.24.5-nightly-2022-10-05.nix
+++ b/manifests/forc-tx-0.24.5-nightly-2022-10-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8a8f0c39d0bb3e0424a5cdabf0b625b73c90667c";
+  sha256 = "sha256-8Y1IUqYWk29szUFWBwrk4fGDRvIKcC9XY2Zu/h89Jng=";
+}

--- a/manifests/forc-tx-0.24.5.nix
+++ b/manifests/forc-tx-0.24.5.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.24.5";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e695606d8884a18664f6231681333a784e623bc9";
+  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
+}

--- a/manifests/forc-tx-0.25.0-nightly-2022-10-06.nix
+++ b/manifests/forc-tx-0.25.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-tx-0.25.0.nix
+++ b/manifests/forc-tx-0.25.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.0";
+  date = "2022-10-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
+  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
+}

--- a/manifests/forc-tx-0.25.1-nightly-2022-10-07.nix
+++ b/manifests/forc-tx-0.25.1-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.1";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4740fb2f9b9c4c4d6e8ba2110831604b40ccc645";
+  sha256 = "sha256-czP0vMoQE3ZjXFcLHNRKntBkbpJb7yPaMsIwxny+xPM=";
+}

--- a/manifests/forc-tx-0.25.1.nix
+++ b/manifests/forc-tx-0.25.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.1";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
+  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
+}

--- a/manifests/forc-tx-0.25.2-nightly-2022-10-08.nix
+++ b/manifests/forc-tx-0.25.2-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.2";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e8a28b5867234a6391bf99ddc55db41957096480";
+  sha256 = "sha256-pw0Zs2LX5D6kyScWDuOz3dobkhRQ5DgySirK4Tj+fBU=";
+}

--- a/manifests/forc-tx-0.25.2-nightly-2022-10-09.nix
+++ b/manifests/forc-tx-0.25.2-nightly-2022-10-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.2";
+  date = "2022-10-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "61d6d659b22c25a606f1437a122176474293180d";
+  sha256 = "sha256-Ch+iPSPFlnzL9JlZXPHhr7fWTJqNIAP0TfKdyQieQ0M=";
+}

--- a/manifests/forc-tx-0.25.2-nightly-2022-10-10.nix
+++ b/manifests/forc-tx-0.25.2-nightly-2022-10-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.2";
+  date = "2022-10-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "71999d3774ec617e4b1167d891cadb1e6e9f38af";
+  sha256 = "sha256-jVrjARMBQSgfBJTSfL9xUBB0NjjbSAX0m7uaROG5urA=";
+}

--- a/manifests/forc-tx-0.25.2-nightly-2022-10-11.nix
+++ b/manifests/forc-tx-0.25.2-nightly-2022-10-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.2";
+  date = "2022-10-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb0a5be05549a7a01df684380eaf0c2ec7f46241";
+  sha256 = "sha256-EUmVdkCM6EIL/imd6Xn4/cGp2RyRDcjJ6QjI7BjQNVI=";
+}

--- a/manifests/forc-tx-0.25.2-nightly-2022-10-12.nix
+++ b/manifests/forc-tx-0.25.2-nightly-2022-10-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.2";
+  date = "2022-10-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6f7554760ba1cde24db5075183ddc9c3f1359066";
+  sha256 = "sha256-uycMRo7+vIkHKQdcCpxh+eGdpBnuq1b674Aw6TXYgU8=";
+}

--- a/manifests/forc-tx-0.25.2-nightly-2022-10-13.nix
+++ b/manifests/forc-tx-0.25.2-nightly-2022-10-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.2";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "205073dc30db355f065c29db41d591bfc166f3fa";
+  sha256 = "sha256-c3eAp7XB0ziwC4NLCyQeHgflBuwftCv+gy0P/RwJID0=";
+}

--- a/manifests/forc-tx-0.25.2.nix
+++ b/manifests/forc-tx-0.25.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.25.2";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
+  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-14.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-15.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a9eaef219282566e99d57ff993c613317a9143a9";
+  sha256 = "sha256-noZchaj5q6Y5rp1t6VOfmV96ggJZDNdNMtEmdsbK0cg=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-16.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a1d40f58883e3fe8d23140fbf922d263f17b7c20";
+  sha256 = "sha256-3WPBVNfM/lkyA44mVqqR05t0pBfgI5vnBIOGJSMfeW8=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-17.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "314648f8448cefad534f129431ebd15f06e8b418";
+  sha256 = "sha256-zXLLLvftB+aTX4ZFbjfQ/1YLBLCX70ASZ8U6Z1ppXH8=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-18.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dbd6b9211fd3c4ceeb34b3f6aedb0a7b9f0e6ef8";
+  sha256 = "sha256-Qhf/QDTkb68kX4feeTtdMjSTt34xKhNeRAlhgxGF6wU=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-19.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a2395b4c99c299cf246f1b1ef59785345c94641e";
+  sha256 = "sha256-GvqPVs1EtRuygKA8kEdZyImxlM835AVMKgK74rnX2wk=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-21.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0e84d98a06d32a036d88198505e0d6868c985f25";
+  sha256 = "sha256-38yHKfdmro4oDIYQy2HiSgTP3w4soKLiLPRJBUWa4Pg=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-22.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "aaf7c8833ed3f5949dc501c741014b640b426889";
+  sha256 = "sha256-3n0ewjyJl6HVS++MDTBgtUMMoJt6KhFb2iypBJDm7xw=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-23.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ef8088ab8282a14579bde6af7fec9314435b4a9d";
+  sha256 = "sha256-DpoMWFk+Jhou3I6khR77I5X0Zmt+bxq94XgtvSLHWmo=";
+}

--- a/manifests/forc-tx-0.26.0-nightly-2022-10-24.nix
+++ b/manifests/forc-tx-0.26.0-nightly-2022-10-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3270118703b3516bffc1b2ae6f99c11aed7b1130";
+  sha256 = "sha256-Y8cJ8RYDjkVFGqJ++ZNNehS4QESC/cpqLI8N1bkjwc4=";
+}

--- a/manifests/forc-tx-0.26.0.nix
+++ b/manifests/forc-tx-0.26.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.26.0";
+  date = "2022-10-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
+  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
+}

--- a/manifests/forc-tx-0.27.0-nightly-2022-10-25.nix
+++ b/manifests/forc-tx-0.27.0-nightly-2022-10-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.27.0";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8ae44c2ea0eb154f77e769ef3f69d7f1ab0116b9";
+  sha256 = "sha256-5yuILUm2XiRpou8bTKdfyXOYGkoKpxJ/YhsqXyJPtlk=";
+}

--- a/manifests/forc-tx-0.27.0.nix
+++ b/manifests/forc-tx-0.27.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.27.0";
+  date = "2022-10-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "40f1e79de08af109f2ebb066f51704f36094ed1e";
+  sha256 = "sha256-qIso6YBCs4HKu1fAqM0fgq0vcaOqgGeZ2CY0ZLjTm+o=";
+}

--- a/manifests/forc-tx-0.28.0.nix
+++ b/manifests/forc-tx-0.28.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.28.0";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a7978381effcf999adc5726587bf8f711f04e414";
+  sha256 = "sha256-3xqbdGXjWIfdZV7po64bp+N79MGfEkL0fRyKcel0A2s=";
+}

--- a/manifests/forc-tx-0.28.1-nightly-2022-10-26.nix
+++ b/manifests/forc-tx-0.28.1-nightly-2022-10-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.28.1";
+  date = "2022-10-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "203b59053c713574007a94663923411f18c501ef";
+  sha256 = "sha256-bnVLOvj+NkTapIe47m3zLcZsLuBHQ3thSzUkiuHUddc=";
+}

--- a/manifests/forc-tx-0.28.1-nightly-2022-10-27.nix
+++ b/manifests/forc-tx-0.28.1-nightly-2022-10-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.28.1";
+  date = "2022-10-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "18a9eb235a8d8255cf90faa25989a563ccf99d12";
+  sha256 = "sha256-7QTYA/vscSnJfGfaiKd/KfxvtG0ny0r8It8lqaJHtoM=";
+}

--- a/manifests/forc-tx-0.28.1-nightly-2022-10-28.nix
+++ b/manifests/forc-tx-0.28.1-nightly-2022-10-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.28.1";
+  date = "2022-10-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c0880ebce66b625352222cd737361e9574c6681c";
+  sha256 = "sha256-UXM7jrrVSKj+h5UDo3hG7iBsEaFRGs0Kv/hBFneYkr8=";
+}

--- a/manifests/forc-tx-0.28.1-nightly-2022-10-29.nix
+++ b/manifests/forc-tx-0.28.1-nightly-2022-10-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.28.1";
+  date = "2022-10-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "51987a96a6f0ac23f4102478290e0bc1736b2af6";
+  sha256 = "sha256-qTgRMNueyU9NtCI6KHumAjrFYqJ2xqWEqW8py1okZsU=";
+}

--- a/manifests/forc-tx-0.28.1-nightly-2022-10-30.nix
+++ b/manifests/forc-tx-0.28.1-nightly-2022-10-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.28.1";
+  date = "2022-10-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "03ded848a6281930714a4b97a74364697705baf2";
+  sha256 = "sha256-sztgZklxQotgNRvJs0wbmP4n+Rty0kb6/I15nOEDoxU=";
+}

--- a/manifests/forc-tx-0.28.1-nightly-2022-10-31.nix
+++ b/manifests/forc-tx-0.28.1-nightly-2022-10-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.28.1";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1668ee5d01a83267a77e1b759178874d525ef726";
+  sha256 = "sha256-o00OwNerNsWhF2eKbd1ukKNDVG667y9WRyMUnZrA1IU=";
+}

--- a/manifests/forc-tx-0.28.1.nix
+++ b/manifests/forc-tx-0.28.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.28.1";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "84f9aad376760cd9c8eacc8a4848bffeb25bf9a5";
+  sha256 = "sha256-S5sB6ahI7P2Qv4Rh3GTE7lkYcEAbp1znpW/hlkyuh9U=";
+}

--- a/manifests/forc-tx-0.29.0-nightly-2022-11-01.nix
+++ b/manifests/forc-tx-0.29.0-nightly-2022-11-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.29.0";
+  date = "2022-11-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bdc3160d92539dee21378633b24475b6d6666e0c";
+  sha256 = "sha256-za7htSCITOpeMWCM/duj9JDIK6UXUedIRs4ydhtJJKM=";
+}

--- a/manifests/forc-tx-0.29.0-nightly-2022-11-02.nix
+++ b/manifests/forc-tx-0.29.0-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.29.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b0f05c4c1c30d691c34b828c50ff641415eb2530";
+  sha256 = "sha256-EJJGk6iCFwcEEsGYHVsUx+Y2OAjdE98pCCgyqeweD9Q=";
+}

--- a/manifests/forc-tx-0.29.0.nix
+++ b/manifests/forc-tx-0.29.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.29.0";
+  date = "2022-10-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
+  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
+}

--- a/manifests/forc-tx-0.3.0.nix
+++ b/manifests/forc-tx-0.3.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.3.0";
+  date = "2022-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b81eee7d23af71958ba1a3276855949277902a57";
+  sha256 = "sha256-25ZOELcJchuJapvGZFigzsl3BPEUW/R3f5NhvoXBKeE=";
+}

--- a/manifests/forc-tx-0.3.1.nix
+++ b/manifests/forc-tx-0.3.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.3.1";
+  date = "2022-01-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d9b5a1103a1f37672d6f09c8dae34b813872d44b";
+  sha256 = "sha256-eYVjjBkg6Gxc7mKMl7oaK3Ws2XVDHWAt+z3WIjGM3Xs=";
+}

--- a/manifests/forc-tx-0.3.2.nix
+++ b/manifests/forc-tx-0.3.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.3.2";
+  date = "2022-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3012191420362e9ba1df0324b2a9e80eeded7e1d";
+  sha256 = "sha256-5AirUGidtaNFfVf4uSutfrEvs2wd/ROiDyudYHb2EWQ=";
+}

--- a/manifests/forc-tx-0.3.3.nix
+++ b/manifests/forc-tx-0.3.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.3.3";
+  date = "2022-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "441ab123839f2eb4f5dd1b055fdbe5a5b26a6736";
+  sha256 = "sha256-QI8nqWfKr+/yGP96NnNdpKGwHHzA6UxEyQvjwQLgcSU=";
+}

--- a/manifests/forc-tx-0.30.0-nightly-2022-11-03.nix
+++ b/manifests/forc-tx-0.30.0-nightly-2022-11-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.0";
+  date = "2022-11-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ff747c226b7bebcdf62960f2040550cec33666c6";
+  sha256 = "sha256-NXzLpC1IxRqF+TvJKwO8bxww9rKpFCjbo+Ou+fMquXY=";
+}

--- a/manifests/forc-tx-0.30.0-nightly-2022-11-04.nix
+++ b/manifests/forc-tx-0.30.0-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.0";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4a5e93f5fc66168d70a0f11f0a3ef1ee4ff11c31";
+  sha256 = "sha256-vVMlYw7BAWfOZ2n/n4wtVNZXd1ehsppQLyux3nVNpAA=";
+}

--- a/manifests/forc-tx-0.30.0.nix
+++ b/manifests/forc-tx-0.30.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.0";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "37deaee8fccf5804d78a003cf64f14fac654fc41";
+  sha256 = "sha256-BIVBDX3i2ym6d/90AuK/I/ATtJqUFZS9OdltCdBtqI0=";
+}

--- a/manifests/forc-tx-0.30.1-nightly-2022-11-05.nix
+++ b/manifests/forc-tx-0.30.1-nightly-2022-11-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.1";
+  date = "2022-11-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-tx-0.30.1-nightly-2022-11-06.nix
+++ b/manifests/forc-tx-0.30.1-nightly-2022-11-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.1";
+  date = "2022-11-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "eee52c7438c11d28a2c9fcc25f1b06b2b80b0c51";
+  sha256 = "sha256-jKVys7ECF2WKzMgLwrfl82CZ6f0rSoglHfRo98x1yeo=";
+}

--- a/manifests/forc-tx-0.30.1-nightly-2022-11-07.nix
+++ b/manifests/forc-tx-0.30.1-nightly-2022-11-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.1";
+  date = "2022-11-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "18c35232a1d81f347e96a0d9351e03d84cb49f2e";
+  sha256 = "sha256-t97QbtnAHlioRfmbz7OGkJmFKcf7BzW1iuqUPc1MG24=";
+}

--- a/manifests/forc-tx-0.30.1-nightly-2022-11-08.nix
+++ b/manifests/forc-tx-0.30.1-nightly-2022-11-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.1";
+  date = "2022-11-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "aa56f73056ab0bf58555717d41e676e3a35250d4";
+  sha256 = "sha256-Bc+9qEf4EsCJQasNsfTOOXwpX8xIYrnuG+4epLoFMjk=";
+}

--- a/manifests/forc-tx-0.30.1-nightly-2022-11-09.nix
+++ b/manifests/forc-tx-0.30.1-nightly-2022-11-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.1";
+  date = "2022-11-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7f4bd3b61b1085913da1b918cc7256dcdf94ad3";
+  sha256 = "sha256-1WDIPnDoxe56KZmXoFvvre7fdWU2NFFyfS3QcwLsZl4=";
+}

--- a/manifests/forc-tx-0.30.1-nightly-2022-11-10.nix
+++ b/manifests/forc-tx-0.30.1-nightly-2022-11-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.1";
+  date = "2022-11-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "94f73b2b7645dc029890aca6d4f9779e7bb72f5d";
+  sha256 = "sha256-mWd7wxAUvhFz5aScr9VdOkDwm9ZzVdU1V5akkwyd/RI=";
+}

--- a/manifests/forc-tx-0.30.1.nix
+++ b/manifests/forc-tx-0.30.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.30.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
+  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
+}

--- a/manifests/forc-tx-0.31.0-nightly-2022-11-11.nix
+++ b/manifests/forc-tx-0.31.0-nightly-2022-11-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.0";
+  date = "2022-11-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "29d70dde3e29067c01152e5f52fabead75034cfa";
+  sha256 = "sha256-yGZgI9Gqj4uVM80v0+XpVWLzeeRWIJcxye78aF4abTc=";
+}

--- a/manifests/forc-tx-0.31.0-nightly-2022-11-12.nix
+++ b/manifests/forc-tx-0.31.0-nightly-2022-11-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.0";
+  date = "2022-11-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ca7c1a480314a826ef89831c1a3c582b19bca4a3";
+  sha256 = "sha256-aDMen4oyrDA+/erat7ZQ5COksqVR1iPZL13riiDfQXE=";
+}

--- a/manifests/forc-tx-0.31.0.nix
+++ b/manifests/forc-tx-0.31.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.0";
+  date = "2022-11-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7a389ddb35bae051938e5441c8ef4a8b63dd269c";
+  sha256 = "sha256-fRGQtZxDPD0sPfpt6xKYOaR9Ty1NDqR8El6rRIuU83M=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-13.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c32b0759d25c0b515cbf535f9fb9b8e6fda38ff2";
+  sha256 = "sha256-5GlH4fTix4r+b66tsE1vx/iyJCsNPnWjfuY7Iu36234=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-15.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4fe5a388ed894aca00e4a3995e085d63bdab169c";
+  sha256 = "sha256-rYSo5OCSswN7YZL0NipM1wTkC/wAyVRZplJATfSPIt0=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-17.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0f86e24747a50f80992f94adcac4abd9f33fb819";
+  sha256 = "sha256-Brnbq/JbQh/jr30z4Zuc6CTY1nLCZfq+M3xschI3gI0=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-22.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dd4a52153aab6de8fdd1e2c0bd215fafa56230b9";
+  sha256 = "sha256-3cBbaZJFOtlmy4sKOVDt0iS6ZVOklJXyLGW7Z5N+QiI=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-23.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f581909b377c6beecc8b2558d71bd3067b1c0205";
+  sha256 = "sha256-UmkTIHMPLQfobnKRBFf+nutxz9+U34Fikq9/SfBxO2Q=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-24.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "43c4307898de06832e8f0ceaabcec74cc1edcbdb";
+  sha256 = "sha256-z5rz4wBUyNobicpIf3lfxbFsLMzgUNs+hjyoNQTQWp0=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-25.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "412a4cd9741e63a384ba227da6f01f92913fae60";
+  sha256 = "sha256-02huSg2ap6iWtGAB9J9AT1kfsXpGX0ifo/FIES1wuZY=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-26.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "47423bf97be06c815bd4e0c882046be986911629";
+  sha256 = "sha256-p6nSrB8QnQktN/UrjUd99+UtwudH30QCGoLCy1rvHTs=";
+}

--- a/manifests/forc-tx-0.31.1-nightly-2022-11-29.nix
+++ b/manifests/forc-tx-0.31.1-nightly-2022-11-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e1e6fe74c8d5577219e908681582062ad5bbdbae";
+  sha256 = "sha256-TWyRV1OMui6dKx4JhzNS/8Fwbi65Oh4oiGTP7stW/zI=";
+}

--- a/manifests/forc-tx-0.31.1.nix
+++ b/manifests/forc-tx-0.31.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.1";
+  date = "2022-11-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c32b0759d25c0b515cbf535f9fb9b8e6fda38ff2";
+  sha256 = "sha256-5GlH4fTix4r+b66tsE1vx/iyJCsNPnWjfuY7Iu36234=";
+}

--- a/manifests/forc-tx-0.31.2-nightly-2022-11-30.nix
+++ b/manifests/forc-tx-0.31.2-nightly-2022-11-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.2";
+  date = "2022-11-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "12239f7d57441a75b0979f2f34d5151a777a5c0a";
+  sha256 = "sha256-9qHs1OatcgPBSLToDkCvTfTXxeAOTjrM1jABQZxqUaI=";
+}

--- a/manifests/forc-tx-0.31.2.nix
+++ b/manifests/forc-tx-0.31.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.2";
+  date = "2022-11-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "12239f7d57441a75b0979f2f34d5151a777a5c0a";
+  sha256 = "sha256-9qHs1OatcgPBSLToDkCvTfTXxeAOTjrM1jABQZxqUaI=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-01.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "12ad8423811d566972dd75fbb954cdb95afde8d8";
+  sha256 = "sha256-vsRRV7NAxSQw+NlZr7dUe2g0Hd8LSjkyXxDiygVfb54=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-02.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2188c1bf686a59c1815120fee888953a1d03ccea";
+  sha256 = "sha256-eYi3lLFgmLCOMnSnR/3trgGfZL50VbHFrjbeHQAzFp0=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-03.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "487770f695ee46be38d43e84ef87e7366a49a916";
+  sha256 = "sha256-OpLBWrpnSFyjczil6zvnLQHvgnG++rIjYuETawANhMo=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-04.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ec819e606e39607534cf82ce39f05b2ae51e7b2e";
+  sha256 = "sha256-eZbcUTekYI0xYkrGRzgVqT8Rgyx39jZb7TxfAU/kzsU=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-06.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3e6f8cf625e1f31f7c9fb20e1564dc09d14eb8f3";
+  sha256 = "sha256-q6io3Fjln0wWVGRsCjvnGL2ILJdLt2enMvl8iLTCDu0=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-07.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d605418bacb4c7f328c8d6689a709a9b82cb497b";
+  sha256 = "sha256-hOzuAm0Rij/BlmiMFBHt0eERqRfi8/5SsIgjRdBwSzA=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-08.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1b75006f3806191bd012f763853b926646fbd0ec";
+  sha256 = "sha256-AwY0FHhKFtygydXCjkWdhUeuCdIvIWez9Cz9WAy+xrY=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-09.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b44442262b08f635643de8fa0a821bb89c51c1d0";
+  sha256 = "sha256-XJd7cx8MXBiDBvi95FBz9fgFy4hqztGa2AG1YG84Udk=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-10.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3bd7118a34444ab2e6747d956f7271b77b610d43";
+  sha256 = "sha256-We5WcW8vFnXH+2FLfOu3D0bFjUuLpP+dR3h+d/OX4Ns=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-11.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4264e2f3ef2ade9bc7483e9b4eb86ac08949d59b";
+  sha256 = "sha256-ffBT+TgrHwG2f0OlRZzJ9FhDcFqlTc2mT9wJAjwQJ1s=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-12.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0550c195bec81c9c529512b81fcdd1f04da7f5a";
+  sha256 = "sha256-NRmU0+JaXvsEoggbyd2/4I7+vglap9nafO/dkJ61KM8=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-13.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2b6189fe282db7e433d92c31a6ac74561e210160";
+  sha256 = "sha256-j21CvjQbJpNbDptGankS1zYAa/ya07i2Ur4CTFnxxXg=";
+}

--- a/manifests/forc-tx-0.31.3-nightly-2022-12-14.nix
+++ b/manifests/forc-tx-0.31.3-nightly-2022-12-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "949dfb98bd8ad0d89c5a59a33b391892e665a760";
+  sha256 = "sha256-3e5IYyeyQWynIViLkD2JmKawKofvG+BxhQO7eRQQafc=";
+}

--- a/manifests/forc-tx-0.31.3.nix
+++ b/manifests/forc-tx-0.31.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.31.3";
+  date = "2022-11-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "12ad8423811d566972dd75fbb954cdb95afde8d8";
+  sha256 = "sha256-vsRRV7NAxSQw+NlZr7dUe2g0Hd8LSjkyXxDiygVfb54=";
+}

--- a/manifests/forc-tx-0.32.0-nightly-2022-12-15.nix
+++ b/manifests/forc-tx-0.32.0-nightly-2022-12-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.0";
+  date = "2022-12-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ed1610a2f6bce5fba39ec53fe7da1ba2f05da4ce";
+  sha256 = "sha256-ZteML6BecCLkj7w5fVJcRVxRYpZocpgNXuNRjDszEYc=";
+}

--- a/manifests/forc-tx-0.32.0.nix
+++ b/manifests/forc-tx-0.32.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.0";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ed1610a2f6bce5fba39ec53fe7da1ba2f05da4ce";
+  sha256 = "sha256-ZteML6BecCLkj7w5fVJcRVxRYpZocpgNXuNRjDszEYc=";
+}

--- a/manifests/forc-tx-0.32.1-nightly-2022-12-16.nix
+++ b/manifests/forc-tx-0.32.1-nightly-2022-12-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.1";
+  date = "2022-12-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "581b44ed124a2ac409cdf4e7a90622451b0d5d5e";
+  sha256 = "sha256-vykM7yK8hN+zh8oyO3vF4SLqQb+AszKJsw6nb9qY6mQ=";
+}

--- a/manifests/forc-tx-0.32.1.nix
+++ b/manifests/forc-tx-0.32.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.1";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "50c1b6c858c044acf88760cb7eb1b39d076f322d";
+  sha256 = "sha256-GnF8eHwhcCC0Yr73jNVjyZUh1lOU9YmFslFzeZnSqHo=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-17.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1b46df8a4d21117a3cf0124ba95744a9ad9b67f4";
+  sha256 = "sha256-ZUIaUDWIsKfLw6n9FAn8EkCgyihOfyGWaCbTVI90RSk=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-18.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c511ccd347e6560ca5cc2ee37887498a30d181f2";
+  sha256 = "sha256-G6RacNQAcME6aOvtF5rjTtRnL/wgTCfa70necg9WKOo=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-19.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "98a5c9bdfa278c0319730f677692616d532e975f";
+  sha256 = "sha256-5RKxMhxcUGBZncTMK0nv2POTMggPAre/xGpwRtc9WwU=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-20.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "495ad00b734b19cb21234a7e03042a4e11ca763c";
+  sha256 = "sha256-mupDuokCCRwZG4JntQttzQ6YlKI75s9vhrgzKy4/1b8=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-21.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "de2706684fcc752bc309d51af7f72e9bac65d545";
+  sha256 = "sha256-uOrfMJfu1n96e791QGvGdmF6ON36JwYjGid4VGPo5XE=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-22.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "cdfc56c700ab32eefb84f75ed3048bd2a0ea22d2";
+  sha256 = "sha256-Ue19bzrUMgOdj9ziVu0mX1hGdWn/sZuIOYxMhFd0/9Q=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-23.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "153ef7a8db2f2bf8a2718d32c1ad1f0af23bc0fd";
+  sha256 = "sha256-CSfpr8aCl0goLlIMUcVAEI25A4TpzWixxrWMmIhQnlo=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-24.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0ac0a0a94ee39e8ef8c92695ce37b484dbf5a51c";
+  sha256 = "sha256-dInIy1s0EH8fPWbwzqKHJTTxoKAkXA3JLoJahQtGys8=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-25.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "41af03e888f43562fd7103e80bb813bae87e416d";
+  sha256 = "sha256-7235lOjmzxGod5UQEkTDvVyUV9XwFFL7VGQ4tVfa9q8=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-28.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2faff70d3d452181dee771b0c2c82cee48b33c6c";
+  sha256 = "sha256-BUCNexRuNGbWPol95Pfhjl8ywaMNxYQI67+DUOVi8VE=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-29.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fefc1e9cac3c7db40691fca3bc6c37da30bc2f0a";
+  sha256 = "sha256-gbvOc3BBJnLCsrSfCLvJBOgybybAJV30d4wqtzgESCs=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2022-12-31.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2022-12-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "9a0e658ed70b429c5fe39537620ef6f9d11d4729";
+  sha256 = "sha256-CFjEqYUmYoAqBUPOkEOnoHqLlgpDzoR3qUGag2yviLE=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2023-01-03.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2023-01-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2023-01-03";
+  url = "https://github.com/fuellabs/sway";
+  rev = "76f56534825ef6ff609684f274c5160d30911ec7";
+  sha256 = "sha256-SzfyiGYqv3N2gw1KYxmJziI02R2Aue4BQTIkELpderE=";
+}

--- a/manifests/forc-tx-0.32.2-nightly-2023-01-05.nix
+++ b/manifests/forc-tx-0.32.2-nightly-2023-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2023-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "77bb26ecd1c01328474e34f83372c8879405a98a";
+  sha256 = "sha256-faE1SJxPMv5etdYW1NNQmUG3tm/DrhjJoogc/4NC3kM=";
+}

--- a/manifests/forc-tx-0.32.2.nix
+++ b/manifests/forc-tx-0.32.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.32.2";
+  date = "2022-12-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "b9996f13463c324e256014935c053c334b880ab5";
+  sha256 = "sha256-ZCAsObQ50XJnsc64XFB/6ia8fjX3vi4rHug6FuC2ySc=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-06.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-06";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5a4d064d2ad094f66836c540ab5f997592916816";
+  sha256 = "sha256-XrAtYskpxR0eG5guX+lUbVsm0FYGKovxfBdDkMDA0RA=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-07.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "536cb99af62b7f0051df750a4d6fe042f9e78a61";
+  sha256 = "sha256-SR0GSNlyFDM0vJpEHhDVkhcILY7t11gStw2XC2rpD50=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-08.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4547574777de6e8ff9befce2210fdd6bde260ad1";
+  sha256 = "sha256-CqnbrK1hPgvcvbK5diInRuB5KMjnUTPEBwlHOXKDSbs=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-10.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dcf3e32f79e42090475867fdbac81c16c72003e5";
+  sha256 = "sha256-2F2xCBs+p2wqdcbDZPO3Wybqq6RoRYqcFZaCp6x0Xj4=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-11.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f14d6ef1c99eb16196dfb3a37933556ad8b24769";
+  sha256 = "sha256-eKUdFlWV6iaxAJVATOPhcLMoZq1NTxOIlR3t2xTBNLY=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-12.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c2898502974c3a2d9e2782e904a02e42c8d5836f";
+  sha256 = "sha256-vJ3zAXBGrEe5LcSftJO4/3qu1/Fj7Pz1tyUEJOXLEWI=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-13.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d9f6f8ab2699b8370cb81e13567b7e3c3734db65";
+  sha256 = "sha256-Ly5eBmiVqKsObanzYDTJgqHf6Q/rhhjq/gzFO1XgLeA=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-14.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0be5f2cbe0bf7a6d008a2210920da9d4ff5dbae";
+  sha256 = "sha256-fs9E1TUwu1xky6BIXFYNTuVmHHB3Emu56xU8fVivpwQ=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-15.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "26eeef0fc690238e90edde9e677c81c9fbbe0af0";
+  sha256 = "sha256-ntfqhRRTZV95awGBRUeRwBoKmZb1b5fXhInOgVzzqqU=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-16.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "847cbccd32ba0a1a5cc6399e837f43b9b0e4726c";
+  sha256 = "sha256-UTJq5EJ+cnNkaj4blNadmdG/NVws2YVAnXR2Ou1fnfI=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-17.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2b6f72fabb85c768e82c6c546a0a7115091e2106";
+  sha256 = "sha256-VYkteK6Mz88fKf12bRgN7+B/vCjk+bWMKM07POxsolI=";
+}

--- a/manifests/forc-tx-0.33.0-nightly-2023-01-18.nix
+++ b/manifests/forc-tx-0.33.0-nightly-2023-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "555f34e4c94c2a2ea4ac2d5226d36772577d2ea6";
+  sha256 = "sha256-6tTFXnoOb+dO7sgXoAt22vNdswJZdmu1sDRRZx1OnPw=";
+}

--- a/manifests/forc-tx-0.33.0.nix
+++ b/manifests/forc-tx-0.33.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.0";
+  date = "2023-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2b2b4b117c4f6a5e762e368af0dfc6896fa31e7d";
+  sha256 = "sha256-K/RT9WFv1uGpBbwckvhcvXPdEnNjluSd2f7CNdjeGhQ=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-19.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0c99c8adad3f7adc3eef34a587298c063cf9f228";
+  sha256 = "sha256-woM4ot15CZj4Y2iFAjFaaf/PFDoluzinuJTz0mvw/bk=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-20.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "89c45ee845962d2b407521c1079bb519e7e954ac";
+  sha256 = "sha256-2JNNjlq9jSPQV/NvgQa2ocibXYePuc8WSv3/YCRpqxg=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-21.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5968792cd7bb8e0c117ff1cc47693503b7dd731e";
+  sha256 = "sha256-WSiRTAIDlvYUjZgAefoeN6ggfzz5bb2Il3ejj2lhYJs=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-22.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1506d92775262ad973630558f66b42d57de8fe9";
+  sha256 = "sha256-X3gQ/p2MEr8KwTKMZvrrwrxXTptbR+yLTw7eG0mSwao=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-24.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3998c10760f338d7f900b0253ff27cb5b9db53e5";
+  sha256 = "sha256-v8F1Q9r1N8lu/qdlE74V/dLiA2ssrR2/R7GB9iLHQeE=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-25.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0a3beae92e6faed5e8ca35da5a8071e58f4a43d1";
+  sha256 = "sha256-9YOhtE24W14fBYmRyNMNl/ETcqr17FtjW2CuHE80jCk=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-26.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "74979e091b947ee219e5f34eafb8a60d1f2cff13";
+  sha256 = "sha256-syGOb3kja6W7E1p05bb3ll+jPRyT9kSBB0YGMTB2U8c=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-27.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "46f92f280b3289f45f3ec181af8046da329dcc89";
+  sha256 = "sha256-KofK4fpsH+ovCZzZGS+kaqWQQSxFDcty2fPywJkjFGc=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-28.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "97190861deda5958921c6cecbc81d9141179fd22";
+  sha256 = "sha256-vf7HixoPlPUOvEsPas5B9PZ2wK+4APQjV0m/HjzMRNg=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-29.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "dd8b2f62442288e71153a3a701cd96491c5bcb8c";
+  sha256 = "sha256-pdjcWnsjb7HpHFRrB42kjMBBM0DmqTUBzf7rG6c9EKA=";
+}

--- a/manifests/forc-tx-0.33.1-nightly-2023-01-30.nix
+++ b/manifests/forc-tx-0.33.1-nightly-2023-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3c0c024c397a290d7576e6d6e589fbbcbc61775f";
+  sha256 = "sha256-+sR31fVHmu82PHOZDARUYEyGyJTXLwQMEsFbha6TBmY=";
+}

--- a/manifests/forc-tx-0.33.1.nix
+++ b/manifests/forc-tx-0.33.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.33.1";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "acd4c1e0fbdc406800a06c845430a80dd3560fcc";
+  sha256 = "sha256-00KVxZUcyCrE4RT2WrmHtxFFFyxLuiD6nJV9PoDzHng=";
+}

--- a/manifests/forc-tx-0.4.0.nix
+++ b/manifests/forc-tx-0.4.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.4.0";
+  date = "2022-02-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "6332f9ad955e1f8e744cc87e07d028092874e0d5";
+  sha256 = "sha256-lDyAgfNC5ezqptxuM7lycuVEofI5W62hzY011MzXUt8=";
+}

--- a/manifests/forc-tx-0.5.0.nix
+++ b/manifests/forc-tx-0.5.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.5.0";
+  date = "2022-02-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5c58c09ffba1719b187a3e1112639eec649eab5e";
+  sha256 = "sha256-11OIZruYjYrylHv8zQOfLW9Fzs0p7aGOWQfq7UQN+5w=";
+}

--- a/manifests/forc-tx-0.6.0.nix
+++ b/manifests/forc-tx-0.6.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.6.0";
+  date = "2022-03-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "35e5a2f12e137953b82470e9637e4969ca064e4a";
+  sha256 = "sha256-HKmNBduWtyIoaUwkj2Nu9GznUOoZFctcaRhFJOnTWLY=";
+}

--- a/manifests/forc-tx-0.6.1.nix
+++ b/manifests/forc-tx-0.6.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.6.1";
+  date = "2022-03-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "3268092ce50e5058b11a5ea2e7f35c6e19352d68";
+  sha256 = "sha256-JOH4UosK8x7FmMqx2qkEqWnyO+z9XPl1C/BrnXWz4uw=";
+}

--- a/manifests/forc-tx-0.7.0.nix
+++ b/manifests/forc-tx-0.7.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.7.0";
+  date = "2022-03-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7dd186041fbd2d4040b9a374fedc9a0cbed9eecb";
+  sha256 = "sha256-B37FgsnDop9Vyn5t7aSn2RceGG3pdLxrHUJHZ2s53d8=";
+}

--- a/manifests/forc-tx-0.8.0.nix
+++ b/manifests/forc-tx-0.8.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.8.0";
+  date = "2022-03-25";
+  url = "https://github.com/fuellabs/sway";
+  rev = "04d26d6924788875fb01fa4fe58fe969849dcfc5";
+  sha256 = "sha256-MTQlnuP9WVHL/rNHsMdmYqvIgHL5IJmIjUF9WqM55M0=";
+}

--- a/manifests/forc-tx-0.9.0.nix
+++ b/manifests/forc-tx-0.9.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.9.0";
+  date = "2022-03-28";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fdebe28e2803ef32238e6b39693748b6bdf6f34e";
+  sha256 = "sha256-dzEkvJ+nP6+Xzp+nVz+VKy0RmfN/UkX/JlP/0cXqaY0=";
+}

--- a/manifests/forc-tx-0.9.1.nix
+++ b/manifests/forc-tx-0.9.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.9.1";
+  date = "2022-03-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "72aa51d6da3d49b1bad2e6d6fffe6d4b3e331380";
+  sha256 = "sha256-Mu3niggbgovHWhm6GtU/hhWqANm5YWFvdsrDExUPKYc=";
+}

--- a/manifests/forc-tx-0.9.2.nix
+++ b/manifests/forc-tx-0.9.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.9.2";
+  date = "2022-03-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4905aa0b2b6cb7178d6229e7bed94c241a418c26";
+  sha256 = "sha256-C+1vF48WryCdT2X09E8RwcY8LRHxGX3ncRkc2MtNnY4=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -1,7 +1,15 @@
 # This file contains a list of manually defined manifest patches.
 # These are used to update or transform manifests to suit the specific needs of each package.
 # Patches are applied if their condition is met in the order they are defined in this list.
-{pkgs}: [
+{pkgs}: let
+  forc-plugins = [
+    "forc-client"
+    "forc-doc"
+    "forc-fmt"
+    "forc-lsp"
+    "forc-tx"
+  ];
+in [
   # By default, most packages have their `Cargo.lock` file in the repo root.
   # We also specify a base, minimum Rust version. This version should never
   # change in order to avoid invalidating the cache for all previously built
@@ -74,7 +82,7 @@
   # Some `forc-pkg` and some crates that depend on it require openssl, so add
   # the required packages.
   {
-    condition = m: pkgs.lib.any (n: m.pname == n) ["forc" "forc-client" "forc-fmt" "forc-lsp"];
+    condition = m: pkgs.lib.any (n: m.pname == n) (["forc"] ++ forc-plugins);
     patch = m: {
       nativeBuildInputs =
         (m.nativeBuildInputs or [])
@@ -88,7 +96,7 @@
   # The forc plugins that reside in the Sway repo are in a dedicated
   # subdirectory.
   {
-    condition = m: m.pname == "forc-client" || m.pname == "forc-fmt" || m.pname == "forc-lsp";
+    condition = m: pkgs.lib.any (n: m.pname == n) forc-plugins;
     patch = m: {
       buildAndTestSubdir = "forc-plugins/${m.pname}";
     };
@@ -184,7 +192,7 @@
   # that are unpermitted in Nix's sandbox during a build. These tests are run
   # at `forc`'s repo CI, so it's fine to disable the check here.
   {
-    condition = m: pkgs.lib.any (n: m.pname == n) ["forc" "forc-client" "forc-fmt" "forc-lsp"] && m.date >= "2022-10-31";
+    condition = m: pkgs.lib.any (n: m.pname == n) (["forc"] ++ forc-plugins) && m.date >= "2022-10-31";
     patch = m: {
       doCheck = false; # Already tested at repo.
     };

--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -43,6 +43,10 @@ declare -A pkg_forc_client=(
     [name]="forc-client"
     [repo]="${fuel_repos[sway]}"
 )
+declare -A pkg_forc_doc=(
+    [name]="forc-doc"
+    [repo]="${fuel_repos[sway]}"
+)
 declare -A pkg_forc_explore=(
     [name]="forc-explore"
     [repo]="${fuel_repos[forc-explorer]}"
@@ -53,6 +57,10 @@ declare -A pkg_forc_fmt=(
 )
 declare -A pkg_forc_lsp=(
     [name]="forc-lsp"
+    [repo]="${fuel_repos[sway]}"
+)
+declare -A pkg_forc_tx=(
+    [name]="forc-tx"
     [repo]="${fuel_repos[sway]}"
 )
 declare -A pkg_forc_wallet=(
@@ -211,7 +219,9 @@ refresh pkg_fuel_core
 refresh pkg_fuel_core_client
 refresh pkg_forc
 refresh pkg_forc_client
+refresh pkg_forc_doc
 refresh pkg_forc_explore
 refresh pkg_forc_fmt
 refresh pkg_forc_lsp
+refresh pkg_forc_tx
 refresh pkg_forc_wallet


### PR DESCRIPTION
Adds the `forc-doc` and `forc-tx` plugins!

The nixpkgs pin update is mostly just to update the pinned nix formatter which use to have a pretty obtrusive CLI but has been fixed in more recent versions.