### PR TITLE
Replace beta-4-rc with beta-4 and beta-5 in CI

### DIFF
--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-beta-4-rc, fuel-nightly]
+        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-beta-4, fuel-beta-5, fuel-nightly]
         os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
beta-4-rc is not in the `milestones.nix`, which might be why this CI step is failing.

Also, beta-5 was missing here.