### PR TITLE
Attempt to solve `macos-latest` `x86_64-darwin` CI build issues for `fuel-nightly`

### DIFF
--- a/manifests/forc-0.39.1-nightly-2023-05-30.nix
+++ b/manifests/forc-0.39.1-nightly-2023-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc";
-  version = "0.39.1";
-  date = "2023-05-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8844b4f60ef19ba5b1972e8e4932e023ec0415c0";
-  sha256 = "sha256-bjH9jXuWxYBdwc/2ofNLE4NIUu6+Dqds0CajUmnsO9s=";
-}

--- a/manifests/forc-0.39.1-nightly-2023-05-31.nix
+++ b/manifests/forc-0.39.1-nightly-2023-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc";
-  version = "0.39.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "08c5bc164a057531bfd0265336f147a0c4828bb3";
-  sha256 = "sha256-xJXli+x2UnSLsWYxA5YaitVr297DZr0cj3CxKGhrhG8=";
-}

--- a/manifests/forc-client-0.39.1-nightly-2023-05-30.nix
+++ b/manifests/forc-client-0.39.1-nightly-2023-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-client";
-  version = "0.39.1";
-  date = "2023-05-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8844b4f60ef19ba5b1972e8e4932e023ec0415c0";
-  sha256 = "sha256-bjH9jXuWxYBdwc/2ofNLE4NIUu6+Dqds0CajUmnsO9s=";
-}

--- a/manifests/forc-client-0.39.1-nightly-2023-05-31.nix
+++ b/manifests/forc-client-0.39.1-nightly-2023-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-client";
-  version = "0.39.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "08c5bc164a057531bfd0265336f147a0c4828bb3";
-  sha256 = "sha256-xJXli+x2UnSLsWYxA5YaitVr297DZr0cj3CxKGhrhG8=";
-}

--- a/manifests/forc-doc-0.39.1-nightly-2023-05-30.nix
+++ b/manifests/forc-doc-0.39.1-nightly-2023-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-doc";
-  version = "0.39.1";
-  date = "2023-05-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8844b4f60ef19ba5b1972e8e4932e023ec0415c0";
-  sha256 = "sha256-bjH9jXuWxYBdwc/2ofNLE4NIUu6+Dqds0CajUmnsO9s=";
-}

--- a/manifests/forc-doc-0.39.1-nightly-2023-05-31.nix
+++ b/manifests/forc-doc-0.39.1-nightly-2023-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-doc";
-  version = "0.39.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "08c5bc164a057531bfd0265336f147a0c4828bb3";
-  sha256 = "sha256-xJXli+x2UnSLsWYxA5YaitVr297DZr0cj3CxKGhrhG8=";
-}

--- a/manifests/forc-fmt-0.39.1-nightly-2023-05-30.nix
+++ b/manifests/forc-fmt-0.39.1-nightly-2023-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-fmt";
-  version = "0.39.1";
-  date = "2023-05-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8844b4f60ef19ba5b1972e8e4932e023ec0415c0";
-  sha256 = "sha256-bjH9jXuWxYBdwc/2ofNLE4NIUu6+Dqds0CajUmnsO9s=";
-}

--- a/manifests/forc-fmt-0.39.1-nightly-2023-05-31.nix
+++ b/manifests/forc-fmt-0.39.1-nightly-2023-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-fmt";
-  version = "0.39.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "08c5bc164a057531bfd0265336f147a0c4828bb3";
-  sha256 = "sha256-xJXli+x2UnSLsWYxA5YaitVr297DZr0cj3CxKGhrhG8=";
-}

--- a/manifests/forc-index-0.15.1-nightly-2023-05-31.nix
+++ b/manifests/forc-index-0.15.1-nightly-2023-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-index";
-  version = "0.15.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/fuel-indexer";
-  rev = "0076a7bf976c03594521115e3fbd962010562bfd";
-  sha256 = "sha256-Ji7wtZMNYM5VDVPo6xcLNBtwzHGNe8EK+p3vG4qTKNQ=";
-}

--- a/manifests/forc-lsp-0.39.1-nightly-2023-05-30.nix
+++ b/manifests/forc-lsp-0.39.1-nightly-2023-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-lsp";
-  version = "0.39.1";
-  date = "2023-05-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8844b4f60ef19ba5b1972e8e4932e023ec0415c0";
-  sha256 = "sha256-bjH9jXuWxYBdwc/2ofNLE4NIUu6+Dqds0CajUmnsO9s=";
-}

--- a/manifests/forc-lsp-0.39.1-nightly-2023-05-31.nix
+++ b/manifests/forc-lsp-0.39.1-nightly-2023-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-lsp";
-  version = "0.39.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "08c5bc164a057531bfd0265336f147a0c4828bb3";
-  sha256 = "sha256-xJXli+x2UnSLsWYxA5YaitVr297DZr0cj3CxKGhrhG8=";
-}

