### PR TITLE
chore: Refresh manifests after wasm patch

### DIFF
--- a/manifests/forc-0.54.0-nightly-2024-04-14.nix
+++ b/manifests/forc-0.54.0-nightly-2024-04-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.54.0";
+  date = "2024-04-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d90cbc8419e47283519e39046c3ea5616e64df84";
+  sha256 = "sha256-bI5+vL8dVpAuRMcrznrYhnMUPpax6Q0iC/w7sps3ims=";
+}

--- a/manifests/forc-0.54.0-nightly-2024-04-16.nix
+++ b/manifests/forc-0.54.0-nightly-2024-04-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.54.0";
+  date = "2024-04-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ebd832f4868f393c66e98f16430fff457e19b7bf";
+  sha256 = "sha256-Ij92/XOTQz/NKtBmPSYujy9bFUI0CF6cZbwdDPHzvu4=";
+}

--- a/manifests/forc-0.54.0-nightly-2024-04-17.nix
+++ b/manifests/forc-0.54.0-nightly-2024-04-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.54.0";
+  date = "2024-04-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fbb5c7a71325cac0388a0860bb9ca64acd5f277d";
+  sha256 = "sha256-S8Rxufj+yvHRHIDZH+AljyHntni28SlA0PXTDaCGNbo=";
+}

--- a/manifests/forc-client-0.54.0-nightly-2024-04-14.nix
+++ b/manifests/forc-client-0.54.0-nightly-2024-04-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.54.0";
+  date = "2024-04-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d90cbc8419e47283519e39046c3ea5616e64df84";
+  sha256 = "sha256-bI5+vL8dVpAuRMcrznrYhnMUPpax6Q0iC/w7sps3ims=";
+}

--- a/manifests/forc-client-0.54.0-nightly-2024-04-16.nix
+++ b/manifests/forc-client-0.54.0-nightly-2024-04-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.54.0";
+  date = "2024-04-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ebd832f4868f393c66e98f16430fff457e19b7bf";
+  sha256 = "sha256-Ij92/XOTQz/NKtBmPSYujy9bFUI0CF6cZbwdDPHzvu4=";
+}

--- a/manifests/forc-client-0.54.0-nightly-2024-04-17.nix
+++ b/manifests/forc-client-0.54.0-nightly-2024-04-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.54.0";
+  date = "2024-04-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fbb5c7a71325cac0388a0860bb9ca64acd5f277d";
+  sha256 = "sha256-S8Rxufj+yvHRHIDZH+AljyHntni28SlA0PXTDaCGNbo=";
+}

--- a/manifests/forc-doc-0.54.0-nightly-2024-04-14.nix
+++ b/manifests/forc-doc-0.54.0-nightly-2024-04-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.54.0";
+  date = "2024-04-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d90cbc8419e47283519e39046c3ea5616e64df84";
+  sha256 = "sha256-bI5+vL8dVpAuRMcrznrYhnMUPpax6Q0iC/w7sps3ims=";
+}

--- a/manifests/forc-doc-0.54.0-nightly-2024-04-16.nix
+++ b/manifests/forc-doc-0.54.0-nightly-2024-04-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.54.0";
+  date = "2024-04-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ebd832f4868f393c66e98f16430fff457e19b7bf";
+  sha256 = "sha256-Ij92/XOTQz/NKtBmPSYujy9bFUI0CF6cZbwdDPHzvu4=";
+}

--- a/manifests/forc-doc-0.54.0-nightly-2024-04-17.nix
+++ b/manifests/forc-doc-0.54.0-nightly-2024-04-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.54.0";
+  date = "2024-04-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fbb5c7a71325cac0388a0860bb9ca64acd5f277d";
+  sha256 = "sha256-S8Rxufj+yvHRHIDZH+AljyHntni28SlA0PXTDaCGNbo=";
+}

--- a/manifests/forc-fmt-0.54.0-nightly-2024-04-14.nix
+++ b/manifests/forc-fmt-0.54.0-nightly-2024-04-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.54.0";
+  date = "2024-04-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d90cbc8419e47283519e39046c3ea5616e64df84";
+  sha256 = "sha256-bI5+vL8dVpAuRMcrznrYhnMUPpax6Q0iC/w7sps3ims=";
+}

--- a/manifests/forc-fmt-0.54.0-nightly-2024-04-16.nix
+++ b/manifests/forc-fmt-0.54.0-nightly-2024-04-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.54.0";
+  date = "2024-04-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ebd832f4868f393c66e98f16430fff457e19b7bf";
+  sha256 = "sha256-Ij92/XOTQz/NKtBmPSYujy9bFUI0CF6cZbwdDPHzvu4=";
+}

