### PR TITLE
chore: add patch for forc-client rust version 1.7.4

### DIFF
--- a/manifests/forc-0.48.1-nightly-2024-01-05.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb1a627757a70ad6d0cbe0bd2c17f0ad1230ad75";
+  sha256 = "sha256-RfWaiEnxXwQOHe7365D+zuQ7P5ulGXiptmY3TfX9DRs=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-07.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bd06ad5ba69f2c1c2cdef00d26d4eb664ebb80a4";
+  sha256 = "sha256-bSp0vfK2Kyjuj9ZBrwb73NZP3kwUTh05STT60/47dKA=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-09.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a164fe17696075da0c235922866fe0e5be2252e5";
+  sha256 = "sha256-9aw+HsBE4VlPDB9KIw0ExPfrsYGxinaaLljLMEF5o1E=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-10.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7109ca7301320d76677527288dbd28b515b59d47";
+  sha256 = "sha256-4jozKN3fhi+ZPjwKr7nlYnevymnSx+tCHGpFlJ3yU5k=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-11.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7a592bcef531d4629e8cf5ae1519d703be417d4";
+  sha256 = "sha256-Utj3GbjDbjlcn2p7LqDjg2QgrTAHBzsUWtrMuk/zIc0=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-12.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0dc2ddcf062b2ffed2383f559d55093f15db726";
+  sha256 = "sha256-Uy0C8DIiSyhWLvVfPmxexe5bmp7O7cFIunyoxZRzfug=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-13.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5ee8877716da380c5f66a575d09f6f50c3a66b06";
+  sha256 = "sha256-lgjzGn1r7t5EwfchrguWVLd28NAAQ7GTge0K00O2FHE=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-14.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d712a083b7f564a777969356a8118696c91e2c5";
+  sha256 = "sha256-kIbYiG79p21kaRP9vUw7885y4bwW4eqFnWIELJ0ec+U=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-15.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e678a3fed232574da8e89b28b1f1fe687b8755d5";
+  sha256 = "sha256-fY9EDSTre7xEP+PnpJnteYTYjhOp8rDEgms29992tl0=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-16.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "813ef65c02c5a7613610685933360295050d587c";
+  sha256 = "sha256-y74XGQ2wCFu9OSZy28+sYR8RDEWsFETH6wO87qRx25c=";
+}

--- a/manifests/forc-0.48.1-nightly-2024-01-18.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5adaa672a313561e1dfb9ce9493d5b172887d06";
+  sha256 = "sha256-nfnbaxoLr3OBoDmjwHCvkUB04+fMpG/079/+6VhYVog=";
+}

--- a/manifests/forc-0.49.0-nightly-2024-01-19.nix
+++ b/manifests/forc-0.49.0-nightly-2024-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.0";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d4c12dd813edb9a8da07c57ee0ff3a043329e7e9";
+  sha256 = "sha256-oKI6tniYr1ME0RmJqF8ijCsnTcE3f2c4D6j9wScodu8=";
+}

--- a/manifests/forc-0.49.0.nix
+++ b/manifests/forc-0.49.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.0";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a17fbf3e7d8dc9845458260c343b4d8f006f3633";
+  sha256 = "sha256-kNy0O+DO9Xnlv41+gTzELqTaKfaYTkghy+wsLFiHm0Q=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-20.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-21.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ef7a7e4b42f7f1d256e730597874c47b4a86b928";
+  sha256 = "sha256-7snAKhwgcH0R8HLjEloLIEbMZUbtIsZskn3FErZMNSY=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-22.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "def5f67860765e7ad1fb6feaf682b23275830af3";
+  sha256 = "sha256-0SRp4MumWpnFkntvVsRvv/nHWWm+8ElWv3zFuSZ4T4g=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-23.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "161c373ca86a8ee2a6f55900d2c617f28dec9f9f";
+  sha256 = "sha256-rd33z59CCEztWZ81yl1MYp/ye6OXk9fkuttyJ/DLFYU=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-24.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c43b57fd3ddafe88c6b5ef5abf1057b05c3e1d09";
+  sha256 = "sha256-UHHtXPWwwo+Jn6qczi2G55mOCUVLKk2oiL64iLByJ3I=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-26.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4d98a5fe786d1ed71304f6fea44aaac16132db56";
+  sha256 = "sha256-iLy5hVxWdh5cPYhyNgKdoZb5vZbvweVMcHB2Y9Pfvko=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-27.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "27a792400f7f60a5d5406d88bf3c15d21f768490";
+  sha256 = "sha256-9REG5IHvGTXDrHyOrILR+Hu06MSyNDrX3wbsk8rAY+k=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-29.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "059b057401d5e9ee4e6d327ccffe173037e2d789";
+  sha256 = "sha256-eZ35LVLZhudEFoGkQhBTOUMU/cPYFyX8Z4ecuZwsgwg=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-30.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c4e3f13f06c1a5594c3535e9fb05b19dbecaf051";
+  sha256 = "sha256-lBRLgugiMtla5KtxP1g65ERTmwzQCkL48yIHMzliwXI=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-01-31.nix
+++ b/manifests/forc-0.49.1-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8b4e454c94dbb3383bba97592d58378026ab72e1";
+  sha256 = "sha256-xIVsUM+0DzYDobD7uBgOXkA4TlgK2I7/Ocq73Y8IJaY=";
+}

--- a/manifests/forc-0.49.1-nightly-2024-02-01.nix
+++ b/manifests/forc-0.49.1-nightly-2024-02-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-02-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1fee545237a53423a2c6828da95837d380fed5a6";
+  sha256 = "sha256-3bYHzCNzjCBXC59CNnOrhqB+eN8gLdjaRjZIzDKcpEM=";
+}

