### PR TITLE
Add patch for rust 1.76

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,10 @@ jobs:
     steps:
       - uses: ravsamhq/notify-slack-action@v1
         with:
-          status: ${{ job.status }}
+          status: "failure"
           token: ${{ secrets.GITHUB_TOKEN }}
           notification_title: "{workflow} has {status_message}"
           message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
           footer: ""
-          notify_when: "failure"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_TOOLING }}    

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -94,11 +94,10 @@ jobs:
     steps:
       - uses: ravsamhq/notify-slack-action@v1
         with:
-          status: ${{ job.status }}
+          status: "failure"
           token: ${{ secrets.GITHUB_TOKEN }}
           notification_title: "{workflow} has {status_message}"
           message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
           footer: ""
-          notify_when: "failure"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_TOOLING }}    

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701253981,
-        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "lastModified": 1710272261,
+        "narHash": "sha256-g0bDwXFmTE7uGDOs9HcJsfLFhH7fOsASbAuOzDC+fhQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "rev": "0ad13a6833440b8e238947e47bea7f11071dc2b2",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701483183,
-        "narHash": "sha256-MDH3oUajqTaYClCiq1QK7jWVMtMFDJWxVBCFAnkt6J4=",
+        "lastModified": 1710382258,
+        "narHash": "sha256-2FW1q+o34VBweYQiEkRaSEkNMq3ecrn83VzETeGiVbY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47fe4578cb64a365f400e682a70e054657c42fa5",
+        "rev": "8ce81e71ab04a7e906fae62da086d6ee5d6cfc21",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     "sway-vim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1676340483,
-        "narHash": "sha256-WjnR5oOVs9drlMiYgR0HdGm+HkGcuF1z/LPQATVGxYs=",
+        "lastModified": 1709240346,
+        "narHash": "sha256-vP1Wlq0IPEwEMDQivQiy6w6ja2u2sjLqn8WgDJTbzPU=",
         "owner": "fuellabs",
         "repo": "sway.vim",
-        "rev": "93aed5a89124806a01c91d8ab4b55aed13cbddb0",
+        "rev": "07dc8e73a573dd84661d2af4729a36140a183710",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {

--- a/manifests/forc-0.49.3-nightly-2024-03-09.nix
+++ b/manifests/forc-0.49.3-nightly-2024-03-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.3";
+  date = "2024-03-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "13731d98b364f53c29b3bb1463c3895cae605868";
+  sha256 = "sha256-WJXFxBs0/4yN6WnSX8nB3r08iKRMvKVbFP0d5vC4YAo=";
+}

--- a/manifests/forc-0.49.3-nightly-2024-03-11.nix
+++ b/manifests/forc-0.49.3-nightly-2024-03-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.3";
+  date = "2024-03-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "421caefe6c8241b75488f8e515ec41544a35d888";
+  sha256 = "sha256-VZdxELeKuNl9A1ip7sQWKVhu6eorxTwXoX3fuZN2gVQ=";
+}

--- a/manifests/forc-0.49.3-nightly-2024-03-12.nix
+++ b/manifests/forc-0.49.3-nightly-2024-03-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.3";
+  date = "2024-03-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "92c90d00b1a29b08e2e9a47676012a025d48728f";
+  sha256 = "sha256-HwwECtHE2tTpnRR7AQuR2l37WOtyt2oyRAcyeOKaD44=";
+}

--- a/manifests/forc-0.49.3-nightly-2024-03-13.nix
+++ b/manifests/forc-0.49.3-nightly-2024-03-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.3";
+  date = "2024-03-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "441413aee6825f2f123307fb2ddfc50e01a73277";
+  sha256 = "sha256-wf3NY0679d++uxqiOYnIjN10fG6b9vgMvHJiIOp++Qw=";
+}

--- a/manifests/forc-0.49.3-nightly-2024-03-14.nix
+++ b/manifests/forc-0.49.3-nightly-2024-03-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.3";
+  date = "2024-03-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f3309dabc3b77cdb3431189f72177253f4dd1ef0";
+  sha256 = "sha256-blF28sYwa0JeMqFh6EsWpdNMYMCnLkWrC24tcc7GnXM=";
+}

--- a/manifests/forc-0.49.3.nix
+++ b/manifests/forc-0.49.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.49.3";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0dc6570377ee9c4a6359ade597fa27351e02a728";
+  sha256 = "sha256-wqNERqRNtL0OfQPoJqLDFBB8bMiyA1TIAkTpsdPqrAQ=";
+}

