### PR TITLE
chore: patch rust v1.79.0

### DIFF
--- a/manifests/forc-wallet-0.8.2-nightly-2024-07-11.nix
+++ b/manifests/forc-wallet-0.8.2-nightly-2024-07-11.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.8.2";
+  date = "2024-07-11";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "76e9796cbee4426312e8e840d022cd695ca64fab";
+  sha256 = "sha256-ais2tFxNIRsY0fELoxnBAF+Xf1FuG8BlGY9Hhv9P3/o=";
+}

--- a/manifests/forc-wallet-0.8.2-nightly-2024-08-13.nix
+++ b/manifests/forc-wallet-0.8.2-nightly-2024-08-13.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.8.2";
+  date = "2024-08-13";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "29d9b25c2ce7a273618945d561148e3034e47441";
+  sha256 = "sha256-gsC0a2NAMbgKQ2hV7Zn+6K+lFKHgOwaYu0udFxQ4uiE=";
+}

--- a/manifests/forc-wallet-0.9.0.nix
+++ b/manifests/forc-wallet-0.9.0.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.9.0";
+  date = "2024-08-12";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "29d9b25c2ce7a273618945d561148e3034e47441";
+  sha256 = "sha256-gsC0a2NAMbgKQ2hV7Zn+6K+lFKHgOwaYu0udFxQ4uiE=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -331,7 +331,9 @@ in [
   {
     condition = m: m.date >= "2024-08-08";
     patch = m: {
-      rust = pkgs.rust-bin.stable."1.79.0".default;
+      rust = pkgs.rust-bin.stable."1.79.0".default.override {
+        targets = ["wasm32-unknown-unknown"];
+      };
     };
   }
 ]

--- a/patches.nix
+++ b/patches.nix
@@ -326,4 +326,12 @@ in [
       };
     };
   }
+
+  # `fuels-rs` requires Rust 1.79 as of v0.66.0 due to use of `path::absolute`.
+  {
+    condition = m: m.date >= "2024-08-08";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.79.0".default;
+    };
+  }
 ]


### PR DESCRIPTION
https://github.com/FuelLabs/fuel.nix/actions/runs/10361272047/job/28683384240

```
forc-wallet> error: package `fuels v0.66.0` cannot be built because it requires rustc 1.79.0 or newer, while the currently active rustc version is 1.76.0
```