--- a/manifests/forc-0.49.1.nix
+++ b/manifests/forc-0.49.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.1";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-0.49.2.nix
+++ b/manifests/forc-0.49.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.2";
+  date = "2024-02-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a70c746d27b3300beef896ccd1dcce1299836192";
+  sha256 = "sha256-R07m9fTIbsJURYmH1HVFTK87rwp0JwYHnD+vrHH8LTw=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-05.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb1a627757a70ad6d0cbe0bd2c17f0ad1230ad75";
+  sha256 = "sha256-RfWaiEnxXwQOHe7365D+zuQ7P5ulGXiptmY3TfX9DRs=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-07.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bd06ad5ba69f2c1c2cdef00d26d4eb664ebb80a4";
+  sha256 = "sha256-bSp0vfK2Kyjuj9ZBrwb73NZP3kwUTh05STT60/47dKA=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-09.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a164fe17696075da0c235922866fe0e5be2252e5";
+  sha256 = "sha256-9aw+HsBE4VlPDB9KIw0ExPfrsYGxinaaLljLMEF5o1E=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-10.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7109ca7301320d76677527288dbd28b515b59d47";
+  sha256 = "sha256-4jozKN3fhi+ZPjwKr7nlYnevymnSx+tCHGpFlJ3yU5k=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-11.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7a592bcef531d4629e8cf5ae1519d703be417d4";
+  sha256 = "sha256-Utj3GbjDbjlcn2p7LqDjg2QgrTAHBzsUWtrMuk/zIc0=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-12.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0dc2ddcf062b2ffed2383f559d55093f15db726";
+  sha256 = "sha256-Uy0C8DIiSyhWLvVfPmxexe5bmp7O7cFIunyoxZRzfug=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-13.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5ee8877716da380c5f66a575d09f6f50c3a66b06";
+  sha256 = "sha256-lgjzGn1r7t5EwfchrguWVLd28NAAQ7GTge0K00O2FHE=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-14.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d712a083b7f564a777969356a8118696c91e2c5";
+  sha256 = "sha256-kIbYiG79p21kaRP9vUw7885y4bwW4eqFnWIELJ0ec+U=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-15.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e678a3fed232574da8e89b28b1f1fe687b8755d5";
+  sha256 = "sha256-fY9EDSTre7xEP+PnpJnteYTYjhOp8rDEgms29992tl0=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-16.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "813ef65c02c5a7613610685933360295050d587c";
+  sha256 = "sha256-y74XGQ2wCFu9OSZy28+sYR8RDEWsFETH6wO87qRx25c=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-18.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5adaa672a313561e1dfb9ce9493d5b172887d06";
+  sha256 = "sha256-nfnbaxoLr3OBoDmjwHCvkUB04+fMpG/079/+6VhYVog=";
+}

--- a/manifests/forc-client-0.49.0-nightly-2024-01-19.nix
+++ b/manifests/forc-client-0.49.0-nightly-2024-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.0";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d4c12dd813edb9a8da07c57ee0ff3a043329e7e9";
+  sha256 = "sha256-oKI6tniYr1ME0RmJqF8ijCsnTcE3f2c4D6j9wScodu8=";
+}

--- a/manifests/forc-client-0.49.0.nix
+++ b/manifests/forc-client-0.49.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.0";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a17fbf3e7d8dc9845458260c343b4d8f006f3633";
+  sha256 = "sha256-kNy0O+DO9Xnlv41+gTzELqTaKfaYTkghy+wsLFiHm0Q=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-20.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-21.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ef7a7e4b42f7f1d256e730597874c47b4a86b928";
+  sha256 = "sha256-7snAKhwgcH0R8HLjEloLIEbMZUbtIsZskn3FErZMNSY=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-22.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "def5f67860765e7ad1fb6feaf682b23275830af3";
+  sha256 = "sha256-0SRp4MumWpnFkntvVsRvv/nHWWm+8ElWv3zFuSZ4T4g=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-23.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "161c373ca86a8ee2a6f55900d2c617f28dec9f9f";
+  sha256 = "sha256-rd33z59CCEztWZ81yl1MYp/ye6OXk9fkuttyJ/DLFYU=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-24.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c43b57fd3ddafe88c6b5ef5abf1057b05c3e1d09";
+  sha256 = "sha256-UHHtXPWwwo+Jn6qczi2G55mOCUVLKk2oiL64iLByJ3I=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-26.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4d98a5fe786d1ed71304f6fea44aaac16132db56";
+  sha256 = "sha256-iLy5hVxWdh5cPYhyNgKdoZb5vZbvweVMcHB2Y9Pfvko=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-27.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "27a792400f7f60a5d5406d88bf3c15d21f768490";
+  sha256 = "sha256-9REG5IHvGTXDrHyOrILR+Hu06MSyNDrX3wbsk8rAY+k=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-29.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "059b057401d5e9ee4e6d327ccffe173037e2d789";
+  sha256 = "sha256-eZ35LVLZhudEFoGkQhBTOUMU/cPYFyX8Z4ecuZwsgwg=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-30.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c4e3f13f06c1a5594c3535e9fb05b19dbecaf051";
+  sha256 = "sha256-lBRLgugiMtla5KtxP1g65ERTmwzQCkL48yIHMzliwXI=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-01-31.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8b4e454c94dbb3383bba97592d58378026ab72e1";
+  sha256 = "sha256-xIVsUM+0DzYDobD7uBgOXkA4TlgK2I7/Ocq73Y8IJaY=";
+}

--- a/manifests/forc-client-0.49.1-nightly-2024-02-01.nix
+++ b/manifests/forc-client-0.49.1-nightly-2024-02-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-02-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1fee545237a53423a2c6828da95837d380fed5a6";
+  sha256 = "sha256-3bYHzCNzjCBXC59CNnOrhqB+eN8gLdjaRjZIzDKcpEM=";
+}

