### PR TITLE
WIP Add the fuelup package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   nix-build:
     strategy:
       matrix:
-        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-nightly, sway-vim]
+        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-nightly, fuelup, sway-vim]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -58,7 +58,7 @@ jobs:
     needs: refresh-manifests
     strategy:
       matrix:
-        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-nightly, sway-vim]
+        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-nightly, fuelup, sway-vim]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Includes the following packages:
 | [`forc-wallet`][forc-wallet-repo] | A Fuel Wallet CLI implementation. |
 | [`fuel-indexer`][fuel-indexer-repo] | An indexer for the Fuel blockchain. |
 | [`sway-vim`][sway-vim-repo] | The Sway Vim plugin. |
+| [`fuelup`][fuelup-repo] | The fuelup toolchain manager. Unnecessary if using fuel.nix |
 | `fuel` | All of the above tools under a single package. |
 
 If you have Nix installed with the "flakes" feature enabled, you can run any of
@@ -198,6 +199,7 @@ inspired by nixpkgs' `rustPlatform`.*
 [fuel-core-repo]: https://github.com/fuellabs/fuel-core
 [fuel-indexer-repo]: https://github.com/fuellabs/fuel-indexer
 [fuellabs-cachix]: https://app.cachix.org/cache/mitchmindtree-fuellabs
+[fuelup]: https://github.com/fuellabs/fuelup
 [nix-flakes]: https://nixos.wiki/wiki/Flakes
 [nix-manual]: https://nixos.org/manual/nix/stable/
 [rust-overlay-repo]: https://github.com/oxalica/rust-overlay

--- a/filters.nix
+++ b/filters.nix
@@ -19,4 +19,5 @@ with pkgs.lib; [
   (m: m.pname != "fuel-core-client" || (versionAtLeast m.version "0.14.2" && m.date >= "2022-12-17"))
   (m: m.pname != "fuel-gql-cli" || (versionAtLeast m.version "0.9.0" && m.date < "2022-12-17"))
   (m: m.pname != "fuel-indexer" || versionAtLeast m.version "0.1.8")
+  (m: m.pname != "fuelup" || versionAtLeast m.version "0.1.0")
 ]

--- a/manifests/forc-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-0.35.1.nix
+++ b/manifests/forc-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-0.35.2.nix
+++ b/manifests/forc-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-client-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-client-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-client-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-client-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-client-0.35.1.nix
+++ b/manifests/forc-client-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-client-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-client-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-client-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-client-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-client-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-client-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-client-0.35.2.nix
+++ b/manifests/forc-client-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-doc-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-doc-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-doc-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-doc-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-doc-0.35.1.nix
+++ b/manifests/forc-doc-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-doc-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-doc-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-doc-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-doc-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-doc-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-doc-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-doc-0.35.2.nix
+++ b/manifests/forc-doc-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-fmt-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-fmt-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-fmt-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-fmt-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-fmt-0.35.1.nix
+++ b/manifests/forc-fmt-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-fmt-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-fmt-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-fmt-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-fmt-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-fmt-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-fmt-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-fmt-0.35.2.nix
+++ b/manifests/forc-fmt-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-index-0.2.3-nightly-2023-02-16.nix
+++ b/manifests/forc-index-0.2.3-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.3";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "6b318e9d92b014583af91a1fdf8e35ce3ed86dd9";
+  sha256 = "sha256-A8/dgeUXmBB4OoFbF1eJVVzHinoprcYHOgRjN1JKOis=";
+}

--- a/manifests/forc-index-0.2.3-nightly-2023-02-17.nix
+++ b/manifests/forc-index-0.2.3-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.2.3";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "105deac1224963592625ebc55c7a88e17cdf91fd";
+  sha256 = "sha256-TfOPCIHzd/lQDd1EY6N2ltdnu0Bq7sqCURthUwPN+U0=";
+}

--- a/manifests/forc-index-0.3.0-nightly-2023-02-18.nix
+++ b/manifests/forc-index-0.3.0-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.3.0";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
+  sha256 = "sha256-Co7LCA6xflg8ExTsEJQvepmtSWkAEZpmm0n3shx7i0c=";
+}

--- a/manifests/forc-index-0.3.0-nightly-2023-02-21.nix
+++ b/manifests/forc-index-0.3.0-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.3.0";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "69a6039cdfbcb2944390fa9eca507caaa21b2aa2";
+  sha256 = "sha256-BQ/2Z4XustvZeek+mOXTrmdkVowD4PHFzJ+9gDi60hc=";
+}

--- a/manifests/forc-index-0.3.0.nix
+++ b/manifests/forc-index-0.3.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.3.0";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
+  sha256 = "sha256-Co7LCA6xflg8ExTsEJQvepmtSWkAEZpmm0n3shx7i0c=";
+}

--- a/manifests/forc-lsp-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-lsp-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-lsp-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-lsp-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-lsp-0.35.1.nix
+++ b/manifests/forc-lsp-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-lsp-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-lsp-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-lsp-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-lsp-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-lsp-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-lsp-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-lsp-0.35.2.nix
+++ b/manifests/forc-lsp-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-tx-0.35.1-nightly-2023-02-16.nix
+++ b/manifests/forc-tx-0.35.1-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.1";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-tx-0.35.1-nightly-2023-02-17.nix
+++ b/manifests/forc-tx-0.35.1-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ada81db36faaba3d8a1e1be4c5a78a02831c7c7d";
+  sha256 = "sha256-NdV7q5xbwNIa95sttPUf98Tuv8/CB50cSwY3Db9wzMY=";
+}

--- a/manifests/forc-tx-0.35.1.nix
+++ b/manifests/forc-tx-0.35.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.1";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
+  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
+}

--- a/manifests/forc-tx-0.35.2-nightly-2023-02-18.nix
+++ b/manifests/forc-tx-0.35.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-tx-0.35.2-nightly-2023-02-19.nix
+++ b/manifests/forc-tx-0.35.2-nightly-2023-02-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.2";
+  date = "2023-02-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "44aa2e2fc7c0c6522de522621ba543145050761f";
+  sha256 = "sha256-8suKLHo/eE3Fbb3g705RlYAm6e3bu7KzDMCEL038FEY=";
+}

--- a/manifests/forc-tx-0.35.2-nightly-2023-02-21.nix
+++ b/manifests/forc-tx-0.35.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d1c2ed9d68246d8dc308e15e0724bc86fda1916f";
+  sha256 = "sha256-AwOTwFcNvt1RK3gVP8CcZ6kQom2ppkcFIUX6DCSXbQg=";
+}

--- a/manifests/forc-tx-0.35.2.nix
+++ b/manifests/forc-tx-0.35.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
+  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
+}

--- a/manifests/forc-wallet-0.1.3-nightly-2023-02-18.nix
+++ b/manifests/forc-wallet-0.1.3-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.1.3";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "4070e5276ef03b8891b80a075892cc238fd0ceee";
+  sha256 = "sha256-3DluZeDLCvXNcCn81M+DM590IK+3MB4C7NQuu0YlyZg=";
+}

--- a/manifests/forc-wallet-0.2.0.nix
+++ b/manifests/forc-wallet-0.2.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.2.0";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "c0a69f05e48031632b58e1b69eebb1ea19b6dd2d";
+  sha256 = "sha256-cUeASmn/40N07gDve83mNprpMoNxxheVN51e+ferIk8=";
+}

