### PR TITLE
+= Dockerfile and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,25 @@ for `x86_64-linux`, `x86_64-darwin` and `aarch64-darwin` systems.
 See the [**Quick Start**][fuel-nix-quick-start] guide from
 [**the book**][fuel-nix-book] to get started.
 
+# To run in docker:
+
+build `fuel-nix` :
+
+```
+docker build -t fuel-nix -f docker/Dockerfile .
+```
+
+jump into it with shell:
+
+```
+docker run -it fuel-nix
+```
+
+if you wanna mount your current dictory to have access to files from inside container:
+
+```
+docker run -it -v $(pwd):/pwd fuel-nix   # and inside docker `cd /pwd`
+```
+
 [fuel-nix-book]: https://nix.fuel.network
 [fuel-nix-quick-start]: https://nix.fuel.network/quick-start

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+# Use NixOS/nix as the base image
+FROM nixos/nix
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy the current directory contents into the container at /usr/src/app
+COPY . .
+
+# Install the Fuel tools using Nix
+RUN nix-channel --add https://nixos.org/channels/nixos-unstable nixos \
+    && nix-channel --update \
+    && nix --extra-experimental-features "nix-command flakes" build github:FuelLabs/fuel.nix#fuel
+# Correct URL to repository is : https://github.com/FuelLabs/fuel.nix/
+
+# Define environment variable for Nix
+ENV ENV="/root/.nix-profile/etc/profile.d/nix.sh"
+
+# Run a shell when the container launches
+# CMD ["/bin/sh"]
+CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,9 @@ FROM nixos/nix
 # Set the working directory in the container
 WORKDIR /usr/src/app
 
-# Copy the current directory contents into the container at /usr/src/app
-COPY . .
+# For better cashing, first copy only files that maybe required
+# for building nix environment.
+COPY *.nix manifests patch script .
 
 # Install the Fuel tools using Nix
 RUN nix-channel --add https://nixos.org/channels/nixos-unstable nixos \
@@ -13,9 +14,13 @@ RUN nix-channel --add https://nixos.org/channels/nixos-unstable nixos \
     && nix --extra-experimental-features "nix-command flakes" build github:FuelLabs/fuel.nix#fuel
 # Correct URL to repository is : https://github.com/FuelLabs/fuel.nix/
 
+# Now, once we finished long, expensive nix building, we can
+# copy over all contents of the current directory into the container at /usr/src/app 
+COPY . .
+
 # Define environment variable for Nix
 ENV ENV="/root/.nix-profile/etc/profile.d/nix.sh"
 
 # Run a shell when the container launches
-# CMD ["/bin/sh"]
 CMD ["/bin/bash"]
+


### PR DESCRIPTION
I am Nix/NixOS newbie, I hope this PR will be inspiration for someone to make nice Docker to build everything inside (i.e. not requiring any tools on host, e.g. hix) or eventually opportunity for me to learn through code review process. Or maybe that's good enough Dockerfile to start with :crossed_fingers: .

Try:

```
git clone https://github.com/FuelLabs/fuel.nix.git
cd fuel.nix
git fetch origin gww-fuel/dockerfile
git checkout -b gww-fuel/dockerfile origin/gww-fuel/dockerfile
grep docker README.md  # to have cheatsheet of docker commands
docker build -t fuel-nix -f docker/Dockerfile .  # build
docker run -it -v $(pwd):/pwd fuel-nix   # and inside docker `cd /pwd`
```