--- a/manifests/forc-0.51.1-nightly-2024-03-07.nix
+++ b/manifests/forc-0.51.1-nightly-2024-03-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.51.1";
+  date = "2024-03-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c1c25014f9913a0031d8fcdd2c893008f3a5b821";
+  sha256 = "sha256-5a/d4pnHK2TQjsvfw5L4762fX+6lR4/g0f61Zh8a3qc=";
+}

--- a/manifests/forc-0.51.1-nightly-2024-03-08.nix
+++ b/manifests/forc-0.51.1-nightly-2024-03-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.51.1";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0b80628f6af72462d3e288743fb3adc80434738";
+  sha256 = "sha256-W5ooJnAT7k+ZomsMfvrxezAZXTrPqidvuYeGV31fy80=";
+}

--- a/manifests/forc-client-0.49.3-nightly-2024-03-09.nix
+++ b/manifests/forc-client-0.49.3-nightly-2024-03-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.3";
+  date = "2024-03-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "13731d98b364f53c29b3bb1463c3895cae605868";
+  sha256 = "sha256-WJXFxBs0/4yN6WnSX8nB3r08iKRMvKVbFP0d5vC4YAo=";
+}

--- a/manifests/forc-client-0.49.3-nightly-2024-03-11.nix
+++ b/manifests/forc-client-0.49.3-nightly-2024-03-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.3";
+  date = "2024-03-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "421caefe6c8241b75488f8e515ec41544a35d888";
+  sha256 = "sha256-VZdxELeKuNl9A1ip7sQWKVhu6eorxTwXoX3fuZN2gVQ=";
+}

--- a/manifests/forc-client-0.49.3-nightly-2024-03-12.nix
+++ b/manifests/forc-client-0.49.3-nightly-2024-03-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.3";
+  date = "2024-03-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "92c90d00b1a29b08e2e9a47676012a025d48728f";
+  sha256 = "sha256-HwwECtHE2tTpnRR7AQuR2l37WOtyt2oyRAcyeOKaD44=";
+}

--- a/manifests/forc-client-0.49.3-nightly-2024-03-13.nix
+++ b/manifests/forc-client-0.49.3-nightly-2024-03-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.3";
+  date = "2024-03-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "441413aee6825f2f123307fb2ddfc50e01a73277";
+  sha256 = "sha256-wf3NY0679d++uxqiOYnIjN10fG6b9vgMvHJiIOp++Qw=";
+}

--- a/manifests/forc-client-0.49.3-nightly-2024-03-14.nix
+++ b/manifests/forc-client-0.49.3-nightly-2024-03-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.3";
+  date = "2024-03-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f3309dabc3b77cdb3431189f72177253f4dd1ef0";
+  sha256 = "sha256-blF28sYwa0JeMqFh6EsWpdNMYMCnLkWrC24tcc7GnXM=";
+}

--- a/manifests/forc-client-0.49.3.nix
+++ b/manifests/forc-client-0.49.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.49.3";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0dc6570377ee9c4a6359ade597fa27351e02a728";
+  sha256 = "sha256-wqNERqRNtL0OfQPoJqLDFBB8bMiyA1TIAkTpsdPqrAQ=";
+}

--- a/manifests/forc-client-0.51.1-nightly-2024-03-07.nix
+++ b/manifests/forc-client-0.51.1-nightly-2024-03-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.51.1";
+  date = "2024-03-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c1c25014f9913a0031d8fcdd2c893008f3a5b821";
+  sha256 = "sha256-5a/d4pnHK2TQjsvfw5L4762fX+6lR4/g0f61Zh8a3qc=";
+}

--- a/manifests/forc-client-0.51.1-nightly-2024-03-08.nix
+++ b/manifests/forc-client-0.51.1-nightly-2024-03-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.51.1";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0b80628f6af72462d3e288743fb3adc80434738";
+  sha256 = "sha256-W5ooJnAT7k+ZomsMfvrxezAZXTrPqidvuYeGV31fy80=";
+}

--- a/manifests/forc-doc-0.49.3-nightly-2024-03-09.nix
+++ b/manifests/forc-doc-0.49.3-nightly-2024-03-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.3";
+  date = "2024-03-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "13731d98b364f53c29b3bb1463c3895cae605868";
+  sha256 = "sha256-WJXFxBs0/4yN6WnSX8nB3r08iKRMvKVbFP0d5vC4YAo=";
+}

--- a/manifests/forc-doc-0.49.3-nightly-2024-03-11.nix
+++ b/manifests/forc-doc-0.49.3-nightly-2024-03-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.3";
+  date = "2024-03-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "421caefe6c8241b75488f8e515ec41544a35d888";
+  sha256 = "sha256-VZdxELeKuNl9A1ip7sQWKVhu6eorxTwXoX3fuZN2gVQ=";
+}

--- a/manifests/forc-doc-0.49.3-nightly-2024-03-12.nix
+++ b/manifests/forc-doc-0.49.3-nightly-2024-03-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.3";
+  date = "2024-03-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "92c90d00b1a29b08e2e9a47676012a025d48728f";
+  sha256 = "sha256-HwwECtHE2tTpnRR7AQuR2l37WOtyt2oyRAcyeOKaD44=";
+}

--- a/manifests/forc-doc-0.49.3-nightly-2024-03-13.nix
+++ b/manifests/forc-doc-0.49.3-nightly-2024-03-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.3";
+  date = "2024-03-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "441413aee6825f2f123307fb2ddfc50e01a73277";
+  sha256 = "sha256-wf3NY0679d++uxqiOYnIjN10fG6b9vgMvHJiIOp++Qw=";
+}

--- a/manifests/forc-doc-0.49.3-nightly-2024-03-14.nix
+++ b/manifests/forc-doc-0.49.3-nightly-2024-03-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.3";
+  date = "2024-03-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f3309dabc3b77cdb3431189f72177253f4dd1ef0";
+  sha256 = "sha256-blF28sYwa0JeMqFh6EsWpdNMYMCnLkWrC24tcc7GnXM=";
+}

--- a/manifests/forc-doc-0.49.3.nix
+++ b/manifests/forc-doc-0.49.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.49.3";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0dc6570377ee9c4a6359ade597fa27351e02a728";
+  sha256 = "sha256-wqNERqRNtL0OfQPoJqLDFBB8bMiyA1TIAkTpsdPqrAQ=";
+}

--- a/manifests/forc-doc-0.51.1-nightly-2024-03-07.nix
+++ b/manifests/forc-doc-0.51.1-nightly-2024-03-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.51.1";
+  date = "2024-03-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c1c25014f9913a0031d8fcdd2c893008f3a5b821";
+  sha256 = "sha256-5a/d4pnHK2TQjsvfw5L4762fX+6lR4/g0f61Zh8a3qc=";
+}

--- a/manifests/forc-doc-0.51.1-nightly-2024-03-08.nix
+++ b/manifests/forc-doc-0.51.1-nightly-2024-03-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.51.1";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0b80628f6af72462d3e288743fb3adc80434738";
+  sha256 = "sha256-W5ooJnAT7k+ZomsMfvrxezAZXTrPqidvuYeGV31fy80=";
+}

--- a/manifests/forc-fmt-0.49.3-nightly-2024-03-09.nix
+++ b/manifests/forc-fmt-0.49.3-nightly-2024-03-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.3";
+  date = "2024-03-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "13731d98b364f53c29b3bb1463c3895cae605868";
+  sha256 = "sha256-WJXFxBs0/4yN6WnSX8nB3r08iKRMvKVbFP0d5vC4YAo=";
+}

--- a/manifests/forc-fmt-0.49.3-nightly-2024-03-11.nix
+++ b/manifests/forc-fmt-0.49.3-nightly-2024-03-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.3";
+  date = "2024-03-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "421caefe6c8241b75488f8e515ec41544a35d888";
+  sha256 = "sha256-VZdxELeKuNl9A1ip7sQWKVhu6eorxTwXoX3fuZN2gVQ=";
+}

--- a/manifests/forc-fmt-0.49.3-nightly-2024-03-12.nix
+++ b/manifests/forc-fmt-0.49.3-nightly-2024-03-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.3";
+  date = "2024-03-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "92c90d00b1a29b08e2e9a47676012a025d48728f";
+  sha256 = "sha256-HwwECtHE2tTpnRR7AQuR2l37WOtyt2oyRAcyeOKaD44=";
+}

--- a/manifests/forc-fmt-0.49.3-nightly-2024-03-13.nix
+++ b/manifests/forc-fmt-0.49.3-nightly-2024-03-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.3";
+  date = "2024-03-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "441413aee6825f2f123307fb2ddfc50e01a73277";
+  sha256 = "sha256-wf3NY0679d++uxqiOYnIjN10fG6b9vgMvHJiIOp++Qw=";
+}