--- a/manifests/forc-client-0.49.1.nix
+++ b/manifests/forc-client-0.49.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.1";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-client-0.49.2.nix
+++ b/manifests/forc-client-0.49.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.2";
+  date = "2024-02-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a70c746d27b3300beef896ccd1dcce1299836192";
+  sha256 = "sha256-R07m9fTIbsJURYmH1HVFTK87rwp0JwYHnD+vrHH8LTw=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-05.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb1a627757a70ad6d0cbe0bd2c17f0ad1230ad75";
+  sha256 = "sha256-RfWaiEnxXwQOHe7365D+zuQ7P5ulGXiptmY3TfX9DRs=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-07.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bd06ad5ba69f2c1c2cdef00d26d4eb664ebb80a4";
+  sha256 = "sha256-bSp0vfK2Kyjuj9ZBrwb73NZP3kwUTh05STT60/47dKA=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-09.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a164fe17696075da0c235922866fe0e5be2252e5";
+  sha256 = "sha256-9aw+HsBE4VlPDB9KIw0ExPfrsYGxinaaLljLMEF5o1E=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-10.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7109ca7301320d76677527288dbd28b515b59d47";
+  sha256 = "sha256-4jozKN3fhi+ZPjwKr7nlYnevymnSx+tCHGpFlJ3yU5k=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-11.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7a592bcef531d4629e8cf5ae1519d703be417d4";
+  sha256 = "sha256-Utj3GbjDbjlcn2p7LqDjg2QgrTAHBzsUWtrMuk/zIc0=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-12.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0dc2ddcf062b2ffed2383f559d55093f15db726";
+  sha256 = "sha256-Uy0C8DIiSyhWLvVfPmxexe5bmp7O7cFIunyoxZRzfug=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-13.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5ee8877716da380c5f66a575d09f6f50c3a66b06";
+  sha256 = "sha256-lgjzGn1r7t5EwfchrguWVLd28NAAQ7GTge0K00O2FHE=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-14.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d712a083b7f564a777969356a8118696c91e2c5";
+  sha256 = "sha256-kIbYiG79p21kaRP9vUw7885y4bwW4eqFnWIELJ0ec+U=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-15.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e678a3fed232574da8e89b28b1f1fe687b8755d5";
+  sha256 = "sha256-fY9EDSTre7xEP+PnpJnteYTYjhOp8rDEgms29992tl0=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-16.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "813ef65c02c5a7613610685933360295050d587c";
+  sha256 = "sha256-y74XGQ2wCFu9OSZy28+sYR8RDEWsFETH6wO87qRx25c=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-18.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5adaa672a313561e1dfb9ce9493d5b172887d06";
+  sha256 = "sha256-nfnbaxoLr3OBoDmjwHCvkUB04+fMpG/079/+6VhYVog=";
+}

--- a/manifests/forc-doc-0.49.0-nightly-2024-01-19.nix
+++ b/manifests/forc-doc-0.49.0-nightly-2024-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.0";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d4c12dd813edb9a8da07c57ee0ff3a043329e7e9";
+  sha256 = "sha256-oKI6tniYr1ME0RmJqF8ijCsnTcE3f2c4D6j9wScodu8=";
+}

--- a/manifests/forc-doc-0.49.0.nix
+++ b/manifests/forc-doc-0.49.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.0";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a17fbf3e7d8dc9845458260c343b4d8f006f3633";
+  sha256 = "sha256-kNy0O+DO9Xnlv41+gTzELqTaKfaYTkghy+wsLFiHm0Q=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-20.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-21.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ef7a7e4b42f7f1d256e730597874c47b4a86b928";
+  sha256 = "sha256-7snAKhwgcH0R8HLjEloLIEbMZUbtIsZskn3FErZMNSY=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-22.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "def5f67860765e7ad1fb6feaf682b23275830af3";
+  sha256 = "sha256-0SRp4MumWpnFkntvVsRvv/nHWWm+8ElWv3zFuSZ4T4g=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-23.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "161c373ca86a8ee2a6f55900d2c617f28dec9f9f";
+  sha256 = "sha256-rd33z59CCEztWZ81yl1MYp/ye6OXk9fkuttyJ/DLFYU=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-24.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c43b57fd3ddafe88c6b5ef5abf1057b05c3e1d09";
+  sha256 = "sha256-UHHtXPWwwo+Jn6qczi2G55mOCUVLKk2oiL64iLByJ3I=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-26.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4d98a5fe786d1ed71304f6fea44aaac16132db56";
+  sha256 = "sha256-iLy5hVxWdh5cPYhyNgKdoZb5vZbvweVMcHB2Y9Pfvko=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-27.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "27a792400f7f60a5d5406d88bf3c15d21f768490";
+  sha256 = "sha256-9REG5IHvGTXDrHyOrILR+Hu06MSyNDrX3wbsk8rAY+k=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-29.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "059b057401d5e9ee4e6d327ccffe173037e2d789";
+  sha256 = "sha256-eZ35LVLZhudEFoGkQhBTOUMU/cPYFyX8Z4ecuZwsgwg=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-30.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c4e3f13f06c1a5594c3535e9fb05b19dbecaf051";
+  sha256 = "sha256-lBRLgugiMtla5KtxP1g65ERTmwzQCkL48yIHMzliwXI=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-01-31.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8b4e454c94dbb3383bba97592d58378026ab72e1";
+  sha256 = "sha256-xIVsUM+0DzYDobD7uBgOXkA4TlgK2I7/Ocq73Y8IJaY=";
+}

--- a/manifests/forc-doc-0.49.1-nightly-2024-02-01.nix
+++ b/manifests/forc-doc-0.49.1-nightly-2024-02-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-02-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1fee545237a53423a2c6828da95837d380fed5a6";
+  sha256 = "sha256-3bYHzCNzjCBXC59CNnOrhqB+eN8gLdjaRjZIzDKcpEM=";
+}