--- a/manifests/fuel-core-0.16.0.nix
+++ b/manifests/fuel-core-0.16.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.16.0";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "17164720336031a756c336926bdd961baccfdfb3";
+  sha256 = "sha256-8WPdMug3VsbiRnZH97+i/o1TqrHmmCaoPN9J3ZMzwd8=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-16.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "95a9608d61fee2f30446bb59d967c3dad2655fef";
+  sha256 = "sha256-iQGu2qnySx2uYwc15mWe70HWLnKZjtfGX0p/BqlNVXA=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-17.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "8a48f4d6390a8a98899f29918590a482ff77aa9b";
+  sha256 = "sha256-/ckOIru/DyVwdauBcTuCV91T00Id1E7CL2xK9zCVLHw=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-18.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "31e81ff34716cb3d72eb190d1aec8e2c68b44bab";
+  sha256 = "sha256-XRihxjPO0/AoAFYBuiurq24NcaxOfYVfpsVmNesDZLw=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-20.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0cefc99bbf4e14c6c43702f33954efebd3ebdc76";
+  sha256 = "sha256-V4O0xG/BejzdjlXLbZ4w6Er/eVHaVDi23V/Ozdg6AP4=";
+}

--- a/manifests/fuel-core-0.17.2-nightly-2023-02-21.nix
+++ b/manifests/fuel-core-0.17.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0b2f445b2d25f0a394445df6b9361f302b6b84e7";
+  sha256 = "sha256-QRAb/Bn4AiucgDVKj+JtUHqaNrXpFx6chp0is+HyxFc=";
+}

--- a/manifests/fuel-core-0.17.2.nix
+++ b/manifests/fuel-core-0.17.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.2";
+  date = "2023-02-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "95a9608d61fee2f30446bb59d967c3dad2655fef";
+  sha256 = "sha256-iQGu2qnySx2uYwc15mWe70HWLnKZjtfGX0p/BqlNVXA=";
+}

--- a/manifests/fuel-core-client-0.16.0.nix
+++ b/manifests/fuel-core-client-0.16.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.16.0";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "17164720336031a756c336926bdd961baccfdfb3";
+  sha256 = "sha256-8WPdMug3VsbiRnZH97+i/o1TqrHmmCaoPN9J3ZMzwd8=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-16.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "95a9608d61fee2f30446bb59d967c3dad2655fef";
+  sha256 = "sha256-iQGu2qnySx2uYwc15mWe70HWLnKZjtfGX0p/BqlNVXA=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-17.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "8a48f4d6390a8a98899f29918590a482ff77aa9b";
+  sha256 = "sha256-/ckOIru/DyVwdauBcTuCV91T00Id1E7CL2xK9zCVLHw=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-18.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "31e81ff34716cb3d72eb190d1aec8e2c68b44bab";
+  sha256 = "sha256-XRihxjPO0/AoAFYBuiurq24NcaxOfYVfpsVmNesDZLw=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-20.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0cefc99bbf4e14c6c43702f33954efebd3ebdc76";
+  sha256 = "sha256-V4O0xG/BejzdjlXLbZ4w6Er/eVHaVDi23V/Ozdg6AP4=";
+}

--- a/manifests/fuel-core-client-0.17.2-nightly-2023-02-21.nix
+++ b/manifests/fuel-core-client-0.17.2-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0b2f445b2d25f0a394445df6b9361f302b6b84e7";
+  sha256 = "sha256-QRAb/Bn4AiucgDVKj+JtUHqaNrXpFx6chp0is+HyxFc=";
+}

--- a/manifests/fuel-core-client-0.17.2.nix
+++ b/manifests/fuel-core-client-0.17.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.2";
+  date = "2023-02-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "95a9608d61fee2f30446bb59d967c3dad2655fef";
+  sha256 = "sha256-iQGu2qnySx2uYwc15mWe70HWLnKZjtfGX0p/BqlNVXA=";
+}

--- a/manifests/fuel-indexer-0.2.3-nightly-2023-02-16.nix
+++ b/manifests/fuel-indexer-0.2.3-nightly-2023-02-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.3";
+  date = "2023-02-16";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "6b318e9d92b014583af91a1fdf8e35ce3ed86dd9";
+  sha256 = "sha256-A8/dgeUXmBB4OoFbF1eJVVzHinoprcYHOgRjN1JKOis=";
+}

--- a/manifests/fuel-indexer-0.2.3-nightly-2023-02-17.nix
+++ b/manifests/fuel-indexer-0.2.3-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.2.3";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "105deac1224963592625ebc55c7a88e17cdf91fd";
+  sha256 = "sha256-TfOPCIHzd/lQDd1EY6N2ltdnu0Bq7sqCURthUwPN+U0=";
+}

--- a/manifests/fuel-indexer-0.3.0-nightly-2023-02-18.nix
+++ b/manifests/fuel-indexer-0.3.0-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.3.0";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
+  sha256 = "sha256-Co7LCA6xflg8ExTsEJQvepmtSWkAEZpmm0n3shx7i0c=";
+}

--- a/manifests/fuel-indexer-0.3.0-nightly-2023-02-21.nix
+++ b/manifests/fuel-indexer-0.3.0-nightly-2023-02-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.3.0";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "69a6039cdfbcb2944390fa9eca507caaa21b2aa2";
+  sha256 = "sha256-BQ/2Z4XustvZeek+mOXTrmdkVowD4PHFzJ+9gDi60hc=";
+}

--- a/manifests/fuel-indexer-0.3.0.nix
+++ b/manifests/fuel-indexer-0.3.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.3.0";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
+  sha256 = "sha256-Co7LCA6xflg8ExTsEJQvepmtSWkAEZpmm0n3shx7i0c=";
+}

--- a/manifests/fuelup-0.0.0.nix
+++ b/manifests/fuelup-0.0.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.0.0";
+  date = "2022-05-25";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "80d488d98449ce92446f969796e187676c70f98d";
+  sha256 = "sha256-HG0kI5Hu5IdDAxQk9/dz2GBy/Od9byhIC751P5gqKDM=";
+}

--- a/manifests/fuelup-0.0.1.nix
+++ b/manifests/fuelup-0.0.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.0.1";
+  date = "2022-05-25";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "c2120ecb84c51faa873fb06de74d95e537368984";
+  sha256 = "sha256-4LiiuN64+Y8+LduYleqyXeI6bdCE5LcKYCu+8RgXy0U=";
+}

--- a/manifests/fuelup-0.1.0.nix
+++ b/manifests/fuelup-0.1.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.1.0";
+  date = "2022-05-27";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "226cf5cc81e09f23d1dfd2f23b5866d07ee7eed2";
+  sha256 = "sha256-27Gj9jlBO3RtpjD3VZ6xMnp3wLZrTjJ43R0SJlW1PMo=";
+}

--- a/manifests/fuelup-0.1.1.nix
+++ b/manifests/fuelup-0.1.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.1.1";
+  date = "2022-05-27";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "1932a08a9b7e81a06d7be94864b6d6e9d48ab558";
+  sha256 = "sha256-NRTss2IhRvNYXzu7K5o4z5Ov/s26g0L3wfHSUVOywDI=";
+}

--- a/manifests/fuelup-0.1.2.nix
+++ b/manifests/fuelup-0.1.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.1.2";
+  date = "2022-05-28";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "03815ae5d7f7ed94c60d7836ecab0236ee7d1ef4";
+  sha256 = "sha256-PC768klXr/27As7I5F7PSZlb3twyXgAsVusR+3NP2PM=";
+}

