### PR TITLE
use buildjet-4vcpu-ubuntu-2204 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [fuel, fuel-beta-4, fuel-beta-5, fuel-nightly]
-        os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
+        os: [buildjet-4vcpu-ubuntu-2204, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The download-manifests-and-nix-build action has been [failing](https://github.com/FuelLabs/fuel.nix/actions/runs/8311430669/job/22745959329#logs) with running out of memory using ubuntu-latest. This switches to using to buildjet-4vcpu-ubuntu-2204.