--- a/manifests/forc-doc-0.49.1.nix
+++ b/manifests/forc-doc-0.49.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.1";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-doc-0.49.2.nix
+++ b/manifests/forc-doc-0.49.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.2";
+  date = "2024-02-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a70c746d27b3300beef896ccd1dcce1299836192";
+  sha256 = "sha256-R07m9fTIbsJURYmH1HVFTK87rwp0JwYHnD+vrHH8LTw=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-05.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb1a627757a70ad6d0cbe0bd2c17f0ad1230ad75";
+  sha256 = "sha256-RfWaiEnxXwQOHe7365D+zuQ7P5ulGXiptmY3TfX9DRs=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-07.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bd06ad5ba69f2c1c2cdef00d26d4eb664ebb80a4";
+  sha256 = "sha256-bSp0vfK2Kyjuj9ZBrwb73NZP3kwUTh05STT60/47dKA=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-09.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a164fe17696075da0c235922866fe0e5be2252e5";
+  sha256 = "sha256-9aw+HsBE4VlPDB9KIw0ExPfrsYGxinaaLljLMEF5o1E=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-10.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7109ca7301320d76677527288dbd28b515b59d47";
+  sha256 = "sha256-4jozKN3fhi+ZPjwKr7nlYnevymnSx+tCHGpFlJ3yU5k=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-11.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7a592bcef531d4629e8cf5ae1519d703be417d4";
+  sha256 = "sha256-Utj3GbjDbjlcn2p7LqDjg2QgrTAHBzsUWtrMuk/zIc0=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-12.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0dc2ddcf062b2ffed2383f559d55093f15db726";
+  sha256 = "sha256-Uy0C8DIiSyhWLvVfPmxexe5bmp7O7cFIunyoxZRzfug=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-13.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5ee8877716da380c5f66a575d09f6f50c3a66b06";
+  sha256 = "sha256-lgjzGn1r7t5EwfchrguWVLd28NAAQ7GTge0K00O2FHE=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-14.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d712a083b7f564a777969356a8118696c91e2c5";
+  sha256 = "sha256-kIbYiG79p21kaRP9vUw7885y4bwW4eqFnWIELJ0ec+U=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-15.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e678a3fed232574da8e89b28b1f1fe687b8755d5";
+  sha256 = "sha256-fY9EDSTre7xEP+PnpJnteYTYjhOp8rDEgms29992tl0=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-16.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "813ef65c02c5a7613610685933360295050d587c";
+  sha256 = "sha256-y74XGQ2wCFu9OSZy28+sYR8RDEWsFETH6wO87qRx25c=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-18.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5adaa672a313561e1dfb9ce9493d5b172887d06";
+  sha256 = "sha256-nfnbaxoLr3OBoDmjwHCvkUB04+fMpG/079/+6VhYVog=";
+}

--- a/manifests/forc-fmt-0.49.0-nightly-2024-01-19.nix
+++ b/manifests/forc-fmt-0.49.0-nightly-2024-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.0";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d4c12dd813edb9a8da07c57ee0ff3a043329e7e9";
+  sha256 = "sha256-oKI6tniYr1ME0RmJqF8ijCsnTcE3f2c4D6j9wScodu8=";
+}

--- a/manifests/forc-fmt-0.49.0.nix
+++ b/manifests/forc-fmt-0.49.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.0";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a17fbf3e7d8dc9845458260c343b4d8f006f3633";
+  sha256 = "sha256-kNy0O+DO9Xnlv41+gTzELqTaKfaYTkghy+wsLFiHm0Q=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-20.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-21.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ef7a7e4b42f7f1d256e730597874c47b4a86b928";
+  sha256 = "sha256-7snAKhwgcH0R8HLjEloLIEbMZUbtIsZskn3FErZMNSY=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-22.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "def5f67860765e7ad1fb6feaf682b23275830af3";
+  sha256 = "sha256-0SRp4MumWpnFkntvVsRvv/nHWWm+8ElWv3zFuSZ4T4g=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-23.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "161c373ca86a8ee2a6f55900d2c617f28dec9f9f";
+  sha256 = "sha256-rd33z59CCEztWZ81yl1MYp/ye6OXk9fkuttyJ/DLFYU=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-24.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c43b57fd3ddafe88c6b5ef5abf1057b05c3e1d09";
+  sha256 = "sha256-UHHtXPWwwo+Jn6qczi2G55mOCUVLKk2oiL64iLByJ3I=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-26.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4d98a5fe786d1ed71304f6fea44aaac16132db56";
+  sha256 = "sha256-iLy5hVxWdh5cPYhyNgKdoZb5vZbvweVMcHB2Y9Pfvko=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-27.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "27a792400f7f60a5d5406d88bf3c15d21f768490";
+  sha256 = "sha256-9REG5IHvGTXDrHyOrILR+Hu06MSyNDrX3wbsk8rAY+k=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-29.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "059b057401d5e9ee4e6d327ccffe173037e2d789";
+  sha256 = "sha256-eZ35LVLZhudEFoGkQhBTOUMU/cPYFyX8Z4ecuZwsgwg=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-30.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c4e3f13f06c1a5594c3535e9fb05b19dbecaf051";
+  sha256 = "sha256-lBRLgugiMtla5KtxP1g65ERTmwzQCkL48yIHMzliwXI=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-01-31.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8b4e454c94dbb3383bba97592d58378026ab72e1";
+  sha256 = "sha256-xIVsUM+0DzYDobD7uBgOXkA4TlgK2I7/Ocq73Y8IJaY=";
+}

--- a/manifests/forc-fmt-0.49.1-nightly-2024-02-01.nix
+++ b/manifests/forc-fmt-0.49.1-nightly-2024-02-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-02-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1fee545237a53423a2c6828da95837d380fed5a6";
+  sha256 = "sha256-3bYHzCNzjCBXC59CNnOrhqB+eN8gLdjaRjZIzDKcpEM=";
+}

--- a/manifests/forc-fmt-0.49.1.nix
+++ b/manifests/forc-fmt-0.49.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.1";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-fmt-0.49.2.nix
+++ b/manifests/forc-fmt-0.49.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.2";
+  date = "2024-02-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a70c746d27b3300beef896ccd1dcce1299836192";
+  sha256 = "sha256-R07m9fTIbsJURYmH1HVFTK87rwp0JwYHnD+vrHH8LTw=";
+}

