### PR TITLE
fix: patch rust version to 1.81 as of 2025-01-01

### DIFF
--- a/patches.nix
+++ b/patches.nix
@@ -336,4 +336,14 @@ in [
       };
     };
   }
+
+  # `fuel-core` requires Rust 1.81 as of ~2025-01-01 due to the use of `pprof2@0.13.1`.
+  {
+    condition = m: m.date >= "2024-01-01";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.81.0".default.override {
+        targets = ["wasm32-unknown-unknown"];
+      };
+    };
+  }
 ]

--- a/patches.nix
+++ b/patches.nix
@@ -339,7 +339,7 @@ in [
 
   # `fuel-core` requires Rust 1.81 as of ~2025-01-01 due to the use of `pprof2@0.13.1`.
   {
-    condition = m: m.date >= "2024-01-01";
+    condition = m: m.date >= "2025-01-01";
     patch = m: {
       rust = pkgs.rust-bin.stable."1.81.0".default.override {
         targets = ["wasm32-unknown-unknown"];


### PR DESCRIPTION
Fixes the CI by updating the rust version to `1.81` from `1.79` as of 2025-01-01:

`rustc 1.79.0` is not supported by the following packages:

-  `async-graphql@7.0.13` requires rustc `1.81.0`
-  `pprof2@0.13.1` requires rustc `1.81.0`

These are dependencies of fuel-core and thus blocks our CI at the moment.