--- a/manifests/fuelup-0.1.3.nix
+++ b/manifests/fuelup-0.1.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.1.3";
+  date = "2022-06-12";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "abeef7918e53412eeabb5c26274a18d8cdcb10a0";
+  sha256 = "sha256-P4dsoKaF3JLpRusv+vjYRCP/feWP5Ef3Rbxzwm03ADE=";
+}

--- a/manifests/fuelup-0.10.0-nightly-2022-10-27.nix
+++ b/manifests/fuelup-0.10.0-nightly-2022-10-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.10.0";
+  date = "2022-10-27";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "55a9677047012c3a3e3c919b2208cc828d16f74d";
+  sha256 = "sha256-iXF7emc10VEyX5SY/YUwhY/2RjcHY3WW+4JicQ19RYA=";
+}

--- a/manifests/fuelup-0.10.0.nix
+++ b/manifests/fuelup-0.10.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.10.0";
+  date = "2022-10-26";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "f1a6d969d134a494cfffa65f42d65bc86318724d";
+  sha256 = "sha256-a5mT7+n7/fbB6WVufck2a9HOY1/yP+c1EVcM0bsvAEw=";
+}

--- a/manifests/fuelup-0.10.1-nightly-2022-10-28.nix
+++ b/manifests/fuelup-0.10.1-nightly-2022-10-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.10.1";
+  date = "2022-10-28";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "e17dfa3611e6384b385b549c76fdf273ce18770c";
+  sha256 = "sha256-7UpKgnL/9OUdl94pZjzetLnO59uoIO2mDNNoWZTi93A=";
+}

--- a/manifests/fuelup-0.10.1-nightly-2022-11-02.nix
+++ b/manifests/fuelup-0.10.1-nightly-2022-11-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.10.1";
+  date = "2022-11-02";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "b3318333c7bd33193a8ff830000f74399f57fe82";
+  sha256 = "sha256-A+BmfSSEt/CrxxHZD1fPQp7pTH9Y/oDEWj/Co+bmilk=";
+}

--- a/manifests/fuelup-0.10.1-nightly-2022-11-04.nix
+++ b/manifests/fuelup-0.10.1-nightly-2022-11-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.10.1";
+  date = "2022-11-04";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "47d0d7ff248180b81365f933dd62d4fb8b0e51bc";
+  sha256 = "sha256-jzvp58YaDpRz5mZ/HxQi8W6uXB0fwGNPnSfeiYaNiQs=";
+}

--- a/manifests/fuelup-0.10.1.nix
+++ b/manifests/fuelup-0.10.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.10.1";
+  date = "2022-10-27";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "e17dfa3611e6384b385b549c76fdf273ce18770c";
+  sha256 = "sha256-7UpKgnL/9OUdl94pZjzetLnO59uoIO2mDNNoWZTi93A=";
+}

--- a/manifests/fuelup-0.10.2-nightly-2022-11-07.nix
+++ b/manifests/fuelup-0.10.2-nightly-2022-11-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.10.2";
+  date = "2022-11-07";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "dc2eaf413889bb2ade88f2fdda97feea0b2b64b6";
+  sha256 = "sha256-cuEHBwHvJukQN/Hkf+S+g69zCbGeL/LM5NrgnPyOW14=";
+}

--- a/manifests/fuelup-0.10.2.nix
+++ b/manifests/fuelup-0.10.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.10.2";
+  date = "2022-11-06";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "dc2eaf413889bb2ade88f2fdda97feea0b2b64b6";
+  sha256 = "sha256-cuEHBwHvJukQN/Hkf+S+g69zCbGeL/LM5NrgnPyOW14=";
+}

--- a/manifests/fuelup-0.11.0-nightly-2022-11-08.nix
+++ b/manifests/fuelup-0.11.0-nightly-2022-11-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.11.0";
+  date = "2022-11-08";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "14a5a691a0708a12981c0bc85d3a201d92ff7ef4";
+  sha256 = "sha256-cNFlenlYjlz58p50g8EeJ6hx3OasuVr8moAEEejn6n4=";
+}

--- a/manifests/fuelup-0.11.0.nix
+++ b/manifests/fuelup-0.11.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.11.0";
+  date = "2022-11-07";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "14a5a691a0708a12981c0bc85d3a201d92ff7ef4";
+  sha256 = "sha256-cNFlenlYjlz58p50g8EeJ6hx3OasuVr8moAEEejn6n4=";
+}

--- a/manifests/fuelup-0.11.1-nightly-2022-11-11.nix
+++ b/manifests/fuelup-0.11.1-nightly-2022-11-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.11.1";
+  date = "2022-11-11";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "403303daf2985fb886c6af4aa42138b51a8e3a78";
+  sha256 = "sha256-WmfSIak1H7NU2CBh1TJfm5ifM8Gz1vU1tZ1lg/ZLsoQ=";
+}

--- a/manifests/fuelup-0.11.1.nix
+++ b/manifests/fuelup-0.11.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.11.1";
+  date = "2022-11-10";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "403303daf2985fb886c6af4aa42138b51a8e3a78";
+  sha256 = "sha256-WmfSIak1H7NU2CBh1TJfm5ifM8Gz1vU1tZ1lg/ZLsoQ=";
+}

--- a/manifests/fuelup-0.12.0-nightly-2022-11-16.nix
+++ b/manifests/fuelup-0.12.0-nightly-2022-11-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.12.0";
+  date = "2022-11-16";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "a7cf5500ec6eccac9952bfd7717575dad48efde8";
+  sha256 = "sha256-zjqPNRDZ+zn5EM9eRmv6AxbXObEnj3ZvzJ4XjUhD2Aw=";
+}

--- a/manifests/fuelup-0.12.0.nix
+++ b/manifests/fuelup-0.12.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.12.0";
+  date = "2022-11-15";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "a7cf5500ec6eccac9952bfd7717575dad48efde8";
+  sha256 = "sha256-zjqPNRDZ+zn5EM9eRmv6AxbXObEnj3ZvzJ4XjUhD2Aw=";
+}

--- a/manifests/fuelup-0.12.1-nightly-2022-11-17.nix
+++ b/manifests/fuelup-0.12.1-nightly-2022-11-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.12.1";
+  date = "2022-11-17";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "838bfe7d46a564b1b508b59f32abbd49ba95ffd5";
+  sha256 = "sha256-/qsUbAXoFrXP2SrdcBcLyD/+vZCFB4JWLvlVYCyvKFo=";
+}

--- a/manifests/fuelup-0.12.1.nix
+++ b/manifests/fuelup-0.12.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.12.1";
+  date = "2022-11-16";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "838bfe7d46a564b1b508b59f32abbd49ba95ffd5";
+  sha256 = "sha256-/qsUbAXoFrXP2SrdcBcLyD/+vZCFB4JWLvlVYCyvKFo=";
+}

--- a/manifests/fuelup-0.12.2-nightly-2022-11-23.nix
+++ b/manifests/fuelup-0.12.2-nightly-2022-11-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.12.2";
+  date = "2022-11-23";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "b85f3c08f775d61f3683177600e6dc5f862ce78f";
+  sha256 = "sha256-3zSvgwyoRn6beQXCUDHQp3YOjEYaMH3pGtdIQLpqvhE=";
+}

