### PR TITLE
docs(nix-setup): update nix-installer to v0.20.2

### DIFF
--- a/book/src/nix-setup.md
+++ b/book/src/nix-setup.md
@@ -15,7 +15,7 @@ To recap our [Quick Start](./quick-start.html), we can install Nix with the
 following command:
 
 ```console
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/tag/v0.9.0 | sh -s -- install --extra-conf "extra-substituters = https://fuellabs.cachix.org" --extra-conf "extra-trusted-public-keys = fuellabs.cachix.org-1:3gOmll82VDbT7EggylzOVJ6dr0jgPVU/KMN6+Kf8qx8="
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/tag/v0.20.2 | sh -s -- install --extra-conf "extra-substituters = https://fuellabs.cachix.org" --extra-conf "extra-trusted-public-keys = fuellabs.cachix.org-1:3gOmll82VDbT7EggylzOVJ6dr0jgPVU/KMN6+Kf8qx8="
 ```
 
 This uses the [`nix-installer` tool by Determinate Systems](nix-installer) to

--- a/book/src/quick-start.md
+++ b/book/src/quick-start.md
@@ -9,7 +9,7 @@ Nix is a package manager with a focus on reproducibility and reliability. We can
 install it and enable the Fuel Labs binary cache with the following:
 
 ```console
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/tag/v0.9.0 | sh -s -- install --extra-conf "extra-substituters = https://fuellabs.cachix.org" --extra-conf "extra-trusted-public-keys = fuellabs.cachix.org-1:3gOmll82VDbT7EggylzOVJ6dr0jgPVU/KMN6+Kf8qx8="
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/tag/v0.20.2 | sh -s -- install --extra-conf "extra-substituters = https://fuellabs.cachix.org" --extra-conf "extra-trusted-public-keys = fuellabs.cachix.org-1:3gOmll82VDbT7EggylzOVJ6dr0jgPVU/KMN6+Kf8qx8="
 ```
 
 > **Note:** For more details on Nix installation or how to configure an existing


### PR DESCRIPTION
I had permission trouble ("unable to create symlink: permission denied", etc.) with `nix-installer` v0.9.0 (Macbook M3 Pro, MacOS Sonoma 14.6.1) as provided by the docs, so I used one of the latest stable releases.

This update might make (re-)installation of Nix via our docs more stable for Mac users.

I opted for v0.20.2, which fixes lots of bugs since v0.9.0, and also adds support for MacOS 15 beta, which might be useful soon (v0.21.0 adds extra features that are irrelevant for us now, so I went with a month-older release).

We should either:
- update the version of `nix-installer` more often (preferred, I think; v0.9.0 was released in May 2023, more than a year ago!)
- use `install.determinate.systems/nix` without a `tag` to get the latest stable release of `nix-installer`, but that might introduce installation problems down the line
