### PR TITLE
Fix CI github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       - run: nix develop --print-build-logs --no-update-lock-file .#book-dev --command mdbook build book
 
   notify-slack-on-failure:
+    if: failure()
     needs:
       [
         nix-fmt-check,

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -72,17 +72,16 @@ jobs:
           path: manifests/
       - name: Check and commit changes
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
           git add manifests
           git commit -m "manifest: update"
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.REPO_TOKEN }}
           branch: master
 
   notify-slack-on-failure:
+    if: failure()
     needs:
       [
         refresh-and-upload-manifests,


### PR DESCRIPTION
Using the service user token instead of the actions-user so that we can have branch protections on master.

Also added `if: failure()` to the slack notify failure jobs, so that they will actually trigger if previous steps fail.