### PR TITLE
chore: bump mainnet & testnet channel - forc-wallet 0.11.1

### DIFF
--- a/milestones.nix
+++ b/milestones.nix
@@ -24,15 +24,15 @@
   # Commits sourced from:
   # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-testnet.toml
   testnet = {
-    forc-wallet = "ee49fcbacedc5f446134c6b7e5513d4232bb7566";
-    fuel-core = "8c92d37598b760d64a14df1588ff27b3d14c7d2c";
-    sway = "66bb430395daf5b8f7205f7b9d8d008e2e812d54";
+    forc-wallet = "f4052012e05babee66bf3a70ab06c0c8570f56d9";
+    fuel-core = "eea8c605258d79d5243f3f822c0e1205b0802f3c";
+    sway = "31486c0b47669612acb7c64d66ecb50aea281282";
   };
 
   # Commits sourced from:
   # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-mainnet.toml
   ignition = {
-    forc-wallet = "152bfb48c347363d32dc573c77315baba8d05e5b";
+    forc-wallet = "f4052012e05babee66bf3a70ab06c0c8570f56d9";
     fuel-core = "eea8c605258d79d5243f3f822c0e1205b0802f3c";
     sway = "31486c0b47669612acb7c64d66ecb50aea281282";
   };
@@ -40,7 +40,7 @@
   # Commits sourced from:
   # https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-mainnet.toml
   mainnet = {
-    forc-wallet = "152bfb48c347363d32dc573c77315baba8d05e5b";
+    forc-wallet = "f4052012e05babee66bf3a70ab06c0c8570f56d9";
     fuel-core = "eea8c605258d79d5243f3f822c0e1205b0802f3c";
     sway = "31486c0b47669612acb7c64d66ecb50aea281282";
   };


### PR DESCRIPTION
# Changelog
- chore: bump mainnet & testnet channel - forc-wallet v0.11.1