### PR TITLE
Increase timeout of `refresh-manifests` job

### DIFF
--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -22,7 +22,7 @@ jobs:
           name: mitchmindtree-fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Refresh manifests
-        timeout-minutes: 20
+        timeout-minutes: 60
         run: nix run .#refresh-manifests
       - name: Check and commit changes
         id: commit


### PR DESCRIPTION
This job takes a while as it fetches all of the various fuel repos and scans git history for tags to generate the manifests in an idempotent manner, once for each package. One day we should update `scripts/refresh-manifests` to do a single traversal per-repo, not per pkg.