### PR TITLE
Don't build beta-1 and beta-2 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         package:
           [
             fuel,
-            fuel-beta-1,
-            fuel-beta-2,
             fuel-beta-3,
             fuel-beta-4,
             fuel-nightly,

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -39,8 +39,6 @@ jobs:
         package:
           [
             fuel,
-            fuel-beta-1,
-            fuel-beta-2,
             fuel-beta-3,
             fuel-beta-4,
             fuel-nightly,


### PR DESCRIPTION
Because they use a version of `librocksdb-sys` which is broken.