--- a/manifests/fuelup-0.12.2-nightly-2022-11-24.nix
+++ b/manifests/fuelup-0.12.2-nightly-2022-11-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.12.2";
+  date = "2022-11-24";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "06a15b4c0560eacc88ce9ca374510183fdb59a81";
+  sha256 = "sha256-UucTxhMSocnX+W3UJPx7ixXQfN1ERIc6CFkW2yDfkU4=";
+}

--- a/manifests/fuelup-0.12.2.nix
+++ b/manifests/fuelup-0.12.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.12.2";
+  date = "2022-11-22";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "b85f3c08f775d61f3683177600e6dc5f862ce78f";
+  sha256 = "sha256-3zSvgwyoRn6beQXCUDHQp3YOjEYaMH3pGtdIQLpqvhE=";
+}

--- a/manifests/fuelup-0.13.0-nightly-2022-11-30.nix
+++ b/manifests/fuelup-0.13.0-nightly-2022-11-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.13.0";
+  date = "2022-11-30";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "3a15c8632c0018ab2a21f136dfcd1a97b4f1d63c";
+  sha256 = "sha256-lTcGtSpCzV7UUST5Oidq/03IHXl1suBqJHIxNNxhkQQ=";
+}

--- a/manifests/fuelup-0.13.0-nightly-2022-12-03.nix
+++ b/manifests/fuelup-0.13.0-nightly-2022-12-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.13.0";
+  date = "2022-12-03";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "2f7ed01d79146050f0cfe54ba25cc1588d8d101a";
+  sha256 = "sha256-dBsk1mM8Gi/kJQEVL8db2Rzwd+j9B61TZzASWUKTokA=";
+}

--- a/manifests/fuelup-0.13.0.nix
+++ b/manifests/fuelup-0.13.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.13.0";
+  date = "2022-11-30";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "3a15c8632c0018ab2a21f136dfcd1a97b4f1d63c";
+  sha256 = "sha256-lTcGtSpCzV7UUST5Oidq/03IHXl1suBqJHIxNNxhkQQ=";
+}

--- a/manifests/fuelup-0.14.0-nightly-2022-12-06.nix
+++ b/manifests/fuelup-0.14.0-nightly-2022-12-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.14.0";
+  date = "2022-12-06";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "706fad298a0a48ddc281feec4f6776b291c5de89";
+  sha256 = "sha256-ceihXnTv4E0gKPNboBusMrpYRV8gqchUMhIPY1oLTyE=";
+}

--- a/manifests/fuelup-0.14.0-nightly-2022-12-08.nix
+++ b/manifests/fuelup-0.14.0-nightly-2022-12-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.14.0";
+  date = "2022-12-08";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "f457c4b4a5b2583492879bfee74b6faf4a27a9ac";
+  sha256 = "sha256-TYRNz0ZTT9ceky/s7KdOA/rknqI90+Lzeyb/HW3r7hw=";
+}

--- a/manifests/fuelup-0.14.0-nightly-2022-12-09.nix
+++ b/manifests/fuelup-0.14.0-nightly-2022-12-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.14.0";
+  date = "2022-12-09";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "07381e1597568d6f200d50c97e3780bab8edd4a3";
+  sha256 = "sha256-jNJ8NEbuOk4qsuqQ562KHJyfEpjeD28XH2TFql4I7Os=";
+}

--- a/manifests/fuelup-0.14.0-nightly-2022-12-13.nix
+++ b/manifests/fuelup-0.14.0-nightly-2022-12-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.14.0";
+  date = "2022-12-13";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "22c5a5f85b3e57ffe5e76bf550a7f21c254494ca";
+  sha256 = "sha256-O7Fm7WEUwy2VTWWAgIRuVIqFbW7uZkHCNNEMQIRjEjw=";
+}

--- a/manifests/fuelup-0.14.0.nix
+++ b/manifests/fuelup-0.14.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.14.0";
+  date = "2022-12-05";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "706fad298a0a48ddc281feec4f6776b291c5de89";
+  sha256 = "sha256-ceihXnTv4E0gKPNboBusMrpYRV8gqchUMhIPY1oLTyE=";
+}

--- a/manifests/fuelup-0.15.0-nightly-2022-12-14.nix
+++ b/manifests/fuelup-0.15.0-nightly-2022-12-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.0";
+  date = "2022-12-14";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "a04db2f2a54881db679b77e6449f21e9f682254b";
+  sha256 = "sha256-6ZjSAL77yNABs/g0wuPHrBrhSSeZPGwKzb/G+oEZ5tQ=";
+}

--- a/manifests/fuelup-0.15.0-nightly-2022-12-15.nix
+++ b/manifests/fuelup-0.15.0-nightly-2022-12-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.0";
+  date = "2022-12-15";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "1309f6b6d9c4ce7a9f9e138e7e00cb353ca99689";
+  sha256 = "sha256-kNZ0EwQrY4oQNGPgOReD4Zs0v3MPUgENV8lhsgTuYkg=";
+}

--- a/manifests/fuelup-0.15.0-nightly-2022-12-16.nix
+++ b/manifests/fuelup-0.15.0-nightly-2022-12-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.0";
+  date = "2022-12-16";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "ee798dfa5eb6750d01631bd380cfceb45fbebf07";
+  sha256 = "sha256-CNtS8IL44AL0kU+KIWTQmBGDjWQhbo2CdEIEsZCl44E=";
+}

--- a/manifests/fuelup-0.15.0.nix
+++ b/manifests/fuelup-0.15.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.0";
+  date = "2022-12-13";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "a04db2f2a54881db679b77e6449f21e9f682254b";
+  sha256 = "sha256-6ZjSAL77yNABs/g0wuPHrBrhSSeZPGwKzb/G+oEZ5tQ=";
+}

--- a/manifests/fuelup-0.15.1-nightly-2022-12-17.nix
+++ b/manifests/fuelup-0.15.1-nightly-2022-12-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.1";
+  date = "2022-12-17";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "50e257927564fbfb8e15b55194a653617fd40a94";
+  sha256 = "sha256-mG6yeYPYLrgNth3W55LH8KhFysoeRZCyowS9hLyox7k=";
+}

--- a/manifests/fuelup-0.15.1-nightly-2023-01-05.nix
+++ b/manifests/fuelup-0.15.1-nightly-2023-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.1";
+  date = "2023-01-05";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "7bfbebec74c6173ca55b8ec31d146d3d47be635d";
+  sha256 = "sha256-ZhivmSJmmJ964CQHhHo4utXVh5eAwU0bQYSDwm5cSqM=";
+}

--- a/manifests/fuelup-0.15.1-nightly-2023-01-06.nix
+++ b/manifests/fuelup-0.15.1-nightly-2023-01-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.1";
+  date = "2023-01-06";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "5613fa26f7601326dc2339cad1ee5282507cc4a5";
+  sha256 = "sha256-eGJDt14PKEPkRrn3CPRSi+FV0ILhAOwUhQKhXbJAXvM=";
+}

--- a/manifests/fuelup-0.15.1-nightly-2023-01-11.nix
+++ b/manifests/fuelup-0.15.1-nightly-2023-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.1";
+  date = "2023-01-11";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "cceb6f89227d1067c78f534f6654fd2fc9bc8b00";
+  sha256 = "sha256-23DzkMoIj6U96Hiqn5IyyeQdvutZX7KahhPCyEXHtYg=";
+}