--- a/manifests/forc-tx-0.39.1-nightly-2023-05-30.nix
+++ b/manifests/forc-tx-0.39.1-nightly-2023-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-tx";
-  version = "0.39.1";
-  date = "2023-05-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8844b4f60ef19ba5b1972e8e4932e023ec0415c0";
-  sha256 = "sha256-bjH9jXuWxYBdwc/2ofNLE4NIUu6+Dqds0CajUmnsO9s=";
-}

--- a/manifests/forc-tx-0.39.1-nightly-2023-05-31.nix
+++ b/manifests/forc-tx-0.39.1-nightly-2023-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-tx";
-  version = "0.39.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "08c5bc164a057531bfd0265336f147a0c4828bb3";
-  sha256 = "sha256-xJXli+x2UnSLsWYxA5YaitVr297DZr0cj3CxKGhrhG8=";
-}

--- a/manifests/fuel-core-0.18.1-nightly-2023-05-30.nix
+++ b/manifests/fuel-core-0.18.1-nightly-2023-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "fuel-core";
-  version = "0.18.1";
-  date = "2023-05-30";
-  url = "https://github.com/fuellabs/fuel-core";
-  rev = "ea438b7d8f9404f185239f3f6896bd4c1dd33701";
-  sha256 = "sha256-cJnwue+SjqLhgMqngHrupcsAHBHfUKG4hfVmFvwWoBo=";
-}

--- a/manifests/fuel-core-client-0.18.1-nightly-2023-05-30.nix
+++ b/manifests/fuel-core-client-0.18.1-nightly-2023-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "fuel-core-client";
-  version = "0.18.1";
-  date = "2023-05-30";
-  url = "https://github.com/fuellabs/fuel-core";
-  rev = "ea438b7d8f9404f185239f3f6896bd4c1dd33701";
-  sha256 = "sha256-cJnwue+SjqLhgMqngHrupcsAHBHfUKG4hfVmFvwWoBo=";
-}

--- a/manifests/fuel-indexer-0.15.1-nightly-2023-05-31.nix
+++ b/manifests/fuel-indexer-0.15.1-nightly-2023-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "fuel-indexer";
-  version = "0.15.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/fuel-indexer";
-  rev = "0076a7bf976c03594521115e3fbd962010562bfd";
-  sha256 = "sha256-Ji7wtZMNYM5VDVPo6xcLNBtwzHGNe8EK+p3vG4qTKNQ=";
-}

--- a/patches.nix
+++ b/patches.nix
@@ -303,16 +303,4 @@ in [
       buildInputs = (m.buildInputs or []) ++ [pkgs.openssl];
     };
   }
-
-  # Try adding `CoreFoundation` to `propagatedBuildInputs` to address recent CI error.
-  {
-    condition = m: m.date >= "2023-05-27" && pkgs.lib.hasInfix "darwin" pkgs.system;
-    patch = m: {
-      propagatedBuildInputs =
-        (m.propagatedBuildInputs or [])
-        ++ [
-          pkgs.darwin.apple_sdk.frameworks.CoreFoundation
-        ];
-    };
-  }
 ]

--- a/patches.nix
+++ b/patches.nix
@@ -304,12 +304,12 @@ in [
     };
   }
 
-  # Try adding `CoreFoundation` to `nativeBuildInputs` to address recent CI error.
+  # Try adding `CoreFoundation` to `propagatedBuildInputs` to address recent CI error.
   {
     condition = m: m.date >= "2023-05-27" && pkgs.lib.hasInfix "darwin" pkgs.system;
     patch = m: {
-      nativeBuildInputs =
-        (m.nativeBuildInputs or [])
+      propagatedBuildInputs =
+        (m.propagatedBuildInputs or [])
         ++ [
           pkgs.darwin.apple_sdk.frameworks.CoreFoundation
         ];

--- a/patches.nix
+++ b/patches.nix
@@ -303,4 +303,16 @@ in [
       buildInputs = (m.buildInputs or []) ++ [pkgs.openssl];
     };
   }
+
+  # Try adding `CoreFoundation` to `nativeBuildInputs` to address recent CI error.
+  {
+    condition = m: pkgs.lib.hasInfix "darwin" pkgs.system;
+    patch = m: {
+      nativeBuildInputs =
+        (m.nativeBuildInputs or [])
+        ++ [
+          pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+        ];
+    };
+  }
 ]

--- a/patches.nix
+++ b/patches.nix
@@ -306,7 +306,7 @@ in [
 
   # Try adding `CoreFoundation` to `nativeBuildInputs` to address recent CI error.
   {
-    condition = m: pkgs.lib.hasInfix "darwin" pkgs.system;
+    condition = m: m.date >= "2023-05-27" && pkgs.lib.hasInfix "darwin" pkgs.system;
     patch = m: {
       nativeBuildInputs =
         (m.nativeBuildInputs or [])


### PR DESCRIPTION
Currently, the frameworks are provided as build inputs - this is an attempt to provide the CoreFoundation framework as a nativeBuildInput to see if it addresses the current CI error tracked in #64.

Edit: Also tried `propagatedBuildInputs` to see if propagating CoreFoundation to the runtime inputs helped, but no luck.

Edit: Now attempting to remove the most recent manifest sets in order to find the last working version of `fuel-nightly` so I can diff the two.