### PR TITLE
chore: bump to macos sdk 11 for sysinfo dependency after 2023-05-30

### DIFF
--- a/patches.nix
+++ b/patches.nix
@@ -311,4 +311,17 @@ in [
       rust = pkgs.rust-bin.stable."1.68.0".default;
     };
   }
+  # As of ~2023-05-30, `forc` requires apple sdk 11 for darwin builds.
+  {
+    condition = m: pkgs.lib.hasInfix "darwin" pkgs.system && m.date >= "2023-05-30";
+    patch = m: {
+      buildInputs =
+        (m.buildInputs or [])
+        ++ [
+          pkgs.darwin.apple_sdk_11_0.frameworks.CoreFoundation
+          pkgs.darwin.apple_sdk_11_0.frameworks.Security
+          pkgs.darwin.apple_sdk_11_0.frameworks.SystemConfiguration
+        ];
+    };
+  }
 ]


### PR DESCRIPTION
closes #64.

Introduction of sysinfo dependency to forc, requires us to bump apple sdk version to 11 for builds after `2023-05-30`. Apple sdk 11 breaks libgit2 v1.5.1 builds, so until sway repo releases a new release with [this](https://github.com/FuelLabs/sway/pull/4717) pr, we are blocked.