### PR TITLE
ci: add permissions for github token refresh-manifests

### DIFF
--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -60,6 +60,10 @@ jobs:
   download-manifests-and-commit:
     needs: [refresh-and-upload-manifests, download-manifests-and-nix-build]
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rm -r manifests
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: manifests
           path: manifests/
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
           ref: master
       - run: rm -r ./manifests
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: manifests
           path: manifests/

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           name: manifests
           path: manifests/
+          overwrite: true
 
   download-manifests-and-nix-build:
     needs: refresh-and-upload-manifests
@@ -46,6 +47,7 @@ jobs:
         with:
           name: manifests
           path: manifests/
+          overwrite: true
       - name: stage manifests for nix build
         run: git add -v manifests
       - uses: cachix/install-nix-action@v22
@@ -74,6 +76,7 @@ jobs:
         with:
           name: manifests
           path: manifests/
+          overwrite: true
       - name: Check and commit changes
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -62,10 +62,7 @@ jobs:
   download-manifests-and-commit:
     needs: [refresh-and-upload-manifests, download-manifests-and-nix-build]
     runs-on: ubuntu-latest
-    permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
-      contents: write
+    environment: fuel-nix-bot
     steps:
       - uses: actions/checkout@v3
         with:
@@ -89,10 +86,16 @@ jobs:
           else
             git commit -m "manifest: update"
           fi
+      - name: Get app credentials
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           branch: master
 
   notify-slack-on-failure:

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -26,7 +26,7 @@ jobs:
           if [[ "${#files[*]}" -ne 0 ]]; then
             nix-instantiate --parse "${files[@]}" >/dev/null
           fi
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: manifests
           path: manifests/


### PR DESCRIPTION
It's failing due to missing permissions: https://github.com/FuelLabs/fuel.nix/actions/runs/12919430407

Testing it here: https://github.com/FuelLabs/fuel.nix/actions/runs/12937628058