### PR TITLE
ci: add a ci job to ensure quick start works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,26 @@ jobs:
           name: fuellabs
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+  verify-nix-shell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v22
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v12
+        with:
+          name: fuellabs
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Verify nix shell command from docs
+        run: |
+          nix shell github:fuellabs/fuel.nix#fuel-testnet --command bash -c '
+            set -e
+            echo "Checking fuel-core version..."
+            fuel-core --version
+            echo "Checking forc version..."
+            forc --version
+          '
+
   nix-develop:
     needs: nix-build
     strategy:
@@ -87,6 +107,7 @@ jobs:
         nix-build,
         nix-develop,
         nix-build-book,
+        verify-nix-shell
       ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
closes #158.

Adds a CI job to assert nix-shell works as described in the quick start.