### PR TITLE
Update nightly date for manifest refresh

### DIFF
--- a/.github/workflows/patch-pr.yml
+++ b/.github/workflows/patch-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - run: nix flake update
       - run: nix run .#refresh-manifests
         timeout-minutes: 240
-      - name: validate changed nix files
+      - name: Validate changed nix files
         run: |
           files=( $(git diff --name-only '*.nix') )
           echo "${#files[*]} nix files changed: ${files[*]}"

--- a/manifests/forc-0.48.1-nightly-2024-01-01.nix
+++ b/manifests/forc-0.48.1-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc";
+  version = "0.48.1";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "910e33bd015e2ea4571e042a856a0cd5c910b93a";
+  sha256 = "sha256-KmpIgbuH/Worse7RMsiR1UsSrwAZ1X4nIZG+H1fEoz4=";
+}

--- a/manifests/forc-client-0.48.1-nightly-2024-01-01.nix
+++ b/manifests/forc-client-0.48.1-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-client";
+  version = "0.48.1";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "910e33bd015e2ea4571e042a856a0cd5c910b93a";
+  sha256 = "sha256-KmpIgbuH/Worse7RMsiR1UsSrwAZ1X4nIZG+H1fEoz4=";
+}

--- a/manifests/forc-crypto-0.48.1-nightly-2024-01-01.nix
+++ b/manifests/forc-crypto-0.48.1-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-crypto";
+  version = "0.48.1";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "910e33bd015e2ea4571e042a856a0cd5c910b93a";
+  sha256 = "sha256-KmpIgbuH/Worse7RMsiR1UsSrwAZ1X4nIZG+H1fEoz4=";
+}

--- a/manifests/forc-debug-0.48.1-nightly-2024-01-01.nix
+++ b/manifests/forc-debug-0.48.1-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-debug";
+  version = "0.48.1";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "910e33bd015e2ea4571e042a856a0cd5c910b93a";
+  sha256 = "sha256-KmpIgbuH/Worse7RMsiR1UsSrwAZ1X4nIZG+H1fEoz4=";
+}

--- a/manifests/forc-doc-0.48.1-nightly-2024-01-01.nix
+++ b/manifests/forc-doc-0.48.1-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-doc";
+  version = "0.48.1";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "910e33bd015e2ea4571e042a856a0cd5c910b93a";
+  sha256 = "sha256-KmpIgbuH/Worse7RMsiR1UsSrwAZ1X4nIZG+H1fEoz4=";
+}

--- a/manifests/forc-fmt-0.48.1-nightly-2024-01-01.nix
+++ b/manifests/forc-fmt-0.48.1-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-fmt";
+  version = "0.48.1";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "910e33bd015e2ea4571e042a856a0cd5c910b93a";
+  sha256 = "sha256-KmpIgbuH/Worse7RMsiR1UsSrwAZ1X4nIZG+H1fEoz4=";
+}

--- a/manifests/forc-lsp-0.48.1-nightly-2024-01-01.nix
+++ b/manifests/forc-lsp-0.48.1-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-lsp";
+  version = "0.48.1";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "910e33bd015e2ea4571e042a856a0cd5c910b93a";
+  sha256 = "sha256-KmpIgbuH/Worse7RMsiR1UsSrwAZ1X4nIZG+H1fEoz4=";
+}

--- a/manifests/forc-tx-0.48.1-nightly-2024-01-01.nix
+++ b/manifests/forc-tx-0.48.1-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-tx";
+  version = "0.48.1";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/sway";
+  rev = "910e33bd015e2ea4571e042a856a0cd5c910b93a";
+  sha256 = "sha256-KmpIgbuH/Worse7RMsiR1UsSrwAZ1X4nIZG+H1fEoz4=";
+}

--- a/manifests/forc-wallet-0.4.0-nightly-2024-01-01.nix
+++ b/manifests/forc-wallet-0.4.0-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "forc-wallet";
+  version = "0.4.0";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/forc-wallet";
+  rev = "36ecad0a149929e565542dbc0c977e26f91d593a";
+  sha256 = "sha256-wBauC198giQQ1uPPLbQUx8wLsmwTo2RbsTD4TZFRDVI=";
+}

--- a/manifests/fuel-core-0.22.0-nightly-2024-01-01.nix
+++ b/manifests/fuel-core-0.22.0-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.22.0";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0daa63594f670ad2c6d2028f9cc3f61bf918426c";
+  sha256 = "sha256-W890Wxz+ZiJZyb4b1LgmOBS7u0N+d4KE4Mmq+Glz0BY=";
+}

--- a/manifests/fuel-core-client-0.22.0-nightly-2024-01-01.nix
+++ b/manifests/fuel-core-client-0.22.0-nightly-2024-01-01.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.22.0";
+  date = "2024-01-01";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "0daa63594f670ad2c6d2028f9cc3f61bf918426c";
+  sha256 = "sha256-W890Wxz+ZiJZyb4b1LgmOBS7u0N+d4KE4Mmq+Glz0BY=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -283,7 +283,7 @@ in [
     };
   }
 
-  # `forc` requires Rust 1.70 as of ~2023-07-01
+  # `forc` requires Rust 1.70 as of ~2023-07-01.
   {
     condition = m: m.date >= "2023-07-01";
     patch = m: {

--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -176,7 +176,7 @@ function refresh_nightlies {
         git clone "${pkg[repo]}" "$pkg_repo_dir"
     fi
     local pkg_git_branch="$(cd $pkg_repo_dir && git branch --show-current)"
-    local date_nightly="2022-09-01"
+    local date_nightly="2024-01-01"
     local date_today=$(date -u +"%F")
     echo "Collecting nightlies from $date_nightly to $date_today"
     local last_git_rev=""


### PR DESCRIPTION
Makes it so only nightlies after 01-01-2024 receive new patches. This cuts the time to refresh manifests down from ~3 hours to [43 min](https://github.com/FuelLabs/fuel.nix/actions/runs/12659594373)