--- a/manifests/fuelup-0.15.1-nightly-2023-01-12.nix
+++ b/manifests/fuelup-0.15.1-nightly-2023-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.1";
+  date = "2023-01-12";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "0a9be113045b73bdf4c563507b0afeff672e1d40";
+  sha256 = "sha256-WQd5dkP57QppfLdXnnIAPPbKOEUKLXNdKAb6VDSFGgQ=";
+}

--- a/manifests/fuelup-0.15.1-nightly-2023-01-13.nix
+++ b/manifests/fuelup-0.15.1-nightly-2023-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.1";
+  date = "2023-01-13";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "60339cbd0e9a8630b9f47cc3e33ef7e96a6efce7";
+  sha256 = "sha256-+8fcGRv9AYT2Q3ZHoOHitW/bUE8/Y93yQCQY/ouoBw0=";
+}

--- a/manifests/fuelup-0.15.1-nightly-2023-01-17.nix
+++ b/manifests/fuelup-0.15.1-nightly-2023-01-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.1";
+  date = "2023-01-17";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "42a054f13e281f8759ac28066d6ee2d66ffb2a44";
+  sha256 = "sha256-6lZvLcIhCaKulpXBUo28FJLb+p819s+LLPYTf5OTqHM=";
+}

--- a/manifests/fuelup-0.15.1.nix
+++ b/manifests/fuelup-0.15.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.15.1";
+  date = "2022-12-16";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "50e257927564fbfb8e15b55194a653617fd40a94";
+  sha256 = "sha256-mG6yeYPYLrgNth3W55LH8KhFysoeRZCyowS9hLyox7k=";
+}

--- a/manifests/fuelup-0.16.0-nightly-2023-01-18.nix
+++ b/manifests/fuelup-0.16.0-nightly-2023-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.0";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "0e447648f884c39196e09ec5415a33fc360323ae";
+  sha256 = "sha256-scvBallzXumYQqzyP8U5yd68pd33IleEFJaGt6YTJVQ=";
+}

--- a/manifests/fuelup-0.16.0.nix
+++ b/manifests/fuelup-0.16.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.0";
+  date = "2023-01-17";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "0e447648f884c39196e09ec5415a33fc360323ae";
+  sha256 = "sha256-scvBallzXumYQqzyP8U5yd68pd33IleEFJaGt6YTJVQ=";
+}

--- a/manifests/fuelup-0.16.1-nightly-2023-01-19.nix
+++ b/manifests/fuelup-0.16.1-nightly-2023-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.1";
+  date = "2023-01-19";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "bd4855bfbca5df0886ab0f9966e7fd2044b89ad4";
+  sha256 = "sha256-XlLFMRIhRjN6bo7UnlYdcMNKk55mFUAFcvgKdrIX6qc=";
+}

--- a/manifests/fuelup-0.16.1-nightly-2023-01-21.nix
+++ b/manifests/fuelup-0.16.1-nightly-2023-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.1";
+  date = "2023-01-21";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "85c0936d797818adcd0535578234e744157d55a6";
+  sha256 = "sha256-X7Cp1nzOSnYXnuoVnMf5LumWSan82GNKGaRVtO1bjQ0=";
+}

--- a/manifests/fuelup-0.16.1-nightly-2023-01-23.nix
+++ b/manifests/fuelup-0.16.1-nightly-2023-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.1";
+  date = "2023-01-23";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "ec41db03b98f3d3b91de27cecbafa3f543fce7f6";
+  sha256 = "sha256-keY4aiQuu4OZLwQNtiFj45MkVWUFhiU5HFjACcKQoP0=";
+}

--- a/manifests/fuelup-0.16.1-nightly-2023-01-25.nix
+++ b/manifests/fuelup-0.16.1-nightly-2023-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.1";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "b0ad26c70fab460c1835ab12f6f2932b444b9658";
+  sha256 = "sha256-jC7qsVlftVt3wkaSiQX5Pg/YIOi/UPeUSH3wU7m58bo=";
+}

--- a/manifests/fuelup-0.16.1.nix
+++ b/manifests/fuelup-0.16.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.1";
+  date = "2023-01-18";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "bf116711456ed0355554ea8ca1075507fe8d7cf4";
+  sha256 = "sha256-wrYgAAoFfJqo23Hsz9BMqpsDvllhT5SgtszFpwJjdzw=";
+}

--- a/manifests/fuelup-0.16.2-nightly-2023-01-26.nix
+++ b/manifests/fuelup-0.16.2-nightly-2023-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.2";
+  date = "2023-01-26";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "ecbac1a58fb252bb1d528a9e8e1a79c4b32a0b63";
+  sha256 = "sha256-6SbC6XkxELqMz6HqLwHEpxs4ONxa4B1Ue/Dlrva7Rr8=";
+}

--- a/manifests/fuelup-0.16.2-nightly-2023-01-27.nix
+++ b/manifests/fuelup-0.16.2-nightly-2023-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.2";
+  date = "2023-01-27";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "92025fa33607010c40868bb971cb0e2d0119a193";
+  sha256 = "sha256-gWzlwdGdglSCIRZPQTdD9FlNmF9gGQPOsh4zBWnSWw8=";
+}

--- a/manifests/fuelup-0.16.2-nightly-2023-01-28.nix
+++ b/manifests/fuelup-0.16.2-nightly-2023-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.2";
+  date = "2023-01-28";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "d52c81f3a77a9784db5fc45682408efa61705456";
+  sha256 = "sha256-Ujaf5igI73EHwC9ZzMaPSFhRHroDQeYD2FVKqaClv6A=";
+}

--- a/manifests/fuelup-0.16.2-nightly-2023-01-31.nix
+++ b/manifests/fuelup-0.16.2-nightly-2023-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.2";
+  date = "2023-01-31";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "a3532b292c4ddff50afb2a322e93e9d84099411c";
+  sha256 = "sha256-MsbaNiVsUCfRIQxbRRmwLed/0aVUlb0Pop9upSA4rbI=";
+}

--- a/manifests/fuelup-0.16.2-nightly-2023-02-02.nix
+++ b/manifests/fuelup-0.16.2-nightly-2023-02-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.2";
+  date = "2023-02-02";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "a52da311c0a4fe6de4c24bbaf948267f5942a768";
+  sha256 = "sha256-oerTc823q/NEVxmjzvAD2umrCk/CX0+lMhNqOpxlRhs=";
+}

--- a/manifests/fuelup-0.16.2-nightly-2023-02-09.nix
+++ b/manifests/fuelup-0.16.2-nightly-2023-02-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.2";
+  date = "2023-02-09";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "3d70b85f07bee7be4dfcc5ea3d3f86347f94162a";
+  sha256 = "sha256-iSOV7Co8t13MhO6lckh4THREpwWUqbyUerBOdfZj2os=";
+}

--- a/manifests/fuelup-0.16.2.nix
+++ b/manifests/fuelup-0.16.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.16.2";
+  date = "2023-01-25";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "ecbac1a58fb252bb1d528a9e8e1a79c4b32a0b63";
+  sha256 = "sha256-6SbC6XkxELqMz6HqLwHEpxs4ONxa4B1Ue/Dlrva7Rr8=";
+}

--- a/manifests/fuelup-0.17.0.nix
+++ b/manifests/fuelup-0.17.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.17.0";
+  date = "2023-02-09";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "83d6f19ef3126360d89a85edfaebd31e96a852bf";
+  sha256 = "sha256-Be4V7pUiDkn9Kazn+cPQveDiltzwOie7uRV4JYANhjY=";
+}

