### PR TITLE
Add `openssl` to `buildInputs` for indexer packages

### DIFF
--- a/manifests/forc-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-0.35.1.nix
+++ b/manifests/forc-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-0.35.2.nix
+++ b/manifests/forc-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-client-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-client-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-client-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-client-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-client-0.35.1.nix
+++ b/manifests/forc-client-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-client-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-client-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-client-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-client-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-client-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-client-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-client-0.35.2.nix
+++ b/manifests/forc-client-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-doc-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-doc-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-doc-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-doc-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-doc-0.35.1.nix
+++ b/manifests/forc-doc-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-doc-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-doc-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-doc-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-doc-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-doc-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-doc-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-doc-0.35.2.nix
+++ b/manifests/forc-doc-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-fmt-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-fmt-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-fmt-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-fmt-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-fmt-0.35.1.nix
+++ b/manifests/forc-fmt-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-fmt-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-fmt-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-fmt-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-fmt-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-fmt-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-fmt-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-fmt-0.35.2.nix
+++ b/manifests/forc-fmt-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-index-0.2.3-nightly-2023-02-16.nix
+++ b/manifests/forc-index-0.2.3-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.3";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "6b318e9d92b014583af91a1fdf8e35ce3ed86dd9";
+  sha256 = "sha256-A8/dgeUXmBB4OoFbF1eJVVzHinoprcYHOgRjN1JKOis=";
+}

--- a/manifests/forc-index-0.2.3-nightly-2023-02-17.nix
+++ b/manifests/forc-index-0.2.3-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.3";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "105deac1224963592625ebc55c7a88e17cdf91fd";
+  sha256 = "sha256-TfOPCIHzd/lQDd1EY6N2ltdnu0Bq7sqCURthUwPN+U0=";
+}

--- a/manifests/forc-index-0.3.0-nightly-2023-02-18.nix
+++ b/manifests/forc-index-0.3.0-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.3.0";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
+  sha256 = "sha256-Co7LCA6xflg8ExTsEJQvepmtSWkAEZpmm0n3shx7i0c=";
+}

--- a/manifests/forc-index-0.3.0-nightly-2023-02-21.nix
+++ b/manifests/forc-index-0.3.0-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.3.0";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "69a6039cdfbcb2944390fa9eca507caaa21b2aa2";
+  sha256 = "sha256-BQ/2Z4XustvZeek+mOXTrmdkVowD4PHFzJ+9gDi60hc=";
+}

--- a/manifests/forc-index-0.3.0.nix
+++ b/manifests/forc-index-0.3.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.3.0";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
+  sha256 = "sha256-Co7LCA6xflg8ExTsEJQvepmtSWkAEZpmm0n3shx7i0c=";
+}

--- a/manifests/forc-lsp-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-lsp-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-lsp-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-lsp-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-lsp-0.35.1.nix
+++ b/manifests/forc-lsp-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-lsp-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-lsp-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-lsp-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-lsp-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-lsp-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-lsp-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-lsp-0.35.2.nix
+++ b/manifests/forc-lsp-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-tx-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-tx-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-tx-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-tx-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-tx-0.35.1.nix
+++ b/manifests/forc-tx-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-tx-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-tx-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-tx-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-tx-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-tx-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-tx-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-tx-0.35.2.nix
+++ b/manifests/forc-tx-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-wallet-0.1.3-nightly-2023-02-18.nix
+++ b/manifests/forc-wallet-0.1.3-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.3";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "4070e5276ef03b8891b80a075892cc238fd0ceee";
+  sha256 = "sha256-3DluZeDLCvXNcCn81M+DM590IK+3MB4C7NQuu0YlyZg=";
+}

--- a/manifests/forc-wallet-0.2.0.nix
+++ b/manifests/forc-wallet-0.2.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.2.0";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "c0a69f05e48031632b58e1b69eebb1ea19b6dd2d";
+  sha256 = "sha256-cUeASmn/40N07gDve83mNprpMoNxxheVN51e+ferIk8=";
+}

--- a/manifests/fuel-core-0.16.0.nix
+++ b/manifests/fuel-core-0.16.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.16.0";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "17164720336031a756c336926bdd961baccfdfb3";
+  sha256 = "sha256-8WPdMug3VsbiRnZH97+i/o1TqrHmmCaoPN9J3ZMzwd8=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-16.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "95a9608d61fee2f30446bb59d967c3dad2655fef";
+  sha256 = "sha256-iQGu2qnySx2uYwc15mWe70HWLnKZjtfGX0p/BqlNVXA=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-17.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "8a48f4d6390a8a98899f29918590a482ff77aa9b";
+  sha256 = "sha256-/ckOIru/DyVwdauBcTuCV91T00Id1E7CL2xK9zCVLHw=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-18.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "31e81ff34716cb3d72eb190d1aec8e2c68b44bab";
+  sha256 = "sha256-XRihxjPO0/AoAFYBuiurq24NcaxOfYVfpsVmNesDZLw=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-20.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0cefc99bbf4e14c6c43702f33954efebd3ebdc76";
+  sha256 = "sha256-V4O0xG/BejzdjlXLbZ4w6Er/eVHaVDi23V/Ozdg6AP4=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-21.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0b2f445b2d25f0a394445df6b9361f302b6b84e7";
+  sha256 = "sha256-QRAb/Bn4AiucgDVKj+JtUHqaNrXpFx6chp0is+HyxFc=";
+}

