### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Nix flake for the Fuel Labs ecosystem. **https://fuel.network**
 
 Each night at midnight (UTC) this repo is automatically updated with the latest
 stable and nightly releases of all fuel packages. Builds are tested and cached
-for both `x86_64-linux` and `x86_64-darwin` systems.
+for `x86_64-linux`, `x86_64-darwin` and `aarch64-darwin` systems.
 
 See the [**Quick Start**][fuel-nix-quick-start] guide from
 [**the book**][fuel-nix-book] to get started.


### PR DESCRIPTION
added missing `aarch64-darwin` to the tested and cached section.