--- a/manifests/fuelup-0.17.1.nix
+++ b/manifests/fuelup-0.17.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.17.1";
+  date = "2023-02-09";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "ca5aeee5040eb9ed7f4509d670f299fb55507edc";
+  sha256 = "sha256-fjZqeEOCfTveK1xEHoMzkBYSJR4kJ0pMPCd8WYiyc2A=";
+}

--- a/manifests/fuelup-0.18.0-nightly-2023-02-10.nix
+++ b/manifests/fuelup-0.18.0-nightly-2023-02-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.18.0";
+  date = "2023-02-10";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "0cd59d056a3295edf604860ce538adcbddee2197";
+  sha256 = "sha256-sg3eInhS1cEzHZTzj5DTfA3ARYgHTDZDQnI+3i92720=";
+}

--- a/manifests/fuelup-0.18.0-nightly-2023-02-11.nix
+++ b/manifests/fuelup-0.18.0-nightly-2023-02-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.18.0";
+  date = "2023-02-11";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "3abe817673184ac17a78b2a8965234813ac6d911";
+  sha256 = "sha256-cxjdqLvN7WNdmNcW4PWfxa8DNW/qwqIJ4H/JvX5oQM0=";
+}

--- a/manifests/fuelup-0.18.0-nightly-2023-02-15.nix
+++ b/manifests/fuelup-0.18.0-nightly-2023-02-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.18.0";
+  date = "2023-02-15";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "c5603404d69e0b75f4647004578ccf3ec67c4bce";
+  sha256 = "sha256-pK3bCU0nO5yWK2OBhliETVlyap/yHg342nE+GbG22Zg=";
+}

--- a/manifests/fuelup-0.18.0-nightly-2023-02-17.nix
+++ b/manifests/fuelup-0.18.0-nightly-2023-02-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.18.0";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "6e6ad7cacdb23ab8d0e7ac01e786a33f0043954c";
+  sha256 = "sha256-UCK6rWy2ZAH3obeyJN6SvXHQZYI2ldY2Re7gM7wAklY=";
+}

--- a/manifests/fuelup-0.18.0.nix
+++ b/manifests/fuelup-0.18.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.18.0";
+  date = "2023-02-10";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "0cd59d056a3295edf604860ce538adcbddee2197";
+  sha256 = "sha256-sg3eInhS1cEzHZTzj5DTfA3ARYgHTDZDQnI+3i92720=";
+}

--- a/manifests/fuelup-0.18.1-nightly-2023-02-18.nix
+++ b/manifests/fuelup-0.18.1-nightly-2023-02-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.18.1";
+  date = "2023-02-18";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "3bfc07a2f1f3b930a8c6fd4d9143c17d13480bd6";
+  sha256 = "sha256-yGkfiJGvIuo67EUi2GWoxCpv6MXXpNYe4lj93cLKEPs=";
+}

--- a/manifests/fuelup-0.18.1.nix
+++ b/manifests/fuelup-0.18.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.18.1";
+  date = "2023-02-17";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "3bfc07a2f1f3b930a8c6fd4d9143c17d13480bd6";
+  sha256 = "sha256-yGkfiJGvIuo67EUi2GWoxCpv6MXXpNYe4lj93cLKEPs=";
+}

--- a/manifests/fuelup-0.2.0.nix
+++ b/manifests/fuelup-0.2.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.2.0";
+  date = "2022-06-22";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "473bc9c946e73162cc9ee8ff330896bf97ae5654";
+  sha256 = "sha256-snvpbSwTWPrHs+Tcn30Q+rpBwPZm1MRMoX9h5WimlsU=";
+}

--- a/manifests/fuelup-0.2.1.nix
+++ b/manifests/fuelup-0.2.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.2.1";
+  date = "2022-06-23";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "8e2709ceb9f0597ddfc241a5b28eeb8df246cae7";
+  sha256 = "sha256-F/xaspkHQcKbYQLCAOb9qHPNyg2Zk9K0VTbm2ieNEyY=";
+}

--- a/manifests/fuelup-0.2.2.nix
+++ b/manifests/fuelup-0.2.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.2.2";
+  date = "2022-07-07";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "f0829301db366a76fec4367b6434d9d548b4efc7";
+  sha256 = "sha256-eqVGaSz9TawCUK7iahuRlhgXxO+OrvZmISLVnWyjjk8=";
+}

--- a/manifests/fuelup-0.2.3.nix
+++ b/manifests/fuelup-0.2.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.2.3";
+  date = "2022-08-11";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "8d87c9c9cd846ebb339e7e595827c1d75e5e7ff8";
+  sha256 = "sha256-+a9msvn13v7GCjdvivm8eBANHgaMjPM6k7JGcIAxleY=";
+}

--- a/manifests/fuelup-0.3.0.nix
+++ b/manifests/fuelup-0.3.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.3.0";
+  date = "2022-08-19";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "5806bcc2d679db0b21c90b0af55f13df7897a42f";
+  sha256 = "sha256-9WfqmELID1chHKk9PVX7R1/HlPrFeRqN509k0cH+s94=";
+}

--- a/manifests/fuelup-0.3.1.nix
+++ b/manifests/fuelup-0.3.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.3.1";
+  date = "2022-08-19";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "02662d17473ca0efa39d6829fa2f433a1f2c6f12";
+  sha256 = "sha256-rAXqOkBHPAzrkj7WIzAKTO9nmzAfRBBu3QmfS3+GUtI=";
+}

--- a/manifests/fuelup-0.3.2.nix
+++ b/manifests/fuelup-0.3.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.3.2";
+  date = "2022-08-19";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "2574af8bdb9e1811f95f01672728c31024cf4952";
+  sha256 = "sha256-ptYuccyYpEwThPCnzKfxT1oZORlXnqtVks8q9H6+2CU=";
+}

--- a/manifests/fuelup-0.3.3.nix
+++ b/manifests/fuelup-0.3.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.3.3";
+  date = "2022-08-23";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "cc3c0b6ceed34ec55efe2bc54c8c36d46e3f8a44";
+  sha256 = "sha256-FlGMQh/UU7TAbvlAv2FdAySWGMhjhu++QmTNsUuXxPo=";
+}

--- a/manifests/fuelup-0.4.0-nightly-2022-09-01.nix
+++ b/manifests/fuelup-0.4.0-nightly-2022-09-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.4.0";
+  date = "2022-09-01";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "d5b8a621515f0f98f35b36dfe70ea2af37f22fee";
+  sha256 = "sha256-Cpds7gmBijt1iYEqSLisMBuuIC0fyZAmsNYGTVaFbrc=";
+}

--- a/manifests/fuelup-0.4.0-nightly-2022-09-03.nix
+++ b/manifests/fuelup-0.4.0-nightly-2022-09-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.4.0";
+  date = "2022-09-03";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "e8cf9ec7609b5acdcbcef05b8a9333f2102e8fea";
+  sha256 = "sha256-ahFapkka/Akm9sCvmNLtuIx3qandEuZvpn5G9xmjtyk=";
+}

--- a/manifests/fuelup-0.4.0.nix
+++ b/manifests/fuelup-0.4.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.4.0";
+  date = "2022-08-24";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "f04133187879b3f39c6f324d0175c1de31d860a0";
+  sha256 = "sha256-eix5ozYztlmxfbzuL0HMM6lykNYQ1eHZbgleTFi4hjE=";
+}