--- a/manifests/fuel-core-0.17.2.nix
+++ b/manifests/fuel-core-0.17.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "95a9608d61fee2f30446bb59d967c3dad2655fef";
+  sha256 = "sha256-iQGu2qnySx2uYwc15mWe70HWLnKZjtfGX0p/BqlNVXA=";
+}

--- a/manifests/fuel-core-client-0.16.0.nix
+++ b/manifests/fuel-core-client-0.16.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.16.0";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "17164720336031a756c336926bdd961baccfdfb3";
+  sha256 = "sha256-8WPdMug3VsbiRnZH97+i/o1TqrHmmCaoPN9J3ZMzwd8=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-16.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "95a9608d61fee2f30446bb59d967c3dad2655fef";
+  sha256 = "sha256-iQGu2qnySx2uYwc15mWe70HWLnKZjtfGX0p/BqlNVXA=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-17.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "8a48f4d6390a8a98899f29918590a482ff77aa9b";
+  sha256 = "sha256-/ckOIru/DyVwdauBcTuCV91T00Id1E7CL2xK9zCVLHw=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-18.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "31e81ff34716cb3d72eb190d1aec8e2c68b44bab";
+  sha256 = "sha256-XRihxjPO0/AoAFYBuiurq24NcaxOfYVfpsVmNesDZLw=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-20.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0cefc99bbf4e14c6c43702f33954efebd3ebdc76";
+  sha256 = "sha256-V4O0xG/BejzdjlXLbZ4w6Er/eVHaVDi23V/Ozdg6AP4=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-21.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0b2f445b2d25f0a394445df6b9361f302b6b84e7";
+  sha256 = "sha256-QRAb/Bn4AiucgDVKj+JtUHqaNrXpFx6chp0is+HyxFc=";
+}

--- a/manifests/fuel-core-client-0.17.2.nix
+++ b/manifests/fuel-core-client-0.17.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "95a9608d61fee2f30446bb59d967c3dad2655fef";
+  sha256 = "sha256-iQGu2qnySx2uYwc15mWe70HWLnKZjtfGX0p/BqlNVXA=";
+}

--- a/manifests/fuel-indexer-0.2.3-nightly-2023-02-16.nix
+++ b/manifests/fuel-indexer-0.2.3-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.3";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "6b318e9d92b014583af91a1fdf8e35ce3ed86dd9";
+  sha256 = "sha256-A8/dgeUXmBB4OoFbF1eJVVzHinoprcYHOgRjN1JKOis=";
+}

--- a/manifests/fuel-indexer-0.2.3-nightly-2023-02-17.nix
+++ b/manifests/fuel-indexer-0.2.3-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.3";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "105deac1224963592625ebc55c7a88e17cdf91fd";
+  sha256 = "sha256-TfOPCIHzd/lQDd1EY6N2ltdnu0Bq7sqCURthUwPN+U0=";
+}

--- a/manifests/fuel-indexer-0.3.0-nightly-2023-02-18.nix
+++ b/manifests/fuel-indexer-0.3.0-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.3.0";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
+  sha256 = "sha256-Co7LCA6xflg8ExTsEJQvepmtSWkAEZpmm0n3shx7i0c=";
+}

--- a/manifests/fuel-indexer-0.3.0-nightly-2023-02-21.nix
+++ b/manifests/fuel-indexer-0.3.0-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.3.0";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "69a6039cdfbcb2944390fa9eca507caaa21b2aa2";
+  sha256 = "sha256-BQ/2Z4XustvZeek+mOXTrmdkVowD4PHFzJ+9gDi60hc=";
+}

--- a/manifests/fuel-indexer-0.3.0.nix
+++ b/manifests/fuel-indexer-0.3.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.3.0";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
+  sha256 = "sha256-Co7LCA6xflg8ExTsEJQvepmtSWkAEZpmm0n3shx7i0c=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -295,4 +295,12 @@ in [
       rust = pkgs.rust-bin.stable."1.67.0".default;
     };
   }
+
+  # As of ~2023-02-15, the fuel-indexer crates appear to require openssl.
+  {
+    condition = m: m.date >= "2023-02-15" && m.src.gitRepoUrl == "https://github.com/fuellabs/fuel-indexer";
+    patch = m: {
+      buildInputs = (m.buildInputs or []) ++ [pkgs.openssl];
+    };
+  }
 ]


### PR DESCRIPTION
This requirement appears to have been introduced about a week ago.

This PR also includes the manifests generated since CI started failing.