### PR TITLE
Use macos-latest-xlarge instead of self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,44 +36,30 @@ jobs:
             fuel-nightly,
             sway-vim,
           ]
-        os: [ubuntu-latest, macos-latest, macos-arm]
+        os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.4.0
-      # Since the self-hosted runners already have nix and cachix installed, we skip these steps.
-      - if: matrix.os != 'macos-arm'
-        uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - if: matrix.os != 'macos-arm'
-        uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v12
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      # Copy the nix store to a tmp directory for later comparison.
-      - if: matrix.os == 'macos-arm'
-        run: ./script/list-nix-store.sh > /tmp/store-path-pre-build
-      - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
-      # Since we skipped the cachix action, we must manually update the cachix cache.
-      - if: matrix.os == 'macos-arm'
-        env:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: ./script/cachix-push-paths.sh
 
   nix-develop:
     needs: nix-build
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-arm]
+        os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.4.0
-      - if: matrix.os != 'macos-arm'
-        uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - if: matrix.os != 'macos-arm'
-        uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v12
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -1,4 +1,4 @@
-name: 'refresh-manifests'
+name: "refresh-manifests"
 
 on:
   schedule:
@@ -36,13 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package:
-          [
-            fuel,
-            fuel-beta-3,
-            fuel-beta-4,
-            fuel-nightly,
-          ]
+        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-beta-4-rc, fuel-nightly]
         os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
@@ -54,6 +48,14 @@ jobs:
           path: manifests/
       - name: stage manifests for nix build
         run: git add -v manifests
+      - uses: cachix/install-nix-action@v22
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v12
+        with:
+          name: fuellabs
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
 
   download-manifests-and-commit:
     needs: [refresh-and-upload-manifests, download-manifests-and-nix-build]

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -43,7 +43,7 @@ jobs:
             fuel-beta-4,
             fuel-nightly,
           ]
-        os: [ubuntu-latest, macos-latest, macos-arm]
+        os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -54,25 +54,6 @@ jobs:
           path: manifests/
       - name: stage manifests for nix build
         run: git add -v manifests
-      # Since the self-hosted runners already have nix and cachix installed, we skip these steps.
-      - if: matrix.os != 'macos-arm'
-        uses: cachix/install-nix-action@v22
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - if: matrix.os != 'macos-arm'
-        uses: cachix/cachix-action@v12
-        with:
-          name: fuellabs
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      # Copy the nix store to a tmp directory for later comparison.
-      - if: matrix.os == 'macos-arm'
-        run: ./script/list-nix-store.sh > /tmp/store-path-pre-build
-      - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}
-      # Since we skipped the cachix action, we must manually update the cachix cache.
-      - if: matrix.os == 'macos-arm'
-        env:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: ./script/cachix-push-paths.sh
 
   download-manifests-and-commit:
     needs: [refresh-and-upload-manifests, download-manifests-and-nix-build]


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel.nix/issues/106