### PR TITLE
fix: bump MSRV to 1.73 from 2023-11-29

### DIFF
--- a/patches.nix
+++ b/patches.nix
@@ -319,4 +319,12 @@ in [
       rust = pkgs.rust-bin.stable."1.70.0".default;
     };
   }
+
+  # `fuel-tx` requires Rust 1.73 as of ~2023-11-29 due to use of `div_ceil`.
+  {
+    condition = m: m.date >= "2023-11-29";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.73.0".default;
+    };
+  }
 ]


### PR DESCRIPTION
`fuel-tx` requires Rust 1.73 as of ~2023-11-29 due to use of `div_ceil`.
