### PR TITLE
Fix fuel.nix book building step in publish-book workflow

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: build
         run: nix develop --print-build-logs --no-update-lock-file .#book-dev --command mdbook build book
       - name: deploy


### PR DESCRIPTION
Adds the missing nix installation that provides the environment for building the book.

Follow-up to #61 