### PR TITLE
Switch to the new fuellabs cachix cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
         with:
-          name: mitchmindtree-fuellabs
+          name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix fmt -- --check ./
 
@@ -37,7 +37,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
         with:
-          name: mitchmindtree-fuellabs
+          name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
 
@@ -54,6 +54,6 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
         with:
-          name: mitchmindtree-fuellabs
+          name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix develop --print-build-logs --no-update-lock-file .#fuel-dev

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -19,7 +19,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
         with:
-          name: mitchmindtree-fuellabs
+          name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Refresh manifests
         timeout-minutes: 60
@@ -68,6 +68,6 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
         with:
-          name: mitchmindtree-fuellabs
+          name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ NixOS configuration (i.e. `/etc/nixos/configuration.nix`) like so:
   nix = {
     settings = {
       experimental-features = ["nix-command" "flakes"];
-      substituters = ["https://mitchmindtree-fuellabs.cachix.org"];
+      substituters = ["https://fuellabs.cachix.org"];
       trusted-public-keys = [
-        "mitchmindtree-fuellabs.cachix.org-1:UDUQvwjM3wRCZe1chrgqAehb3M0M5x9qjpEwJwPn7Ik="
+        "fuellabs.cachix.org-1:3gOmll82VDbT7EggylzOVJ6dr0jgPVU/KMN6+Kf8qx8="
       ];
     };
   };
@@ -37,8 +37,8 @@ file (e.g.  `/etc/nix/nix.conf`):
 
 ```conf
 experimental-features = nix-command flakes
-substituters = https://cache.nixos.org/ https://mitchmindtree-fuellabs.cachix.org
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= mitchmindtree-fuellabs.cachix.org-1:UDUQvwjM3wRCZe1chrgqAehb3M0M5x9qjpEwJwPn7Ik=
+substituters = https://cache.nixos.org/ https://fuellabs.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fuellabs.cachix.org-1:3gOmll82VDbT7EggylzOVJ6dr0jgPVU/KMN6+Kf8qx8=
 ```
 
 On non-NixOS Linux systems, be sure to make sure that your user is part of the
@@ -197,7 +197,7 @@ inspired by nixpkgs' `rustPlatform`.*
 [forc-wallet-repo]: https://github.com/fuellabs/forc-wallet
 [fuel-core-repo]: https://github.com/fuellabs/fuel-core
 [fuel-indexer-repo]: https://github.com/fuellabs/fuel-indexer
-[fuellabs-cachix]: https://app.cachix.org/cache/mitchmindtree-fuellabs
+[fuellabs-cachix]: https://app.cachix.org/cache/fuellabs
 [nix-flakes]: https://nixos.wiki/wiki/Flakes
 [nix-manual]: https://nixos.org/manual/nix/stable/
 [rust-overlay-repo]: https://github.com/oxalica/rust-overlay


### PR DESCRIPTION
This switches from the old `mitchmindtree-fuellabs` cachix cache to the new `fuellabs` one.

Updates both CI and the README installation instructions.

Note: This might take a while to build as we populate the cache for the first time!