### PR TITLE
fix: tikv-jmalloc fails to build in debug mode by disabling hardening in fuel-dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -256,6 +256,9 @@
         in
           (pkgs.lib.mapAttrsToList (n: v: v) currentNightlies) ++ [fuel-core-dev sway-dev];
         inherit (fuel-core-dev) LIBCLANG_PATH ROCKSDB_LIB_DIR PROTOC NIX_CFLAGS_COMPILE;
+        # Remove the hardening added by nix to fix jmalloc compilation error.
+        # More info: https://github.com/tikv/jemallocator/issues/108
+        hardeningDisable = ["fortify"];
       };
 
       default = fuel-dev;


### PR DESCRIPTION
closes #166.

Removes the auto hardening enabled on nixOS to fix the build fail in debug mode for fuel repos. More details about the issue and root cause can be found in the issue ticker.