### PR TITLE
Add the `aarch64` architecture to CI for testing and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
 
   nix-build:
     strategy:
+      fail-fast: false
       matrix:
         package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-nightly, sway-vim]
         arch: ["x86_64", "aarch64"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           else
             system="${{ matrix.arch }}-darwin"
           fi
-          nix build --print-build-logs --no-update-lock-file --system $system .#${{ matrix.package }}
+          nix build --print-build-logs --no-update-lock-file --system $system --extra-extra-platforms $system .#${{ matrix.package }}
 
   nix-develop:
     needs: nix-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       matrix:
         package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-nightly, sway-vim]
+        arch: ["x86_64", "aarch64"]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,7 +40,13 @@ jobs:
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
+      - run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            system="${{ matrix.arch }}-linux"
+          else
+            system="${{ matrix.arch }}-darwin"
+          fi
+          nix build --print-build-logs --no-update-lock-file --system $system .#${{ matrix.package }}
 
   nix-develop:
     needs: nix-build


### PR DESCRIPTION
This is an attempt to enable ARM builds (and in turn binary caching) for macOS and potentially Linux too. #29.

---

## Cross Compilation

It looks like this is going to be a bit more complicated than simply specifying the target system! I'll continue to collect relevant references and findings here:

- https://nix.dev/tutorials/cross-compilation
- https://nixos.wiki/wiki/Cross_Compiling
- https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#cross-compilation-cross-compilation.
- https://github.com/oxalica/rust-overlay/blob/master/docs/cross_compilation.md

One concern is that, even if we do get cross compilation working, [the build will end up being performed from a different set of derivations](https://discourse.nixos.org/t/how-do-i-cross-compile-a-flake/12062/7?u=mindtree), and we'll end up missing the cache for folks building on ARM systems that are both host *and* target. 

## `aarch64` GitHub Runners

Ultimately, we'd have a GitHub runner with the ARM darwin architecture. It looks like GitHub have this on their roadmap for Q4: https://github.com/github/roadmap/issues/528.

I wonder if there's possibly a 3rd-party macOS runner that could be used in the meantime to simplify this? It seems GitHub supports this:

- https://github.blog/changelog/2022-08-09-github-actions-self-hosted-runners-now-support-apple-m1-hardware/
- https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners