### PR TITLE
refresh-manifests workflow checks all platforms before committing manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: "fuel"
 
 on:
-  #pull_request:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: "fuel"
 
 on:
-  pull_request:
+  #pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -18,15 +18,15 @@ jobs:
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      # - run: nix run .#refresh-manifests
-      #   timeout-minutes: 120
-      # - name: validate changed nix files
-      #   run: |
-      #     files=( $(git diff --name-only '*.nix') )
-      #     echo "${#files[*]} nix files changed: ${files[*]}"
-      #     if [[ "${#files[*]}" -ne 0 ]]; then
-      #       nix-instantiate --parse "${files[@]}" >/dev/null
-      #     fi
+      - run: nix run .#refresh-manifests
+        timeout-minutes: 120
+      - name: validate changed nix files
+        run: |
+          files=( $(git diff --name-only '*.nix') )
+          echo "${#files[*]} nix files changed: ${files[*]}"
+          if [[ "${#files[*]}" -ne 0 ]]; then
+            nix-instantiate --parse "${files[@]}" >/dev/null
+          fi
       - uses: actions/upload-artifact@v3
         with:
           name: manifests
@@ -56,7 +56,6 @@ jobs:
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix flake show
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
 
   download-manifests-and-commit:
@@ -71,6 +70,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: manifests
+          path: manifests/
       - name: Check and commit changes
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -49,7 +49,6 @@ jobs:
           path: manifests/
       - name: stage manifests for nix build
         run: git add -v manifests
-      - run: nix flake show
       - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -57,6 +56,7 @@ jobs:
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix flake show
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
 
   download-manifests-and-commit:

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -18,15 +18,15 @@ jobs:
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix run .#refresh-manifests
-        timeout-minutes: 120
-      - name: validate changed nix files
-        run: |
-          files=( $(git diff --name-only '*.nix') )
-          echo "${#files[*]} nix files changed: ${files[*]}"
-          if [[ "${#files[*]}" -ne 0 ]]; then
-            nix-instantiate --parse "${files[@]}" >/dev/null
-          fi
+      # - run: nix run .#refresh-manifests
+      #   timeout-minutes: 120
+      # - name: validate changed nix files
+      #   run: |
+      #     files=( $(git diff --name-only '*.nix') )
+      #     echo "${#files[*]} nix files changed: ${files[*]}"
+      #     if [[ "${#files[*]}" -ne 0 ]]; then
+      #       nix-instantiate --parse "${files[@]}" >/dev/null
+      #     fi
       - uses: actions/upload-artifact@v3
         with:
           name: manifests
@@ -46,8 +46,10 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: manifests
+          path: manifests/
       - name: stage manifests for nix build
-        run: git add manifests
+        run: git add -v manifests
+      - run: nix flake show
       - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -58,7 +58,7 @@ jobs:
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
 
   download-manifests-and-commit:
-    needs: [refresh-and-upload-manifests, download-manifests-and-build]
+    needs: [refresh-and-upload-manifests, download-manifests-and-nix-build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -6,14 +6,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  refresh-manifests:
-    name: "Refresh manifests and sync channels"
+  refresh-and-upload-manifests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.2
-        with:
-          persist-credentials: false
-          ref: master
+      - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -21,48 +17,36 @@ jobs:
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - name: Refresh manifests
-        timeout-minutes: 60
-        run: nix run .#refresh-manifests
-      - name: Check and commit changes
-        id: commit
-        continue-on-error: true
+      - run: nix run .#refresh-manifests
+        timeout-minutes: 120
+      - name: validate changed nix files
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add manifests
-          git commit -m "manifest: update"
-      - name: Validate nix files changed
-        if: steps.commit.outcome == 'success'
-        run: |
-          files=( $(git diff --name-only HEAD HEAD^ '*.nix') )
+          files=( $(git diff --name-only '*.nix') )
           echo "${#files[*]} nix files changed: ${files[*]}"
           if [[ "${#files[*]}" -ne 0 ]]; then
             nix-instantiate --parse "${files[@]}" >/dev/null
           fi
-      - name: Build fuel
-        run: nix build --print-build-logs --no-update-lock-file .#fuel
-      - name: Build fuel-nightly
-        run: nix build --print-build-logs --no-update-lock-file .#fuel-nightly
-      - name: Develop fuel-dev
-        run: nix develop --print-build-logs --no-update-lock-file .#fuel-dev
-      - name: Push changes
-        if: steps.commit.outcome == 'success'
-        uses: ad-m/github-push-action@master
+      - uses: actions/upload-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: master
+          name: manifests
+          path: manifests/
 
-  refresh-cache:
-    name: "Refresh cache for all platforms"
-    needs: refresh-manifests
+  download-manifests-and-nix-build:
+    needs: refresh-and-upload-manifests
     strategy:
+      fail-fast: false
       matrix:
-        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-nightly, sway-vim]
+        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-nightly]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
+      - run: rm -r manifests
+      - uses: actions/download-artifact@v3
+        with:
+          name: manifests
+      - name: stage manifests for nix build
+        run: git add manifests
       - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -71,3 +55,27 @@ jobs:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
+
+  download-manifests-and-commit:
+    needs: [refresh-and-upload-manifests, download-manifests-and-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: master
+      - run: rm -r ./manifests
+      - uses: actions/download-artifact@v3
+        with:
+          name: manifests
+      - name: Check and commit changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add manifests
+          git commit -m "manifest: update"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: master

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *' # Midnight UTC
   workflow_dispatch:
+  pull_request:
 
 jobs:
   refresh-and-upload-manifests:

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *' # Midnight UTC
   workflow_dispatch:
-  pull_request:
 
 jobs:
   refresh-and-upload-manifests:


### PR DESCRIPTION
Closes #70
Closes #71

The new workflow has three main jobs:

1. Refresh the manifests using the `refresh-manifests.sh` script and upload the `manifests` directory to temporary workflow storage.
2. If `1.` succeeds: For all supported platforms and all major package sets (fuel, fuel-nightly, fuel-beta-3, etc), download the new manifests from temporary storage, add them to git staging so they get picked up by nix, then do a test nix build. Cache the binaries on success.
3. If `2.` succeeds: Download the manifests from temporary storage, commit them to master and push to the main master branch.