### PR TITLE
chore: remove beta-4 rc channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
             fuel-beta-1,
             fuel-beta-2,
             fuel-beta-3,
-            fuel-beta-4-rc,
-            fuel-beta-4-rc-2,
             fuel-beta-4,
             fuel-nightly,
             sway-vim,

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -42,8 +42,6 @@ jobs:
             fuel-beta-1,
             fuel-beta-2,
             fuel-beta-3,
-            fuel-beta-4-rc,
-            fuel-beta-4-rc-2,
             fuel-beta-4,
             fuel-nightly,
           ]

--- a/milestones.nix
+++ b/milestones.nix
@@ -31,26 +31,6 @@
   };
 
   # Commits sourced from:
-  # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-4-rc.toml
-  beta-4-rc = {
-    forc-explorer = "4bb7392eed085ee3a6795b98ea25392b3f41ade8";
-    forc-wallet = "14c29a7b160edfd974901f8e10bbe23aba3db105";
-    fuel-core = "955ff5f7508daf0cd4b1542a58bded78d09516f4";
-    fuel-indexer = "c4aa7256308b77e3c612a217e81a2bfc0ac3532d";
-    sway = "3b66f8e424bd21e3ba467783b10b36e808cfa6ee";
-  };
-
-  # Commits sourced from:
-  # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-4-rc.2.toml
-  beta-4-rc-2 = {
-    forc-explorer = "4bb7392eed085ee3a6795b98ea25392b3f41ade8";
-    forc-wallet = "755404c32dc3955b72304b200449e0cc9759f6ca";
-    fuel-core = "704848a7b2164033b01e3c6c56c8a87772b81000";
-    fuel-indexer = "94ee6d6b345c50e5016d5e6b1efa7dbe4e750b45";
-    sway = "04a597093e7441898933dd412b8e4dc6ac860cd3";
-  };
-
-  # Commits sourced from:
   # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-4.toml
   beta-4 = {
     forc-explorer = "4bb7392eed085ee3a6795b98ea25392b3f41ade8";


### PR DESCRIPTION
Beta-4 is stable now and should be used instead. 

These were removed in fuelup here https://github.com/FuelLabs/fuelup/pull/511