--- a/manifests/forc-index-0.24.3-nightly-2024-01-31.nix
+++ b/manifests/forc-index-0.24.3-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-index";
+  version = "0.24.3";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a6bc822772ec1da1eb8ec22e35404605e3481b0a";
+  sha256 = "sha256-2As1uU5j/HNL58KfMHER21l5rWiB+KHWCJfYcFQltDQ=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-05.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb1a627757a70ad6d0cbe0bd2c17f0ad1230ad75";
+  sha256 = "sha256-RfWaiEnxXwQOHe7365D+zuQ7P5ulGXiptmY3TfX9DRs=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-07.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bd06ad5ba69f2c1c2cdef00d26d4eb664ebb80a4";
+  sha256 = "sha256-bSp0vfK2Kyjuj9ZBrwb73NZP3kwUTh05STT60/47dKA=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-09.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a164fe17696075da0c235922866fe0e5be2252e5";
+  sha256 = "sha256-9aw+HsBE4VlPDB9KIw0ExPfrsYGxinaaLljLMEF5o1E=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-10.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7109ca7301320d76677527288dbd28b515b59d47";
+  sha256 = "sha256-4jozKN3fhi+ZPjwKr7nlYnevymnSx+tCHGpFlJ3yU5k=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-11.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7a592bcef531d4629e8cf5ae1519d703be417d4";
+  sha256 = "sha256-Utj3GbjDbjlcn2p7LqDjg2QgrTAHBzsUWtrMuk/zIc0=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-12.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0dc2ddcf062b2ffed2383f559d55093f15db726";
+  sha256 = "sha256-Uy0C8DIiSyhWLvVfPmxexe5bmp7O7cFIunyoxZRzfug=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-13.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5ee8877716da380c5f66a575d09f6f50c3a66b06";
+  sha256 = "sha256-lgjzGn1r7t5EwfchrguWVLd28NAAQ7GTge0K00O2FHE=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-14.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d712a083b7f564a777969356a8118696c91e2c5";
+  sha256 = "sha256-kIbYiG79p21kaRP9vUw7885y4bwW4eqFnWIELJ0ec+U=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-15.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e678a3fed232574da8e89b28b1f1fe687b8755d5";
+  sha256 = "sha256-fY9EDSTre7xEP+PnpJnteYTYjhOp8rDEgms29992tl0=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-16.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "813ef65c02c5a7613610685933360295050d587c";
+  sha256 = "sha256-y74XGQ2wCFu9OSZy28+sYR8RDEWsFETH6wO87qRx25c=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-18.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5adaa672a313561e1dfb9ce9493d5b172887d06";
+  sha256 = "sha256-nfnbaxoLr3OBoDmjwHCvkUB04+fMpG/079/+6VhYVog=";
+}

--- a/manifests/forc-lsp-0.49.0-nightly-2024-01-19.nix
+++ b/manifests/forc-lsp-0.49.0-nightly-2024-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.0";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d4c12dd813edb9a8da07c57ee0ff3a043329e7e9";
+  sha256 = "sha256-oKI6tniYr1ME0RmJqF8ijCsnTcE3f2c4D6j9wScodu8=";
+}

--- a/manifests/forc-lsp-0.49.0.nix
+++ b/manifests/forc-lsp-0.49.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.0";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a17fbf3e7d8dc9845458260c343b4d8f006f3633";
+  sha256 = "sha256-kNy0O+DO9Xnlv41+gTzELqTaKfaYTkghy+wsLFiHm0Q=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-20.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-21.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ef7a7e4b42f7f1d256e730597874c47b4a86b928";
+  sha256 = "sha256-7snAKhwgcH0R8HLjEloLIEbMZUbtIsZskn3FErZMNSY=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-22.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "def5f67860765e7ad1fb6feaf682b23275830af3";
+  sha256 = "sha256-0SRp4MumWpnFkntvVsRvv/nHWWm+8ElWv3zFuSZ4T4g=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-23.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "161c373ca86a8ee2a6f55900d2c617f28dec9f9f";
+  sha256 = "sha256-rd33z59CCEztWZ81yl1MYp/ye6OXk9fkuttyJ/DLFYU=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-24.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c43b57fd3ddafe88c6b5ef5abf1057b05c3e1d09";
+  sha256 = "sha256-UHHtXPWwwo+Jn6qczi2G55mOCUVLKk2oiL64iLByJ3I=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-26.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4d98a5fe786d1ed71304f6fea44aaac16132db56";
+  sha256 = "sha256-iLy5hVxWdh5cPYhyNgKdoZb5vZbvweVMcHB2Y9Pfvko=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-27.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "27a792400f7f60a5d5406d88bf3c15d21f768490";
+  sha256 = "sha256-9REG5IHvGTXDrHyOrILR+Hu06MSyNDrX3wbsk8rAY+k=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-29.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "059b057401d5e9ee4e6d327ccffe173037e2d789";
+  sha256 = "sha256-eZ35LVLZhudEFoGkQhBTOUMU/cPYFyX8Z4ecuZwsgwg=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-30.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c4e3f13f06c1a5594c3535e9fb05b19dbecaf051";
+  sha256 = "sha256-lBRLgugiMtla5KtxP1g65ERTmwzQCkL48yIHMzliwXI=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-01-31.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8b4e454c94dbb3383bba97592d58378026ab72e1";
+  sha256 = "sha256-xIVsUM+0DzYDobD7uBgOXkA4TlgK2I7/Ocq73Y8IJaY=";
+}

--- a/manifests/forc-lsp-0.49.1-nightly-2024-02-01.nix
+++ b/manifests/forc-lsp-0.49.1-nightly-2024-02-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-02-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1fee545237a53423a2c6828da95837d380fed5a6";
+  sha256 = "sha256-3bYHzCNzjCBXC59CNnOrhqB+eN8gLdjaRjZIzDKcpEM=";
+}

