### PR TITLE
chore: use rust 1.85 as of 2025-04-10 for fuel-core

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740560979,
-        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740623427,
-        "narHash": "sha256-3SdPQrZoa4odlScFDUHd4CUPQ/R1gtH4Mq9u8CBiK8M=",
+        "lastModified": 1744425163,
+        "narHash": "sha256-iFcqIbyY25uhtRrQal5vFTxt0q59vDf++nY8du5hof4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d342e8b5fd88421ff982f383c853f0fc78a847ab",
+        "rev": "4bb0b6dfc5bafa8b4e8dbe1170f051c437b2cb79",
         "type": "github"
       },
       "original": {

--- a/manifests/fuel-core-0.43.0-nightly-2025-04-12.nix
+++ b/manifests/fuel-core-0.43.0-nightly-2025-04-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.43.0";
+  date = "2025-04-12";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2a7e031fca28c751215030f719c99cb6a82d30f3";
+  sha256 = "sha256-BnGzIGYbXIcY8KzfdsYBnFxSNXDsUxeG70e/lwqS+fQ=";
+}

--- a/manifests/fuel-core-client-0.43.0-nightly-2025-04-12.nix
+++ b/manifests/fuel-core-client-0.43.0-nightly-2025-04-12.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.43.0";
+  date = "2025-04-12";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "2a7e031fca28c751215030f719c99cb6a82d30f3";
+  sha256 = "sha256-BnGzIGYbXIcY8KzfdsYBnFxSNXDsUxeG70e/lwqS+fQ=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -356,4 +356,14 @@ in [
       };
     };
   }
+
+  # `fuel-core` requires Rust 1.85 as of `2a7e031fca28c751215030f719c99cb6a82d30f3`.
+  {
+    condition = m: m.date >= "2025-04-10";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.85.0".default.override {
+        targets = ["wasm32-unknown-unknown"];
+      };
+    };
+  }
 ]


### PR DESCRIPTION
Bumps rust version for https://github.com/FuelLabs/fuel-core/commit/2a7e031fca28c751215030f719c99cb6a82d30f3