### PR TITLE
chore: migrate from REPO_TOKEN to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/patch-pr.yml
+++ b/.github/workflows/patch-pr.yml
@@ -17,6 +17,7 @@ jobs:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -54,5 +55,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master
 
   notify-slack-on-failure:


### PR DESCRIPTION
Switch to using GitHub's built-in GITHUB_TOKEN instead of our custom REPO_TOKEN in CI workflows.