--- a/manifests/forc-lsp-0.49.1.nix
+++ b/manifests/forc-lsp-0.49.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.1";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-lsp-0.49.2.nix
+++ b/manifests/forc-lsp-0.49.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.2";
+  date = "2024-02-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a70c746d27b3300beef896ccd1dcce1299836192";
+  sha256 = "sha256-R07m9fTIbsJURYmH1HVFTK87rwp0JwYHnD+vrHH8LTw=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-05.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-05";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bb1a627757a70ad6d0cbe0bd2c17f0ad1230ad75";
+  sha256 = "sha256-RfWaiEnxXwQOHe7365D+zuQ7P5ulGXiptmY3TfX9DRs=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-07.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "bd06ad5ba69f2c1c2cdef00d26d4eb664ebb80a4";
+  sha256 = "sha256-bSp0vfK2Kyjuj9ZBrwb73NZP3kwUTh05STT60/47dKA=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-09.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a164fe17696075da0c235922866fe0e5be2252e5";
+  sha256 = "sha256-9aw+HsBE4VlPDB9KIw0ExPfrsYGxinaaLljLMEF5o1E=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-10.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-10";
+  url = "https://github.com/fuellabs/sway";
+  rev = "7109ca7301320d76677527288dbd28b515b59d47";
+  sha256 = "sha256-4jozKN3fhi+ZPjwKr7nlYnevymnSx+tCHGpFlJ3yU5k=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-11.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e7a592bcef531d4629e8cf5ae1519d703be417d4";
+  sha256 = "sha256-Utj3GbjDbjlcn2p7LqDjg2QgrTAHBzsUWtrMuk/zIc0=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-12.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e0dc2ddcf062b2ffed2383f559d55093f15db726";
+  sha256 = "sha256-Uy0C8DIiSyhWLvVfPmxexe5bmp7O7cFIunyoxZRzfug=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-13.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5ee8877716da380c5f66a575d09f6f50c3a66b06";
+  sha256 = "sha256-lgjzGn1r7t5EwfchrguWVLd28NAAQ7GTge0K00O2FHE=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-14.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "5d712a083b7f564a777969356a8118696c91e2c5";
+  sha256 = "sha256-kIbYiG79p21kaRP9vUw7885y4bwW4eqFnWIELJ0ec+U=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-15.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "e678a3fed232574da8e89b28b1f1fe687b8755d5";
+  sha256 = "sha256-fY9EDSTre7xEP+PnpJnteYTYjhOp8rDEgms29992tl0=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-16.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "813ef65c02c5a7613610685933360295050d587c";
+  sha256 = "sha256-y74XGQ2wCFu9OSZy28+sYR8RDEWsFETH6wO87qRx25c=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-18.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c5adaa672a313561e1dfb9ce9493d5b172887d06";
+  sha256 = "sha256-nfnbaxoLr3OBoDmjwHCvkUB04+fMpG/079/+6VhYVog=";
+}

--- a/manifests/forc-tx-0.49.0-nightly-2024-01-19.nix
+++ b/manifests/forc-tx-0.49.0-nightly-2024-01-19.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.0";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d4c12dd813edb9a8da07c57ee0ff3a043329e7e9";
+  sha256 = "sha256-oKI6tniYr1ME0RmJqF8ijCsnTcE3f2c4D6j9wScodu8=";
+}

--- a/manifests/forc-tx-0.49.0.nix
+++ b/manifests/forc-tx-0.49.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.0";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a17fbf3e7d8dc9845458260c343b4d8f006f3633";
+  sha256 = "sha256-kNy0O+DO9Xnlv41+gTzELqTaKfaYTkghy+wsLFiHm0Q=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-20.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-20";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-21.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-21.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-21";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ef7a7e4b42f7f1d256e730597874c47b4a86b928";
+  sha256 = "sha256-7snAKhwgcH0R8HLjEloLIEbMZUbtIsZskn3FErZMNSY=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-22.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-22.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-22";
+  url = "https://github.com/fuellabs/sway";
+  rev = "def5f67860765e7ad1fb6feaf682b23275830af3";
+  sha256 = "sha256-0SRp4MumWpnFkntvVsRvv/nHWWm+8ElWv3zFuSZ4T4g=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-23.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-23";
+  url = "https://github.com/fuellabs/sway";
+  rev = "161c373ca86a8ee2a6f55900d2c617f28dec9f9f";
+  sha256 = "sha256-rd33z59CCEztWZ81yl1MYp/ye6OXk9fkuttyJ/DLFYU=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-24.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-24";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c43b57fd3ddafe88c6b5ef5abf1057b05c3e1d09";
+  sha256 = "sha256-UHHtXPWwwo+Jn6qczi2G55mOCUVLKk2oiL64iLByJ3I=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-26.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-26";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4d98a5fe786d1ed71304f6fea44aaac16132db56";
+  sha256 = "sha256-iLy5hVxWdh5cPYhyNgKdoZb5vZbvweVMcHB2Y9Pfvko=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-27.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-27";
+  url = "https://github.com/fuellabs/sway";
+  rev = "27a792400f7f60a5d5406d88bf3c15d21f768490";
+  sha256 = "sha256-9REG5IHvGTXDrHyOrILR+Hu06MSyNDrX3wbsk8rAY+k=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-29.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-29.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-29";
+  url = "https://github.com/fuellabs/sway";
+  rev = "059b057401d5e9ee4e6d327ccffe173037e2d789";
+  sha256 = "sha256-eZ35LVLZhudEFoGkQhBTOUMU/cPYFyX8Z4ecuZwsgwg=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-30.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-30";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c4e3f13f06c1a5594c3535e9fb05b19dbecaf051";
+  sha256 = "sha256-lBRLgugiMtla5KtxP1g65ERTmwzQCkL48yIHMzliwXI=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-01-31.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/sway";
+  rev = "8b4e454c94dbb3383bba97592d58378026ab72e1";
+  sha256 = "sha256-xIVsUM+0DzYDobD7uBgOXkA4TlgK2I7/Ocq73Y8IJaY=";
+}

--- a/manifests/forc-tx-0.49.1-nightly-2024-02-01.nix
+++ b/manifests/forc-tx-0.49.1-nightly-2024-02-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-02-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "1fee545237a53423a2c6828da95837d380fed5a6";
+  sha256 = "sha256-3bYHzCNzjCBXC59CNnOrhqB+eN8gLdjaRjZIzDKcpEM=";
+}

