### PR TITLE
feat: add mainnet and ignition milestones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
             fuel-beta-4,
             fuel-beta-5,
             fuel-testnet,
+            fuel-ignition,
+            fuel-mainnet,
             fuel-nightly,
             sway-vim,
           ]

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [fuel, fuel-beta-4, fuel-beta-5, fuel-testnet, fuel-nightly]
+        package: [fuel, fuel-beta-4, fuel-beta-5, fuel-testnet, fuel-mainnet, fuel-ignition, fuel-nightly]
         os: [buildjet-4vcpu-ubuntu-2204, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:

--- a/milestones.nix
+++ b/milestones.nix
@@ -34,7 +34,7 @@
   ignition = {
     forc-wallet = "152bfb48c347363d32dc573c77315baba8d05e5b";
     fuel-core = "eea8c605258d79d5243f3f822c0e1205b0802f3c";
-    sway = "d5662c6bd0e5519446aa1b3ebb6af703025accec";
+    sway = "31486c0b47669612acb7c64d66ecb50aea281282";
   };
 
   # Commits sourced from:
@@ -42,6 +42,6 @@
   mainnet = {
     forc-wallet = "152bfb48c347363d32dc573c77315baba8d05e5b";
     fuel-core = "eea8c605258d79d5243f3f822c0e1205b0802f3c";
-    sway = "d5662c6bd0e5519446aa1b3ebb6af703025accec";
+    sway = "31486c0b47669612acb7c64d66ecb50aea281282";
   };
 }

--- a/milestones.nix
+++ b/milestones.nix
@@ -28,4 +28,20 @@
     fuel-core = "8c92d37598b760d64a14df1588ff27b3d14c7d2c";
     sway = "66bb430395daf5b8f7205f7b9d8d008e2e812d54";
   };
+
+  # Commits sourced from:
+  # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-mainnet.toml
+  ignition = {
+    forc-wallet = "152bfb48c347363d32dc573c77315baba8d05e5b";
+    fuel-core = "eea8c605258d79d5243f3f822c0e1205b0802f3c";
+    sway = "d5662c6bd0e5519446aa1b3ebb6af703025accec";
+  };
+
+  # Commits sourced from:
+  # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-mainnet.toml
+  mainnet = {
+    forc-wallet = "152bfb48c347363d32dc573c77315baba8d05e5b";
+    fuel-core = "eea8c605258d79d5243f3f822c0e1205b0802f3c";
+    sway = "d5662c6bd0e5519446aa1b3ebb6af703025accec";
+  };
 }


### PR DESCRIPTION
Adds new milestones for mainnet and ignition. For now they are the same milestone, following the design in fuelup.