### PR TITLE
ci: Run nix flake update

### DIFF
--- a/.github/workflows/patch-pr.yml
+++ b/.github/workflows/patch-pr.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix flake update
       - run: nix run .#refresh-manifests
         timeout-minutes: 120
       - name: validate changed nix files
@@ -42,7 +43,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add manifests
+          git add manifests flake.lock
           # Check if there are any changes to commit
           if git diff --staged --quiet; then
             echo "No changes to commit."

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710272261,
-        "narHash": "sha256-g0bDwXFmTE7uGDOs9HcJsfLFhH7fOsASbAuOzDC+fhQ=",
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ad13a6833440b8e238947e47bea7f11071dc2b2",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
         "type": "github"
       },
       "original": {
@@ -44,17 +26,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1710382258,
-        "narHash": "sha256-2FW1q+o34VBweYQiEkRaSEkNMq3ecrn83VzETeGiVbY=",
+        "lastModified": 1723688259,
+        "narHash": "sha256-WzeUR1MG9MnJnh9T7qcVe/v12qHvJvzdc3Z5HCeE2ns=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8ce81e71ab04a7e906fae62da086d6ee5d6cfc21",
+        "rev": "6e75319846684326d900daff1e2e11338cc80d2b",
         "type": "github"
       },
       "original": {
@@ -95,24 +76,9 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1710146030,

--- a/manifests/forc-0.62.0-nightly-2024-08-15.nix
+++ b/manifests/forc-0.62.0-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.62.0";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4c2c38430264472221dd4c68142013d819843b01";
+  sha256 = "sha256-c8VQPQ+G7+SwTLXdfV0zHAXSOaIfs8PjV6wNpw/IC/o=";
+}

--- a/manifests/forc-client-0.62.0-nightly-2024-08-15.nix
+++ b/manifests/forc-client-0.62.0-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.62.0";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4c2c38430264472221dd4c68142013d819843b01";
+  sha256 = "sha256-c8VQPQ+G7+SwTLXdfV0zHAXSOaIfs8PjV6wNpw/IC/o=";
+}

--- a/manifests/forc-crypto-0.62.0-nightly-2024-08-15.nix
+++ b/manifests/forc-crypto-0.62.0-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-crypto";
+  version = "0.62.0";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4c2c38430264472221dd4c68142013d819843b01";
+  sha256 = "sha256-c8VQPQ+G7+SwTLXdfV0zHAXSOaIfs8PjV6wNpw/IC/o=";
+}

--- a/manifests/forc-debug-0.62.0-nightly-2024-08-15.nix
+++ b/manifests/forc-debug-0.62.0-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-debug";
+  version = "0.62.0";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4c2c38430264472221dd4c68142013d819843b01";
+  sha256 = "sha256-c8VQPQ+G7+SwTLXdfV0zHAXSOaIfs8PjV6wNpw/IC/o=";
+}

--- a/manifests/forc-doc-0.62.0-nightly-2024-08-15.nix
+++ b/manifests/forc-doc-0.62.0-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.62.0";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4c2c38430264472221dd4c68142013d819843b01";
+  sha256 = "sha256-c8VQPQ+G7+SwTLXdfV0zHAXSOaIfs8PjV6wNpw/IC/o=";
+}

--- a/manifests/forc-fmt-0.62.0-nightly-2024-08-15.nix
+++ b/manifests/forc-fmt-0.62.0-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.62.0";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4c2c38430264472221dd4c68142013d819843b01";
+  sha256 = "sha256-c8VQPQ+G7+SwTLXdfV0zHAXSOaIfs8PjV6wNpw/IC/o=";
+}

--- a/manifests/forc-lsp-0.62.0-nightly-2024-08-15.nix
+++ b/manifests/forc-lsp-0.62.0-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.62.0";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4c2c38430264472221dd4c68142013d819843b01";
+  sha256 = "sha256-c8VQPQ+G7+SwTLXdfV0zHAXSOaIfs8PjV6wNpw/IC/o=";
+}

--- a/manifests/forc-tx-0.62.0-nightly-2024-08-15.nix
+++ b/manifests/forc-tx-0.62.0-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.62.0";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/sway";
+  rev = "4c2c38430264472221dd4c68142013d819843b01";
+  sha256 = "sha256-c8VQPQ+G7+SwTLXdfV0zHAXSOaIfs8PjV6wNpw/IC/o=";
+}

--- a/manifests/fuel-core-0.32.1-nightly-2024-08-15.nix
+++ b/manifests/fuel-core-0.32.1-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.32.1";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e32f1f0b2d437eb0b10cb64aa6eb964b11a5ca56";
+  sha256 = "sha256-iVljKMAQWsGJjxbhFmEnLoYf1XD9I5csXW8QgiUKyN8=";
+}

--- a/manifests/fuel-core-client-0.32.1-nightly-2024-08-15.nix
+++ b/manifests/fuel-core-client-0.32.1-nightly-2024-08-15.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.32.1";
+  date = "2024-08-15";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e32f1f0b2d437eb0b10cb64aa6eb964b11a5ca56";
+  sha256 = "sha256-iVljKMAQWsGJjxbhFmEnLoYf1XD9I5csXW8QgiUKyN8=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -327,7 +327,7 @@ in [
     };
   }
 
-  # `fuels-rs` requires Rust 1.79 as of v0.66.0 due to use of `path::absolute`.
+  # `fuels-rs` requires Rust 1.79 as of v0.66.0 due to the use of `path::absolute`.
   {
     condition = m: m.date >= "2024-08-08";
     patch = m: {


### PR DESCRIPTION
Running `nix flake update` in CI before refreshing the manifests.

Related https://github.com/oxalica/rust-overlay/issues/185