--- a/manifests/forc-tx-0.49.1.nix
+++ b/manifests/forc-tx-0.49.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.1";
+  date = "2024-01-19";
+  url = "https://github.com/fuellabs/sway";
+  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
+  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
+}

--- a/manifests/forc-tx-0.49.2.nix
+++ b/manifests/forc-tx-0.49.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.2";
+  date = "2024-02-02";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a70c746d27b3300beef896ccd1dcce1299836192";
+  sha256 = "sha256-R07m9fTIbsJURYmH1HVFTK87rwp0JwYHnD+vrHH8LTw=";
+}

--- a/manifests/forc-wallet-0.4.1.nix
+++ b/manifests/forc-wallet-0.4.1.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.4.1";
+  date = "2024-01-04";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "16ed86434dd36ffd72f9cc7fbc68003a6bd0188d";
+  sha256 = "sha256-W8JELihoLohoGS8g1YTTFccrg9rKPelWzN76fZS0ad4=";
+}

--- a/manifests/forc-wallet-0.4.2-nightly-2024-01-05.nix
+++ b/manifests/forc-wallet-0.4.2-nightly-2024-01-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.4.2";
+  date = "2024-01-05";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "dcece094ffb835abcb102dfde25e503f008d3242";
+  sha256 = "sha256-Lh1jWD7TS5otPZQGvQxnX7AljO2OJ6ePvUHmW/AukH8=";
+}

--- a/manifests/forc-wallet-0.4.2-nightly-2024-01-11.nix
+++ b/manifests/forc-wallet-0.4.2-nightly-2024-01-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.4.2";
+  date = "2024-01-11";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "e0c391f880f225ef7bf1b9cabdebd6d0e71baae4";
+  sha256 = "sha256-VLZwer3CliOeX44n4ZB/V7vUXHfjm0YId331cvM/lJs=";
+}

