### PR TITLE
add missing packages to forc-plugins list

### DIFF
--- a/patches.nix
+++ b/patches.nix
@@ -4,6 +4,8 @@
 {pkgs}: let
   forc-plugins = [
     "forc-client"
+    "forc-crypto"
+    "forc-debug"
     "forc-doc"
     "forc-fmt"
     "forc-lsp"


### PR DESCRIPTION
`forc-crypto` & `forc-debug` were added in #138 but the refresh manifests are [failing](https://github.com/FuelLabs/fuel.nix/actions/runs/9727826909/job/26848946788)

I think this is because I forgot to add them to the patches.nix file in the forc-plugins list. Hopefully this is all that's needed but we'll see once this is merged and the refresh manifests job is run again.   