### PR TITLE
fix: add wasm32 target for fuel-core after 2024-04-13

### DIFF
--- a/patches.nix
+++ b/patches.nix
@@ -350,9 +350,9 @@ in [
   {
     condition = m: m.date >= "2024-04-13";
     patch = m: {
-      rust = (pkgs.rust-bin.stable."1.76.0".default.override {
-        targets = [ "wasm32-unknown-unknown" ];
-      });
+      rust = pkgs.rust-bin.stable."1.76.0".default.override {
+        targets = ["wasm32-unknown-unknown"];
+      };
     };
   }
 ]

--- a/patches.nix
+++ b/patches.nix
@@ -345,4 +345,14 @@ in [
       rust = pkgs.rust-bin.stable."1.76.0".default;
     };
   }
+
+  # `fuel-core-client` requires wasm32-unknown-unknown target to be added as of ~2024-04-01.
+  {
+    condition = m: m.date >= "2024-04-13";
+    patch = m: {
+      rust = (pkgs.rust-bin.stable."1.76.0".default.override {
+        targets = [ "wasm32-unknown-unknown" ];
+      });
+    };
+  }
 ]


### PR DESCRIPTION
fuel-core requires wasm32 rust toolchain and our CI was blocked because of this requirement. This PR adds wasm32 target after 2024-04-13