### PR TITLE
fix: free space on GH runner before running nix build

### DIFF
--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: jlumbroso/free-disk-space@main
       - run: rm -r manifests
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Error ([source](https://github.com/FuelLabs/fuel.nix/actions/runs/7879608186/job/21501515803)):

> `System.IO.IOException: No space left on device : ‘/home/runner/runners/2.312.0/_diag/Worker_20240209-004940-utc.log’`

Fix:
As per https://github.com/actions/runner-images/issues/2875, there's a way to regain more space on the runners by deleting unnecessary files before the build (manually or using an action like [`free-disk-space-ubuntu`](https://github.com/marketplace/actions/free-disk-space-ubuntu)).