--- a/manifests/forc-fmt-0.49.3-nightly-2024-03-14.nix
+++ b/manifests/forc-fmt-0.49.3-nightly-2024-03-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.3";
+  date = "2024-03-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f3309dabc3b77cdb3431189f72177253f4dd1ef0";
+  sha256 = "sha256-blF28sYwa0JeMqFh6EsWpdNMYMCnLkWrC24tcc7GnXM=";
+}

--- a/manifests/forc-fmt-0.49.3.nix
+++ b/manifests/forc-fmt-0.49.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.49.3";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0dc6570377ee9c4a6359ade597fa27351e02a728";
+  sha256 = "sha256-wqNERqRNtL0OfQPoJqLDFBB8bMiyA1TIAkTpsdPqrAQ=";
+}

--- a/manifests/forc-fmt-0.51.1-nightly-2024-03-07.nix
+++ b/manifests/forc-fmt-0.51.1-nightly-2024-03-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.51.1";
+  date = "2024-03-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c1c25014f9913a0031d8fcdd2c893008f3a5b821";
+  sha256 = "sha256-5a/d4pnHK2TQjsvfw5L4762fX+6lR4/g0f61Zh8a3qc=";
+}

--- a/manifests/forc-fmt-0.51.1-nightly-2024-03-08.nix
+++ b/manifests/forc-fmt-0.51.1-nightly-2024-03-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.51.1";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0b80628f6af72462d3e288743fb3adc80434738";
+  sha256 = "sha256-W5ooJnAT7k+ZomsMfvrxezAZXTrPqidvuYeGV31fy80=";
+}

--- a/manifests/forc-lsp-0.49.3-nightly-2024-03-09.nix
+++ b/manifests/forc-lsp-0.49.3-nightly-2024-03-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.3";
+  date = "2024-03-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "13731d98b364f53c29b3bb1463c3895cae605868";
+  sha256 = "sha256-WJXFxBs0/4yN6WnSX8nB3r08iKRMvKVbFP0d5vC4YAo=";
+}

--- a/manifests/forc-lsp-0.49.3-nightly-2024-03-11.nix
+++ b/manifests/forc-lsp-0.49.3-nightly-2024-03-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.3";
+  date = "2024-03-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "421caefe6c8241b75488f8e515ec41544a35d888";
+  sha256 = "sha256-VZdxELeKuNl9A1ip7sQWKVhu6eorxTwXoX3fuZN2gVQ=";
+}

--- a/manifests/forc-lsp-0.49.3-nightly-2024-03-12.nix
+++ b/manifests/forc-lsp-0.49.3-nightly-2024-03-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.3";
+  date = "2024-03-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "92c90d00b1a29b08e2e9a47676012a025d48728f";
+  sha256 = "sha256-HwwECtHE2tTpnRR7AQuR2l37WOtyt2oyRAcyeOKaD44=";
+}

--- a/manifests/forc-lsp-0.49.3-nightly-2024-03-13.nix
+++ b/manifests/forc-lsp-0.49.3-nightly-2024-03-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.3";
+  date = "2024-03-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "441413aee6825f2f123307fb2ddfc50e01a73277";
+  sha256 = "sha256-wf3NY0679d++uxqiOYnIjN10fG6b9vgMvHJiIOp++Qw=";
+}

--- a/manifests/forc-lsp-0.49.3-nightly-2024-03-14.nix
+++ b/manifests/forc-lsp-0.49.3-nightly-2024-03-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.3";
+  date = "2024-03-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f3309dabc3b77cdb3431189f72177253f4dd1ef0";
+  sha256 = "sha256-blF28sYwa0JeMqFh6EsWpdNMYMCnLkWrC24tcc7GnXM=";
+}

--- a/manifests/forc-lsp-0.49.3.nix
+++ b/manifests/forc-lsp-0.49.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.49.3";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0dc6570377ee9c4a6359ade597fa27351e02a728";
+  sha256 = "sha256-wqNERqRNtL0OfQPoJqLDFBB8bMiyA1TIAkTpsdPqrAQ=";
+}

--- a/manifests/forc-lsp-0.51.1-nightly-2024-03-07.nix
+++ b/manifests/forc-lsp-0.51.1-nightly-2024-03-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.51.1";
+  date = "2024-03-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c1c25014f9913a0031d8fcdd2c893008f3a5b821";
+  sha256 = "sha256-5a/d4pnHK2TQjsvfw5L4762fX+6lR4/g0f61Zh8a3qc=";
+}

