### PR TITLE
`fuel-core` now requires Rust 1.67

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674440843,
-        "narHash": "sha256-kMCGL1wADpbcgGiMgj1pcOxbLy2zfmzsn46YCMWwtIE=",
+        "lastModified": 1675477407,
+        "narHash": "sha256-mcmGElt04ZaW2Xx7flDQ812X0O2oUlS4rCw1Al4x0qw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "57b363f390f031b8b8d26235c2d21b0ad5a84640",
+        "rev": "1f1d13846ae88826391e5d65d85247a30982671b",
         "type": "github"
       },
       "original": {

--- a/manifests/forc-0.34.0-nightly-2023-02-04.nix
+++ b/manifests/forc-0.34.0-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.34.0";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c84790e126f24a3dc34ea11c924da0caef073899";
+  sha256 = "sha256-Ejd/cAqGUv/w+kEtQiSxIT2UR0C9gBfvVB7OpNVGM2s=";
+}

--- a/manifests/forc-client-0.34.0-nightly-2023-02-04.nix
+++ b/manifests/forc-client-0.34.0-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.34.0";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c84790e126f24a3dc34ea11c924da0caef073899";
+  sha256 = "sha256-Ejd/cAqGUv/w+kEtQiSxIT2UR0C9gBfvVB7OpNVGM2s=";
+}

--- a/manifests/forc-doc-0.34.0-nightly-2023-02-04.nix
+++ b/manifests/forc-doc-0.34.0-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.34.0";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c84790e126f24a3dc34ea11c924da0caef073899";
+  sha256 = "sha256-Ejd/cAqGUv/w+kEtQiSxIT2UR0C9gBfvVB7OpNVGM2s=";
+}

--- a/manifests/forc-fmt-0.34.0-nightly-2023-02-04.nix
+++ b/manifests/forc-fmt-0.34.0-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.34.0";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c84790e126f24a3dc34ea11c924da0caef073899";
+  sha256 = "sha256-Ejd/cAqGUv/w+kEtQiSxIT2UR0C9gBfvVB7OpNVGM2s=";
+}

--- a/manifests/forc-index-0.2.2-nightly-2023-02-04.nix
+++ b/manifests/forc-index-0.2.2-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.2";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "c89f376fa912e8c3c5cf0c03da99195a8da04108";
+  sha256 = "sha256-dtkuqBOnjkQHu4sn/eVX+AVJAYIlN3xD3fIKh+9ILVA=";
+}

--- a/manifests/forc-lsp-0.34.0-nightly-2023-02-04.nix
+++ b/manifests/forc-lsp-0.34.0-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.34.0";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c84790e126f24a3dc34ea11c924da0caef073899";
+  sha256 = "sha256-Ejd/cAqGUv/w+kEtQiSxIT2UR0C9gBfvVB7OpNVGM2s=";
+}

--- a/manifests/forc-tx-0.34.0-nightly-2023-02-04.nix
+++ b/manifests/forc-tx-0.34.0-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.34.0";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c84790e126f24a3dc34ea11c924da0caef073899";
+  sha256 = "sha256-Ejd/cAqGUv/w+kEtQiSxIT2UR0C9gBfvVB7OpNVGM2s=";
+}

--- a/manifests/fuel-core-0.16.1-nightly-2023-02-04.nix
+++ b/manifests/fuel-core-0.16.1-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.16.1";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "580b2212bd5fa9870c9fef11e0ad72f373925e78";
+  sha256 = "sha256-D44myJ00lNbIdKid47e387YHlkOOZdc35b/yM+FRMTs=";
+}

--- a/manifests/fuel-core-client-0.16.1-nightly-2023-02-04.nix
+++ b/manifests/fuel-core-client-0.16.1-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.16.1";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "580b2212bd5fa9870c9fef11e0ad72f373925e78";
+  sha256 = "sha256-D44myJ00lNbIdKid47e387YHlkOOZdc35b/yM+FRMTs=";
+}

--- a/manifests/fuel-indexer-0.2.2-nightly-2023-02-04.nix
+++ b/manifests/fuel-indexer-0.2.2-nightly-2023-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.2";
+  date = "2023-02-04";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "c89f376fa912e8c3c5cf0c03da99195a8da04108";
+  sha256 = "sha256-dtkuqBOnjkQHu4sn/eVX+AVJAYIlN3xD3fIKh+9ILVA=";
+}


### PR DESCRIPTION
Updates the `rust-overlay` flake input to bring in support for 1.67.

Also udpates a fuel-core patch to ensure tests aren't run unnecessarily for new fuel-core-client crate.

Also includes manifests for previous failed CI job.