### PR TITLE
Fix CI Failure on No Changes to Commit

### DIFF
--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -75,7 +75,13 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add manifests
-          git commit -m "manifest: update"
+          # Check if there are any changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          else
+            git commit -m "manifest: update"
+          fi
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
This PR addresses the CI job failure when there are no changes to commit by checking for changes before attempting a commit. This change ensures the job exits gracefully in such cases, preventing unnecessary failures.

You can see what was previously happening in this situation [here](https://github.com/FuelLabs/fuel.nix/actions/runs/8413088073) 