--- a/manifests/forc-lsp-0.51.1-nightly-2024-03-08.nix
+++ b/manifests/forc-lsp-0.51.1-nightly-2024-03-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.51.1";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0b80628f6af72462d3e288743fb3adc80434738";
+  sha256 = "sha256-W5ooJnAT7k+ZomsMfvrxezAZXTrPqidvuYeGV31fy80=";
+}

--- a/manifests/forc-tx-0.49.3-nightly-2024-03-09.nix
+++ b/manifests/forc-tx-0.49.3-nightly-2024-03-09.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.3";
+  date = "2024-03-09";
+  url = "https://github.com/fuellabs/sway";
+  rev = "13731d98b364f53c29b3bb1463c3895cae605868";
+  sha256 = "sha256-WJXFxBs0/4yN6WnSX8nB3r08iKRMvKVbFP0d5vC4YAo=";
+}

--- a/manifests/forc-tx-0.49.3-nightly-2024-03-11.nix
+++ b/manifests/forc-tx-0.49.3-nightly-2024-03-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.3";
+  date = "2024-03-11";
+  url = "https://github.com/fuellabs/sway";
+  rev = "421caefe6c8241b75488f8e515ec41544a35d888";
+  sha256 = "sha256-VZdxELeKuNl9A1ip7sQWKVhu6eorxTwXoX3fuZN2gVQ=";
+}

--- a/manifests/forc-tx-0.49.3-nightly-2024-03-12.nix
+++ b/manifests/forc-tx-0.49.3-nightly-2024-03-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.3";
+  date = "2024-03-12";
+  url = "https://github.com/fuellabs/sway";
+  rev = "92c90d00b1a29b08e2e9a47676012a025d48728f";
+  sha256 = "sha256-HwwECtHE2tTpnRR7AQuR2l37WOtyt2oyRAcyeOKaD44=";
+}

--- a/manifests/forc-tx-0.49.3-nightly-2024-03-13.nix
+++ b/manifests/forc-tx-0.49.3-nightly-2024-03-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.3";
+  date = "2024-03-13";
+  url = "https://github.com/fuellabs/sway";
+  rev = "441413aee6825f2f123307fb2ddfc50e01a73277";
+  sha256 = "sha256-wf3NY0679d++uxqiOYnIjN10fG6b9vgMvHJiIOp++Qw=";
+}

--- a/manifests/forc-tx-0.49.3-nightly-2024-03-14.nix
+++ b/manifests/forc-tx-0.49.3-nightly-2024-03-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.3";
+  date = "2024-03-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "f3309dabc3b77cdb3431189f72177253f4dd1ef0";
+  sha256 = "sha256-blF28sYwa0JeMqFh6EsWpdNMYMCnLkWrC24tcc7GnXM=";
+}

--- a/manifests/forc-tx-0.49.3.nix
+++ b/manifests/forc-tx-0.49.3.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.49.3";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "0dc6570377ee9c4a6359ade597fa27351e02a728";
+  sha256 = "sha256-wqNERqRNtL0OfQPoJqLDFBB8bMiyA1TIAkTpsdPqrAQ=";
+}

--- a/manifests/forc-tx-0.51.1-nightly-2024-03-07.nix
+++ b/manifests/forc-tx-0.51.1-nightly-2024-03-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.51.1";
+  date = "2024-03-07";
+  url = "https://github.com/fuellabs/sway";
+  rev = "c1c25014f9913a0031d8fcdd2c893008f3a5b821";
+  sha256 = "sha256-5a/d4pnHK2TQjsvfw5L4762fX+6lR4/g0f61Zh8a3qc=";
+}

--- a/manifests/forc-tx-0.51.1-nightly-2024-03-08.nix
+++ b/manifests/forc-tx-0.51.1-nightly-2024-03-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.51.1";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/sway";
+  rev = "a0b80628f6af72462d3e288743fb3adc80434738";
+  sha256 = "sha256-W5ooJnAT7k+ZomsMfvrxezAZXTrPqidvuYeGV31fy80=";
+}

--- a/manifests/fuel-core-0.22.3-nightly-2024-03-07.nix
+++ b/manifests/fuel-core-0.22.3-nightly-2024-03-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.3";
+  date = "2024-03-07";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a7eec76fecfee07815d7758e1635ad263266c7bd";
+  sha256 = "sha256-gCIsAYma10RQ55fuIqEv8y9KjIVcJmhO8Y0LS82hMYA=";
+}