--- a/manifests/forc-wallet-0.4.2.nix
+++ b/manifests/forc-wallet-0.4.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.4.2";
+  date = "2024-01-04";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "dcece094ffb835abcb102dfde25e503f008d3242";
+  sha256 = "sha256-Lh1jWD7TS5otPZQGvQxnX7AljO2OJ6ePvUHmW/AukH8=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-06.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-06";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "3cab65434bec7c8b7c77b5470a1db0c987a0bd6c";
+  sha256 = "sha256-RdMh4NxCAKKagbBJcQeReDnySXZOTgS7tl5UxA3+GR0=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-07.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-07";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "ca7d2107c33df0bd64b3df5cba208db07d46cc4e";
+  sha256 = "sha256-crcgsLgU9cxSQjjy5uaquu0HUwFC9HH4txGsHlx61Wg=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-08.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-08";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "01cae6c8d56eb3e14f954ec1d73f3060fcfcb5f2";
+  sha256 = "sha256-k3fhCWztPMxYWv4LKRviEOEVRR86VBYJVkSekm6V7xE=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-10.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-10";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e1e631902f762081d2124d9c457ddfe13ac366dc";
+  sha256 = "sha256-SOqn86hPJKMU8F/iev5BY3gwinHjI9TEk4MP9DB2z6A=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-17.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2b2e311b36500761dbc65d3627edc122f13e1551";
+  sha256 = "sha256-DZ53VEB482NF7CNkzWA9V/bgvPzaX+rgDzvhbuAqWRI=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-18.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "622e38bb33b942213cc173e93bbb9eb663d375e0";
+  sha256 = "sha256-jFFwgmA2Kc2Crx5Uogv0HlALIel+6+zurbCM3Yb3RKY=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-20.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "7de49aecc3f6ee24d65a6a3833766d3f5baedf67";
+  sha256 = "sha256-NoBffkN/Xtsiy7tPS/eOt9R+80LAicywKImNPYmKWyo=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-23.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-23";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "d9702f7a65fed13c1ea33118147d446182524bb2";
+  sha256 = "sha256-7Zx9nZsDpSBBl0uPaeiWGq39s8/FDjnLCRPPX4aiSns=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-24.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-24";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a0b022d5ea20aef90b7629332c85f5227ecc0094";
+  sha256 = "sha256-lVYLrT2Xg1IWbVWmq+4z5j6v4DRXMYCtdDjlF7uxj8I=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-25.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-25";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "6df2ff2748db059f9982706c18f07077ef9cc563";
+  sha256 = "sha256-yFyfSW/j1CYOzyCfnlvpZSflaGwTlNMCZzBRRR0dB4Q=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-26.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-26";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "79c8c8d49f206915717d7ef77af11a2c9edd3a30";
+  sha256 = "sha256-VsP3PIeoVV8yCj+KP/WMABrRcbtAOgc0DeSZidputaI=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-27.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-27";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2eaa6d4260f6c0971623143ee63fa333753b77a7";
+  sha256 = "sha256-MvBaNbZP9ujDB2PULfAXTeucRLf1jrdMOP4t7DR6z2Q=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-28.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-28";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a05ce48120e3545196521eaf2c2ac28931b5043c";
+  sha256 = "sha256-j7sZXISYKPpl5VXQwsU1NyMdOSleam5oXKf+eSIeDIU=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-30.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-30";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "3fdd33d89fd0544aa3bcfe858bcc18bbfae7491b";
+  sha256 = "sha256-J5pqY/ziKWIHMsitGuHzgnk12cjkvHe5sZr+RUXAnHs=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-31.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "3c55250c2334033ec5e1d14ea12ee1205eea04ef";
+  sha256 = "sha256-gAZ2j87vRN+e8yhW8J1jVm8mEsCjThvNFWQ7dOZMvhQ=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-02-01.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-02-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-02-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "bc8780c0c7e307a7ce54db75b1f6728ee8ea1633";
+  sha256 = "sha256-m/wSFXhsRQCW9yK5ndmLzzaut+F3w6tDeaaIIgx9ZMg=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-02-03.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-02-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-02-03";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "7e54cb8f107a7153596a2b451d4e5656a1805b1d";
+  sha256 = "sha256-YqiGbFdIDz1XZvmiig1H/yoNspTdMiJey1FwW9xDdDQ=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-06.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-06.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-06";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "3cab65434bec7c8b7c77b5470a1db0c987a0bd6c";
+  sha256 = "sha256-RdMh4NxCAKKagbBJcQeReDnySXZOTgS7tl5UxA3+GR0=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-07.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-07";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "ca7d2107c33df0bd64b3df5cba208db07d46cc4e";
+  sha256 = "sha256-crcgsLgU9cxSQjjy5uaquu0HUwFC9HH4txGsHlx61Wg=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-08.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-08";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "01cae6c8d56eb3e14f954ec1d73f3060fcfcb5f2";
+  sha256 = "sha256-k3fhCWztPMxYWv4LKRviEOEVRR86VBYJVkSekm6V7xE=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-10.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-10.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-10";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e1e631902f762081d2124d9c457ddfe13ac366dc";
+  sha256 = "sha256-SOqn86hPJKMU8F/iev5BY3gwinHjI9TEk4MP9DB2z6A=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-17.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2b2e311b36500761dbc65d3627edc122f13e1551";
+  sha256 = "sha256-DZ53VEB482NF7CNkzWA9V/bgvPzaX+rgDzvhbuAqWRI=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-18.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-18.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-18";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "622e38bb33b942213cc173e93bbb9eb663d375e0";
+  sha256 = "sha256-jFFwgmA2Kc2Crx5Uogv0HlALIel+6+zurbCM3Yb3RKY=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-20.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-20.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-20";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "7de49aecc3f6ee24d65a6a3833766d3f5baedf67";
+  sha256 = "sha256-NoBffkN/Xtsiy7tPS/eOt9R+80LAicywKImNPYmKWyo=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-23.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-23.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-23";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "d9702f7a65fed13c1ea33118147d446182524bb2";
+  sha256 = "sha256-7Zx9nZsDpSBBl0uPaeiWGq39s8/FDjnLCRPPX4aiSns=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-24.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-24.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-24";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a0b022d5ea20aef90b7629332c85f5227ecc0094";
+  sha256 = "sha256-lVYLrT2Xg1IWbVWmq+4z5j6v4DRXMYCtdDjlF7uxj8I=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-25.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-25.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-25";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "6df2ff2748db059f9982706c18f07077ef9cc563";
+  sha256 = "sha256-yFyfSW/j1CYOzyCfnlvpZSflaGwTlNMCZzBRRR0dB4Q=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-26.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-26.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-26";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "79c8c8d49f206915717d7ef77af11a2c9edd3a30";
+  sha256 = "sha256-VsP3PIeoVV8yCj+KP/WMABrRcbtAOgc0DeSZidputaI=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-27.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-27.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-27";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2eaa6d4260f6c0971623143ee63fa333753b77a7";
+  sha256 = "sha256-MvBaNbZP9ujDB2PULfAXTeucRLf1jrdMOP4t7DR6z2Q=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-28.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-28.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-28";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a05ce48120e3545196521eaf2c2ac28931b5043c";
+  sha256 = "sha256-j7sZXISYKPpl5VXQwsU1NyMdOSleam5oXKf+eSIeDIU=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-30.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-30.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-30";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "3fdd33d89fd0544aa3bcfe858bcc18bbfae7491b";
+  sha256 = "sha256-J5pqY/ziKWIHMsitGuHzgnk12cjkvHe5sZr+RUXAnHs=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-31.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "3c55250c2334033ec5e1d14ea12ee1205eea04ef";
+  sha256 = "sha256-gAZ2j87vRN+e8yhW8J1jVm8mEsCjThvNFWQ7dOZMvhQ=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-02-01.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-02-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-02-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "bc8780c0c7e307a7ce54db75b1f6728ee8ea1633";
+  sha256 = "sha256-m/wSFXhsRQCW9yK5ndmLzzaut+F3w6tDeaaIIgx9ZMg=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-02-03.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-02-03.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-02-03";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "7e54cb8f107a7153596a2b451d4e5656a1805b1d";
+  sha256 = "sha256-YqiGbFdIDz1XZvmiig1H/yoNspTdMiJey1FwW9xDdDQ=";
+}

--- a/manifests/fuel-indexer-0.24.3-nightly-2024-01-31.nix
+++ b/manifests/fuel-indexer-0.24.3-nightly-2024-01-31.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-indexer";
+  version = "0.24.3";
+  date = "2024-01-31";
+  url = "https://github.com/fuellabs/fuel-indexer";
+  rev = "a6bc822772ec1da1eb8ec22e35404605e3481b0a";
+  sha256 = "sha256-2As1uU5j/HNL58KfMHER21l5rWiB+KHWCJfYcFQltDQ=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -331,7 +331,7 @@ in [
   # `forc-client` requires Rust 1.74 as of
   # 3fcb76cfb2ad4e4d1987f7f978aa594fd0ce02c5 due to use of `fuels-core v0.54.0`.
   {
-    condition = m: m.date >= "2024-01-08";
+    condition = m: m.date >= "2024-01-04";
     patch = m: {
       rust = pkgs.rust-bin.stable."1.74.0".default;
     };

--- a/patches.nix
+++ b/patches.nix
@@ -327,4 +327,13 @@ in [
       rust = pkgs.rust-bin.stable."1.73.0".default;
     };
   }
+
+  # `forc-client` requires Rust 1.74 as of
+  # 3fcb76cfb2ad4e4d1987f7f978aa594fd0ce02c5 due to use of `fuels-core v0.54.0`.
+  {
+    condition = m: m.date >= "2024-01-08";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.74.0".default;
+    };
+  }
 ]


### PR DESCRIPTION
Adds patch for  3fcb76cfb2ad4e4d1987f7f978aa594fd0ce02c5 commit of sway repo as it introduced fuels-core v0.54.0 which relies on rust 1.74.0 or newer.