--- a/manifests/fuelup-0.5.0-nightly-2022-09-06.nix
+++ b/manifests/fuelup-0.5.0-nightly-2022-09-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-06";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "168097bdcbf7f2ddb4f863da9da86d7bc022082b";
+  sha256 = "sha256-PYelve1C6I80ZNUCITyLdMrbJuROS4Sj1Fhy/GaOdZc=";
+}

--- a/manifests/fuelup-0.5.0-nightly-2022-09-08.nix
+++ b/manifests/fuelup-0.5.0-nightly-2022-09-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-08";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "fe8842917416dbc711818aeb94f6885eeacee4ab";
+  sha256 = "sha256-tEPM12wxEZejIyLzh7D//OmKQcbFIMW34UF5UgOF778=";
+}

--- a/manifests/fuelup-0.5.0-nightly-2022-09-09.nix
+++ b/manifests/fuelup-0.5.0-nightly-2022-09-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-09";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "2529057f0fac6f8a8b991b22b5c1f464454e3af8";
+  sha256 = "sha256-8jsDhwvJGM07NzkwY2J+lJGhWBwdkmnpHfjaffu4p+g=";
+}

--- a/manifests/fuelup-0.5.0-nightly-2022-09-11.nix
+++ b/manifests/fuelup-0.5.0-nightly-2022-09-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-11";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "1c86cecbb72129b069f93706e06688f8eb7e1962";
+  sha256 = "sha256-eX2mh6SAKifugeact8zBGz/xADsH9rVdJZ6KUum9ZRw=";
+}

--- a/manifests/fuelup-0.5.0-nightly-2022-09-13.nix
+++ b/manifests/fuelup-0.5.0-nightly-2022-09-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-13";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "e5b00d25c7057f7bcb7fd3c5c1900c4804c1de26";
+  sha256 = "sha256-gxEG6J/ZNWfoiv4LhawyIZlkDci8nUVHvJFYiDljWS0=";
+}

--- a/manifests/fuelup-0.5.0-nightly-2022-09-16.nix
+++ b/manifests/fuelup-0.5.0-nightly-2022-09-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-16";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "6b6c2ebc0c1bd0c0292aabc3540499bc3571837b";
+  sha256 = "sha256-kiJzK/+FoAMj+ytDKT3omfkABSrpdaZi/L1SOrev++k=";
+}

--- a/manifests/fuelup-0.5.0-nightly-2022-09-17.nix
+++ b/manifests/fuelup-0.5.0-nightly-2022-09-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-17";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "2928dc98354b41a8beeff794aa8b05b936c4c783";
+  sha256 = "sha256-EN7nF+Z8HLOvdpmtL7MQV3w3jtXHgFj6eXYg7NPc0H4=";
+}

--- a/manifests/fuelup-0.5.0-nightly-2022-09-19.nix
+++ b/manifests/fuelup-0.5.0-nightly-2022-09-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-19";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "5d215416924ef76ee37bee38dd9b8b2a1122d1ba";
+  sha256 = "sha256-+Xa/CRF+MFV3oJD5lsf9oyPxhR1eoKOZ7dkFXDm0ELc=";
+}

--- a/manifests/fuelup-0.5.0.nix
+++ b/manifests/fuelup-0.5.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.5.0";
+  date = "2022-09-05";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "739dd701671f04c558f84097f6935703cfc1cb94";
+  sha256 = "sha256-/UbjwBmB9Px3C9qYw9S9SeDjeF1sMFcPSyJVUrCCUvs=";
+}

--- a/manifests/fuelup-0.6.0-nightly-2022-09-20.nix
+++ b/manifests/fuelup-0.6.0-nightly-2022-09-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.6.0";
+  date = "2022-09-20";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "888395ce22ada05b648bd8a6d423c5fac9fdc75a";
+  sha256 = "sha256-Tgis2zU2L5AJHkNA1apPv1a0ASraPfJS00uGkj7/C2k=";
+}

--- a/manifests/fuelup-0.6.0-nightly-2022-09-22.nix
+++ b/manifests/fuelup-0.6.0-nightly-2022-09-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.6.0";
+  date = "2022-09-22";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "24a0fc30d1fbc67fa4dd174a8bb24e426c681fd3";
+  sha256 = "sha256-fk/2UOdzlPNPChWhJETKCOfrUH1oYLxT4vGL7AKNL9Q=";
+}

--- a/manifests/fuelup-0.6.0-nightly-2022-09-23.nix
+++ b/manifests/fuelup-0.6.0-nightly-2022-09-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.6.0";
+  date = "2022-09-23";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "ccf05d29eed87018b4a3196cdcc34c18f74902dc";
+  sha256 = "sha256-jjmy3dbwS5zkVkDwaZ52GRcWWtfzI56O7qI3BRtl00I=";
+}

--- a/manifests/fuelup-0.6.0.nix
+++ b/manifests/fuelup-0.6.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.6.0";
+  date = "2022-09-19";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "888395ce22ada05b648bd8a6d423c5fac9fdc75a";
+  sha256 = "sha256-Tgis2zU2L5AJHkNA1apPv1a0ASraPfJS00uGkj7/C2k=";
+}

--- a/manifests/fuelup-0.7.0-nightly-2022-09-25.nix
+++ b/manifests/fuelup-0.7.0-nightly-2022-09-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.7.0";
+  date = "2022-09-25";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "b64f2238dfda9fef1d71f3dbad4f2dd59dd01ed4";
+  sha256 = "sha256-r1lmF+XAU88mJJYyE8JGy/RVnv9BeLtVz+vVE9Xiuto=";
+}

--- a/manifests/fuelup-0.7.0.nix
+++ b/manifests/fuelup-0.7.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.7.0";
+  date = "2022-09-24";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "b64f2238dfda9fef1d71f3dbad4f2dd59dd01ed4";
+  sha256 = "sha256-r1lmF+XAU88mJJYyE8JGy/RVnv9BeLtVz+vVE9Xiuto=";
+}

--- a/manifests/fuelup-0.7.1-nightly-2022-09-28.nix
+++ b/manifests/fuelup-0.7.1-nightly-2022-09-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.7.1";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "63a1a347e73f522f512d50e58e09f529abb01789";
+  sha256 = "sha256-ymkqo5HGvKHF8CLl3HMz63SdkHvJKQdvJDe9gfUDE88=";
+}

--- a/manifests/fuelup-0.7.1-nightly-2022-09-29.nix
+++ b/manifests/fuelup-0.7.1-nightly-2022-09-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.7.1";
+  date = "2022-09-29";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "b03ff8cc6b7d4d49cafbf76b6dabc81f122edcd6";
+  sha256 = "sha256-2952GHpXtfYT3uQomiTTYWxFKxje2XUgkrMBl6UbpXE=";
+}

--- a/manifests/fuelup-0.7.1-nightly-2022-10-01.nix
+++ b/manifests/fuelup-0.7.1-nightly-2022-10-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.7.1";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "9b8711144613d2639b96fd7a5401e129856424af";
+  sha256 = "sha256-cFnD45Sxerd9GtWi0arXeK2BM+bVvyldzL1pTCBdKtg=";
+}

--- a/manifests/fuelup-0.7.1.nix
+++ b/manifests/fuelup-0.7.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.7.1";
+  date = "2022-09-28";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "63a1a347e73f522f512d50e58e09f529abb01789";
+  sha256 = "sha256-ymkqo5HGvKHF8CLl3HMz63SdkHvJKQdvJDe9gfUDE88=";
+}