--- a/manifests/fuel-core-0.22.3-nightly-2024-03-08.nix
+++ b/manifests/fuel-core-0.22.3-nightly-2024-03-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.3";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "41108896685b7f0c4d67ada0cf21670ebda4631e";
+  sha256 = "sha256-XpdM04SQwDi0WxxPO2zkKlTIqsToFRlZ7N3TbXPBSaI=";
+}

--- a/manifests/fuel-core-0.22.4-nightly-2024-03-12.nix
+++ b/manifests/fuel-core-0.22.4-nightly-2024-03-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.4";
+  date = "2024-03-12";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2c57fbbefa4d6c560b528942a8e2ae109771162f";
+  sha256 = "sha256-gae/H5bZJAtJrfss3v7oYJOD1SvKUfVps3RB2i9i4is=";
+}

--- a/manifests/fuel-core-0.22.4-nightly-2024-03-14.nix
+++ b/manifests/fuel-core-0.22.4-nightly-2024-03-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.4";
+  date = "2024-03-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "ce72eeaf5c9490f87aa3a39ae7f92087908e7d79";
+  sha256 = "sha256-naOdpZq/3CLpg65ZWqdIp1LssCVng614iA9x25QKBK8=";
+}

--- a/manifests/fuel-core-0.22.4.nix
+++ b/manifests/fuel-core-0.22.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.4";
+  date = "2024-03-09";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a31f64be154dedeb4dbd5e5f3dbeb0adf59ef297";
+  sha256 = "sha256-TpRY2rssZjTlAgRi4TC1iCIAkIwZ63eXtbBgLZ8JdCw=";
+}

--- a/manifests/fuel-core-client-0.22.3-nightly-2024-03-07.nix
+++ b/manifests/fuel-core-client-0.22.3-nightly-2024-03-07.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.3";
+  date = "2024-03-07";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a7eec76fecfee07815d7758e1635ad263266c7bd";
+  sha256 = "sha256-gCIsAYma10RQ55fuIqEv8y9KjIVcJmhO8Y0LS82hMYA=";
+}

--- a/manifests/fuel-core-client-0.22.3-nightly-2024-03-08.nix
+++ b/manifests/fuel-core-client-0.22.3-nightly-2024-03-08.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.3";
+  date = "2024-03-08";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "41108896685b7f0c4d67ada0cf21670ebda4631e";
+  sha256 = "sha256-XpdM04SQwDi0WxxPO2zkKlTIqsToFRlZ7N3TbXPBSaI=";
+}

--- a/manifests/fuel-core-client-0.22.4-nightly-2024-03-12.nix
+++ b/manifests/fuel-core-client-0.22.4-nightly-2024-03-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.4";
+  date = "2024-03-12";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2c57fbbefa4d6c560b528942a8e2ae109771162f";
+  sha256 = "sha256-gae/H5bZJAtJrfss3v7oYJOD1SvKUfVps3RB2i9i4is=";
+}

--- a/manifests/fuel-core-client-0.22.4-nightly-2024-03-14.nix
+++ b/manifests/fuel-core-client-0.22.4-nightly-2024-03-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.4";
+  date = "2024-03-14";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "ce72eeaf5c9490f87aa3a39ae7f92087908e7d79";
+  sha256 = "sha256-naOdpZq/3CLpg65ZWqdIp1LssCVng614iA9x25QKBK8=";
+}

--- a/manifests/fuel-core-client-0.22.4.nix
+++ b/manifests/fuel-core-client-0.22.4.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.4";
+  date = "2024-03-09";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "a31f64be154dedeb4dbd5e5f3dbeb0adf59ef297";
+  sha256 = "sha256-TpRY2rssZjTlAgRi4TC1iCIAkIwZ63eXtbBgLZ8JdCw=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -336,4 +336,13 @@ in [
       rust = pkgs.rust-bin.stable."1.74.0".default;
     };
   }
+
+  # `sway-core` requires Rust 1.76 as of
+  # c18797fd04f210d6f2f25415536685e63cbd1cc5 due to use of `std::hash::DefaultHasher`.
+  {
+    condition = m: m.date >= "2024-03-11";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.76.0".default;
+    };
+  }
 ]


### PR DESCRIPTION
[Ci is failing](https://github.com/FuelLabs/fuel.nix/actions/runs/8272645797/job/22636245858) on the older rust version.

This should pass: https://github.com/FuelLabs/fuel.nix/actions/runs/8285934094