--- a/manifests/forc-fmt-0.54.0-nightly-2024-04-17.nix
+++ b/manifests/forc-fmt-0.54.0-nightly-2024-04-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.54.0";
+  date = "2024-04-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fbb5c7a71325cac0388a0860bb9ca64acd5f277d";
+  sha256 = "sha256-S8Rxufj+yvHRHIDZH+AljyHntni28SlA0PXTDaCGNbo=";
+}

--- a/manifests/forc-lsp-0.54.0-nightly-2024-04-14.nix
+++ b/manifests/forc-lsp-0.54.0-nightly-2024-04-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.54.0";
+  date = "2024-04-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d90cbc8419e47283519e39046c3ea5616e64df84";
+  sha256 = "sha256-bI5+vL8dVpAuRMcrznrYhnMUPpax6Q0iC/w7sps3ims=";
+}

--- a/manifests/forc-lsp-0.54.0-nightly-2024-04-16.nix
+++ b/manifests/forc-lsp-0.54.0-nightly-2024-04-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.54.0";
+  date = "2024-04-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ebd832f4868f393c66e98f16430fff457e19b7bf";
+  sha256 = "sha256-Ij92/XOTQz/NKtBmPSYujy9bFUI0CF6cZbwdDPHzvu4=";
+}

--- a/manifests/forc-lsp-0.54.0-nightly-2024-04-17.nix
+++ b/manifests/forc-lsp-0.54.0-nightly-2024-04-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.54.0";
+  date = "2024-04-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fbb5c7a71325cac0388a0860bb9ca64acd5f277d";
+  sha256 = "sha256-S8Rxufj+yvHRHIDZH+AljyHntni28SlA0PXTDaCGNbo=";
+}

--- a/manifests/forc-tx-0.54.0-nightly-2024-04-14.nix
+++ b/manifests/forc-tx-0.54.0-nightly-2024-04-14.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.54.0";
+  date = "2024-04-14";
+  url = "https://github.com/fuellabs/sway";
+  rev = "d90cbc8419e47283519e39046c3ea5616e64df84";
+  sha256 = "sha256-bI5+vL8dVpAuRMcrznrYhnMUPpax6Q0iC/w7sps3ims=";
+}

--- a/manifests/forc-tx-0.54.0-nightly-2024-04-16.nix
+++ b/manifests/forc-tx-0.54.0-nightly-2024-04-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.54.0";
+  date = "2024-04-16";
+  url = "https://github.com/fuellabs/sway";
+  rev = "ebd832f4868f393c66e98f16430fff457e19b7bf";
+  sha256 = "sha256-Ij92/XOTQz/NKtBmPSYujy9bFUI0CF6cZbwdDPHzvu4=";
+}

--- a/manifests/forc-tx-0.54.0-nightly-2024-04-17.nix
+++ b/manifests/forc-tx-0.54.0-nightly-2024-04-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.54.0";
+  date = "2024-04-17";
+  url = "https://github.com/fuellabs/sway";
+  rev = "fbb5c7a71325cac0388a0860bb9ca64acd5f277d";
+  sha256 = "sha256-S8Rxufj+yvHRHIDZH+AljyHntni28SlA0PXTDaCGNbo=";
+}

--- a/manifests/fuel-core-0.24.2-nightly-2024-04-16.nix
+++ b/manifests/fuel-core-0.24.2-nightly-2024-04-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.24.2";
+  date = "2024-04-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "030c67f6cc4ef042ca7bf0ea03ecd3648e56b91a";
+  sha256 = "sha256-RfB3UvhnEsNXWHnG1YzxS0NvYXrGABr9rA24on+jdxs=";
+}

--- a/manifests/fuel-core-0.24.2-nightly-2024-04-17.nix
+++ b/manifests/fuel-core-0.24.2-nightly-2024-04-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.24.2";
+  date = "2024-04-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "df417f7dacfb1765b1da7d66bc4ea4492482ed4d";
+  sha256 = "sha256-eF2M08E4marP1q7eupCGA5ldnyACKAiQAROSpLPZ7wQ=";
+}

--- a/manifests/fuel-core-client-0.24.2-nightly-2024-04-16.nix
+++ b/manifests/fuel-core-client-0.24.2-nightly-2024-04-16.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.24.2";
+  date = "2024-04-16";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "030c67f6cc4ef042ca7bf0ea03ecd3648e56b91a";
+  sha256 = "sha256-RfB3UvhnEsNXWHnG1YzxS0NvYXrGABr9rA24on+jdxs=";
+}

--- a/manifests/fuel-core-client-0.24.2-nightly-2024-04-17.nix
+++ b/manifests/fuel-core-client-0.24.2-nightly-2024-04-17.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.24.2";
+  date = "2024-04-17";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "df417f7dacfb1765b1da7d66bc4ea4492482ed4d";
+  sha256 = "sha256-eF2M08E4marP1q7eupCGA5ldnyACKAiQAROSpLPZ7wQ=";
+}


### PR DESCRIPTION
Follow up to https://github.com/FuelLabs/fuel.nix/pull/133