--- a/manifests/fuelup-0.8.0-nightly-2022-10-02.nix
+++ b/manifests/fuelup-0.8.0-nightly-2022-10-02.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.8.0";
+  date = "2022-10-02";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "d56e3bde93cab5491ecc633f20cf50706d597f09";
+  sha256 = "sha256-yYbycUf9THmsbqk7+YBi70XF51QVMEAlzX00BrHBT7g=";
+}

--- a/manifests/fuelup-0.8.0-nightly-2022-10-03.nix
+++ b/manifests/fuelup-0.8.0-nightly-2022-10-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.8.0";
+  date = "2022-10-03";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "6f4e9a29ff8042aa220ee8555b1fd194b74c6ccf";
+  sha256 = "sha256-o72t/iAS3vCiKGhhj1Gy90dlgqcfajal5fFFt5MLxEc=";
+}

--- a/manifests/fuelup-0.8.0-nightly-2022-10-04.nix
+++ b/manifests/fuelup-0.8.0-nightly-2022-10-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.8.0";
+  date = "2022-10-04";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "f5da39d78de296c8b8e512ebd69d3cb75f0a57de";
+  sha256 = "sha256-ApjQhoob0qXKmta8I5QSXNy9p72teVHEBN6caUfIwI8=";
+}

--- a/manifests/fuelup-0.8.0-nightly-2022-10-06.nix
+++ b/manifests/fuelup-0.8.0-nightly-2022-10-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.8.0";
+  date = "2022-10-06";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "a26a23f317d66f8e4cb6d542e2eb20829b33b72c";
+  sha256 = "sha256-5dKLvcVLu/poFBp+qSOeeZhYIKavs+CsDeTBCUYjLUM=";
+}

--- a/manifests/fuelup-0.8.0-nightly-2022-10-07.nix
+++ b/manifests/fuelup-0.8.0-nightly-2022-10-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.8.0";
+  date = "2022-10-07";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "80780652a7bdf458581457b045a7cd18ce50a66e";
+  sha256 = "sha256-Ac9HYEe3KX1bcPFwNKG3P0VvdGcb+oTy1jvnzF15f9E=";
+}

--- a/manifests/fuelup-0.8.0-nightly-2022-10-08.nix
+++ b/manifests/fuelup-0.8.0-nightly-2022-10-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.8.0";
+  date = "2022-10-08";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "8d84b895e520e9bb1cfaa3366ac8eeaf92afc857";
+  sha256 = "sha256-8/iopuVUw5MJY+62AWi2whwrRJW3bURPUPS+KrZdRdU=";
+}

--- a/manifests/fuelup-0.8.0-nightly-2022-10-18.nix
+++ b/manifests/fuelup-0.8.0-nightly-2022-10-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.8.0";
+  date = "2022-10-18";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "d0c35407127a51f4b5122bd31ee53d3055e0e1f9";
+  sha256 = "sha256-tLit+uWenpls2ECvHyi21Gff+VLnx2ouqamBgtrr7L4=";
+}

--- a/manifests/fuelup-0.8.0.nix
+++ b/manifests/fuelup-0.8.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.8.0";
+  date = "2022-10-01";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "b4a06f4d1bdfc855fcdc977723bd33e238d46e8e";
+  sha256 = "sha256-ecUmYlbhBvXUDXCyHVE47IZFm787PV9+v2dJqrPbRc0=";
+}

--- a/manifests/fuelup-0.9.0-nightly-2022-10-20.nix
+++ b/manifests/fuelup-0.9.0-nightly-2022-10-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.9.0";
+  date = "2022-10-20";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "de8eb17714c7f9f4f1844b8609a91f28b4337aca";
+  sha256 = "sha256-a2prDd9jxiPsiFUQk9Ev/KJqOgmIarz6cYUFSg78oUw=";
+}

--- a/manifests/fuelup-0.9.0-nightly-2022-10-22.nix
+++ b/manifests/fuelup-0.9.0-nightly-2022-10-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.9.0";
+  date = "2022-10-22";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "a519fe3cfddcccf083e58285a0b57db306c7abed";
+  sha256 = "sha256-oIyOYUn2TJRrlUCb1QNZ+k4U1L2Hr/iQYEno+w3LrN0=";
+}

--- a/manifests/fuelup-0.9.0-nightly-2022-10-25.nix
+++ b/manifests/fuelup-0.9.0-nightly-2022-10-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.9.0";
+  date = "2022-10-25";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "952d1a6b036dc13ad7e77774e6910f87cb2d620d";
+  sha256 = "sha256-IoMhm5nZ5mwGD44zdU5s40Z/L3bFa+no76cVzV4v0hY=";
+}

--- a/manifests/fuelup-0.9.0-nightly-2022-10-26.nix
+++ b/manifests/fuelup-0.9.0-nightly-2022-10-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.9.0";
+  date = "2022-10-26";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "27a34dec1178e6e35daaffd89580dc7663094f4b";
+  sha256 = "sha256-fJMw45k+pTETh3HyckspZufKPI5sp+qR05sSdv2XF4s=";
+}

--- a/manifests/fuelup-0.9.0.nix
+++ b/manifests/fuelup-0.9.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuelup";
+  version = "0.9.0";
+  date = "2022-10-19";
+  url = "https://github.com/fuellabs/fuelup";
+  rev = "de8eb17714c7f9f4f1844b8609a91f28b4337aca";
+  sha256 = "sha256-a2prDd9jxiPsiFUQk9Ev/KJqOgmIarz6cYUFSg78oUw=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -69,9 +69,10 @@ in [
     };
   }
 
-  # Fuel-core tests run at their repo - no need to repeat them here.
+  # Fuel-core and fuelup tests run at their respective repos - no need to
+  # repeat them here.
   {
-    condition = m: m.src.gitRepoUrl == "https://github.com/fuellabs/fuel-core";
+    condition = m: pkgs.lib.any (url: m.src.gitRepoUrl == url) ["https://github.com/fuellabs/fuel-core" "https://github.com/fuellabs/fuelup"];
     patch = m: {
       doCheck = false; # Already tested at repo, causes longer build times.
     };

--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -23,6 +23,7 @@ declare -A fuel_repos=(
     [forc-wallet]="https://github.com/fuellabs/forc-wallet"
     [fuel-core]="https://github.com/fuellabs/fuel-core"
     [fuel-indexer]="https://github.com/fuellabs/fuel-indexer"
+    [fuelup]="https://github.com/fuellabs/fuelup"
     [sway]="https://github.com/fuellabs/sway"
     [sway-vim]="https://github.com/fuellabs/sway.vim"
 )
@@ -75,6 +76,10 @@ declare -A pkg_fuel_core_client=(
 declare -A pkg_fuel_indexer=(
     [name]="fuel-indexer"
     [repo]="${fuel_repos[fuel-indexer]}"
+)
+declare -A pkg_fuelup=(
+    [name]="fuelup"
+    [repo]="${fuel_repos[fuelup]}"
 )
 
 # Create a temporary directory for cloning repositories.
@@ -236,3 +241,4 @@ refresh pkg_forc_wallet
 refresh pkg_fuel_core
 refresh pkg_fuel_core_client
 refresh pkg_fuel_indexer
+refresh pkg_fuelup


### PR DESCRIPTION
This could be handy for testing `fuelup` workflows on a Nix system.

TODO: Needs a fuelup patch to run patchelf on downloaded fuelup components as a part of installation.