### PR TITLE
Temporarily filter out indexer packages

### DIFF
--- a/filters.nix
+++ b/filters.nix
@@ -19,4 +19,6 @@ with pkgs.lib; [
   (m: m.pname != "fuel-core-client" || (versionAtLeast m.version "0.14.2" && m.date >= "2022-12-17"))
   (m: m.pname != "fuel-gql-cli" || (versionAtLeast m.version "0.9.0" && m.date < "2022-12-17"))
   (m: m.pname != "fuel-indexer" || versionAtLeast m.version "0.1.8")
+  # Temporarily filter out indexer pkgs due to use of fuels git branch, see #53.
+  (m: m.src.gitRepoUrl == "https://github.com/fuellabs/fuel-indexer" && m.date < "2023-02-22")
 ]

--- a/filters.nix
+++ b/filters.nix
@@ -20,5 +20,5 @@ with pkgs.lib; [
   (m: m.pname != "fuel-gql-cli" || (versionAtLeast m.version "0.9.0" && m.date < "2022-12-17"))
   (m: m.pname != "fuel-indexer" || versionAtLeast m.version "0.1.8")
   # Temporarily filter out indexer pkgs due to use of fuels git branch, see #53.
-  (m: m.src.gitRepoUrl == "https://github.com/fuellabs/fuel-indexer" && m.date < "2023-02-22")
+  (m: m.src.gitRepoUrl != "https://github.com/fuellabs/fuel-indexer" || m.date < "2023-02-22")
 ]

--- a/manifests/forc-0.35.3-nightly-2023-02-22.nix
+++ b/manifests/forc-0.35.3-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.3";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-0.35.3.nix
+++ b/manifests/forc-0.35.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.35.3";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-client-0.35.3-nightly-2023-02-22.nix
+++ b/manifests/forc-client-0.35.3-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.3";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-client-0.35.3.nix
+++ b/manifests/forc-client-0.35.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.35.3";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-doc-0.35.3-nightly-2023-02-22.nix
+++ b/manifests/forc-doc-0.35.3-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.3";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-doc-0.35.3.nix
+++ b/manifests/forc-doc-0.35.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.35.3";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-fmt-0.35.3-nightly-2023-02-22.nix
+++ b/manifests/forc-fmt-0.35.3-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.3";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-fmt-0.35.3.nix
+++ b/manifests/forc-fmt-0.35.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.35.3";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-index-0.3.0-nightly-2023-02-22.nix
+++ b/manifests/forc-index-0.3.0-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.3.0";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "30aab5fb7ab94d58a96dc9053426afc22c5bf68d";
+  sha256 = "sha256-L3NXG1a5eUXu0vFyPuKFZIyDZ/87xzm95LXbYZwtZDE=";
+}

--- a/manifests/forc-index-0.4.0.nix
+++ b/manifests/forc-index-0.4.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.4.0";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "8bf3ab23a4de01d261cef742dda3d630b25cdcdc";
+  sha256 = "sha256-W3JqoS1rqsfoT3jvUiTqN+JqOo266E3AtwrWedVBNdA=";
+}

--- a/manifests/forc-lsp-0.35.3-nightly-2023-02-22.nix
+++ b/manifests/forc-lsp-0.35.3-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.3";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-lsp-0.35.3.nix
+++ b/manifests/forc-lsp-0.35.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.35.3";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-tx-0.35.3-nightly-2023-02-22.nix
+++ b/manifests/forc-tx-0.35.3-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.3";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-tx-0.35.3.nix
+++ b/manifests/forc-tx-0.35.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.35.3";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
+  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
+}

--- a/manifests/forc-wallet-0.2.0-nightly-2023-02-22.nix
+++ b/manifests/forc-wallet-0.2.0-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.2.0";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "c0a69f05e48031632b58e1b69eebb1ea19b6dd2d";
+  sha256 = "sha256-cUeASmn/40N07gDve83mNprpMoNxxheVN51e+ferIk8=";
+}

--- a/manifests/forc-wallet-0.2.1.nix
+++ b/manifests/forc-wallet-0.2.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.2.1";
+  date = "2023-02-23";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "27a5ed29fbc7d648ac017f45b61270a977e3257a";
+  sha256 = "sha256-ru3aKJdqmP83qDDYPcN91CBRMFF4YuwDfWt9HloZ8C8=";
+}

--- a/manifests/fuel-core-0.17.3-nightly-2023-02-22.nix
+++ b/manifests/fuel-core-0.17.3-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.3";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "843ed0b5008acbb7934ae92a1e9ae1368f2b5157";
+  sha256 = "sha256-IE4cLlvKPmnxygIrWUdJQlM30APbm9rqvziV7clWwrM=";
+}

--- a/manifests/fuel-core-0.17.3.nix
+++ b/manifests/fuel-core-0.17.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.17.3";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "843ed0b5008acbb7934ae92a1e9ae1368f2b5157";
+  sha256 = "sha256-IE4cLlvKPmnxygIrWUdJQlM30APbm9rqvziV7clWwrM=";
+}

--- a/manifests/fuel-core-client-0.17.3-nightly-2023-02-22.nix
+++ b/manifests/fuel-core-client-0.17.3-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.3";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "843ed0b5008acbb7934ae92a1e9ae1368f2b5157";
+  sha256 = "sha256-IE4cLlvKPmnxygIrWUdJQlM30APbm9rqvziV7clWwrM=";
+}

--- a/manifests/fuel-core-client-0.17.3.nix
+++ b/manifests/fuel-core-client-0.17.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.17.3";
+  date = "2023-02-21";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "843ed0b5008acbb7934ae92a1e9ae1368f2b5157";
+  sha256 = "sha256-IE4cLlvKPmnxygIrWUdJQlM30APbm9rqvziV7clWwrM=";
+}

--- a/manifests/fuel-indexer-0.3.0-nightly-2023-02-22.nix
+++ b/manifests/fuel-indexer-0.3.0-nightly-2023-02-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.3.0";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "30aab5fb7ab94d58a96dc9053426afc22c5bf68d";
+  sha256 = "sha256-L3NXG1a5eUXu0vFyPuKFZIyDZ/87xzm95LXbYZwtZDE=";
+}

--- a/manifests/fuel-indexer-0.4.0.nix
+++ b/manifests/fuel-indexer-0.4.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.4.0";
+  date = "2023-02-22";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "8bf3ab23a4de01d261cef742dda3d630b25cdcdc";
+  sha256 = "sha256-W3JqoS1rqsfoT3jvUiTqN+JqOo266E3AtwrWedVBNdA=";
+}


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel.nix/issues/53.

Refreshes manifests since the indexer build started failing.