### PR TITLE
Remove support for beta-1 beta-2 and beta-3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         package:
           [
             fuel,
-            fuel-beta-3,
             fuel-beta-4,
             fuel-beta-5,
             fuel-nightly,

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-beta-4-rc, fuel-nightly]
+        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-beta-4, fuel-beta-5, fuel-nightly]
         os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [fuel, fuel-beta-1, fuel-beta-2, fuel-beta-3, fuel-beta-4, fuel-beta-5, fuel-nightly]
+        package: [fuel, fuel-beta-4, fuel-beta-5, fuel-nightly]
         os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:

--- a/book/src/contributing/internals.md
+++ b/book/src/contributing/internals.md
@@ -11,7 +11,7 @@ At a very high level, **fuel.nix** does the following:
    provide package **sets** for the latest semver releases and nightlies e.g.
    (`fuel-latest`, `fuel-nightly`).
 3. [**Provide a special set of "milestone" packages**](./internals/providing-milestones.html)
-   (e.g. `forc-wallet-beta-2`) and package sets (e.g. `fuel-beta-3`) by finding
+   (e.g. `forc-wallet-beta-5`) and package sets (e.g. `fuel-beta-5`) by finding
    packages that match the commits specified in `milestones.nix`.
 4. **Provide `devShell`s** to assist working on the fuel repos by collecting all
    of the inputs to their associated packages and inheriting their environment

--- a/book/src/contributing/internals/providing-milestones.md
+++ b/book/src/contributing/internals/providing-milestones.md
@@ -5,8 +5,7 @@
 Milestones provide a way of pinning a significant set of hand-picked commits
 across the Fuel ecosystem under a single named release.
 
-Milestones are provided by the `./milestones.nix` file. As of writing this,
-the file includes milestones for `beta-1`, `beta-2` and `beta-3`.
+Milestones are provided by the `./milestones.nix` file.
 
 Each milestone is a mapping from a name to a set of repository commits, each of
 which is used to select the set of package manifests used to generate package

--- a/book/src/packages.md
+++ b/book/src/packages.md
@@ -37,10 +37,10 @@ nix run github:fuellabs/fuel.nix#forc-nightly
 Similarly, run the version of a package from a milestone with `-<milestone>`, e.g.
 
 ```
-nix run github:fuellabs/fuel.nix#forc-lsp-beta-3
+nix run github:fuellabs/fuel.nix#forc-lsp-beta-5
 ```
 ```
-nix run github:fuellabs/fuel.nix#forc-wallet-beta-1
+nix run github:fuellabs/fuel.nix#forc-wallet-beta-5
 ```
 
 ## Temporary Shells
@@ -76,9 +76,9 @@ $ exit
 
 # No fuel packages on `PATH`
 
-$ nix shell github:fuellabs/fuel.nix#fuel-beta-3
+$ nix shell github:fuellabs/fuel.nix#fuel-beta-5
 
-# All beta-3 milestone `fuel` packages on `PATH`.
+# All beta-5 milestone `fuel` packages on `PATH`.
 ```
 
 ## Installing Packages

--- a/book/src/quick-start.md
+++ b/book/src/quick-start.md
@@ -59,7 +59,7 @@ were never installed.
 ## Diving Deeper
 
 To find out how to install tools persistently for the current user, how to
-install different toolchain channels (nightly, beta-3, etc), how to install
+install different toolchain channels (nightly, beta-5, etc), how to install
 individual components, along with a whole suite of other options, see [**the
 Packages chapter**](./packages.html).
 

--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
         nightly = pkgs.lib.mapAttrs' mapNightly foldNightly;
       };
 
-      # Construct the milestone package lists, e.g. `{ beta-1 = [...]; beta-2 = [...]; }`.
+      # Construct the milestone package lists, e.g. `{ beta-4 = [...]; beta-5 = [...]; }`.
       milestones = let
         filterPkg = revs: m: builtins.any (rev: rev == m.src.rev) (builtins.attrValues revs);
         filterPublished = revs: builtins.filter (filterPkg revs) published.prepared;

--- a/milestones.nix
+++ b/milestones.nix
@@ -1,35 +1,7 @@
 # A map from repo name to git commit hash for each release milestone.
 # Allows for referencing packages or package sets by milestone, e.g.
-# `forc-beta-2`, `fuel-core-beta-1`, `fuel-beta-2`, etc.
+# `forc-beta-4`, `fuel-core-beta-5`, etc.
 {
-  # Commits sourced from:
-  # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-1.toml
-  beta-1 = {
-    forc-wallet = "9473052e88048f58e8c4e1eba0ff88ef6a4cdd59";
-    fuel-core = "a0351c241754f670470cbf0aa5bb743582b038d1";
-    sway = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
-  };
-
-  # Commits sourced from:
-  # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-2.toml
-  beta-2 = {
-    forc-explorer = "4bb7392eed085ee3a6795b98ea25392b3f41ade8";
-    forc-wallet = "9473052e88048f58e8c4e1eba0ff88ef6a4cdd59";
-    fuel-core = "49e4305fea691bbf293c606334e7b282a54393b3";
-    fuel-indexer = "c2425c8b63f01ef1b540ff3e5832ebdc018b951d";
-    sway = "c32b0759d25c0b515cbf535f9fb9b8e6fda38ff2";
-  };
-
-  # Commits sourced from:
-  # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-3.toml
-  beta-3 = {
-    forc-explorer = "4bb7392eed085ee3a6795b98ea25392b3f41ade8";
-    forc-wallet = "c0a69f05e48031632b58e1b69eebb1ea19b6dd2d";
-    fuel-core = "843ed0b5008acbb7934ae92a1e9ae1368f2b5157";
-    fuel-indexer = "a72e66da03e530976c34e94c4b35ae588fac1d6d";
-    sway = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
-  };
-
   # Commits sourced from:
   # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-4.toml
   beta-4 = {


### PR DESCRIPTION
These toolchains are pretty much nonfunctional as there is no client endpoint anymore, and there’s no reason for anyone to use these.