### PR TITLE
bugfix: gh-action milestones.nix

### DIFF
--- a/.github/workflows/update-milestones.yml
+++ b/.github/workflows/update-milestones.yml
@@ -57,6 +57,21 @@ jobs:
       - name: Install update-milestones script
         run: cargo install --debug --path ./ci/update-milestones
 
+      - name: Create bump branch
+        run: |
+          BRANCH_NAME="bump/milestones-$(date +'%d-%m-%Y')"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          
+          # Check if branch exists remotely
+          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+            echo "Branch $BRANCH_NAME already exists remotely, checking it out"
+            git fetch origin "$BRANCH_NAME"
+            git checkout -b "$BRANCH_NAME" origin/"$BRANCH_NAME"
+          else
+            echo "Creating new branch $BRANCH_NAME"
+            git checkout -b "$BRANCH_NAME"
+          fi
+
       - name: Update milestones
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -88,21 +103,6 @@ jobs:
 
           # Run the update-milestones binary - to update the milestones.nix file
           update-milestones $ARGS
-
-      - name: Create bump branch
-        run: |
-          BRANCH_NAME="bump/milestones-$(date +'%d-%m-%Y')"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-          
-          # Check if branch exists remotely
-          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
-            echo "Branch $BRANCH_NAME already exists remotely, checking it out"
-            git fetch origin "$BRANCH_NAME"
-            git checkout -b "$BRANCH_NAME" origin/"$BRANCH_NAME"
-          else
-            echo "Creating new branch $BRANCH_NAME"
-            git checkout -b "$BRANCH_NAME"
-          fi
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/update-milestones.yml
+++ b/.github/workflows/update-milestones.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: master
-          depth: 1
 
       - name: Set up Git
         run: |

--- a/.github/workflows/update-milestones.yml
+++ b/.github/workflows/update-milestones.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Create bump branch
         run: |
-          BRANCH_NAME="bump/$(date +'%d-%m-%Y')"
+          BRANCH_NAME="bump/milestones-$(date +'%d-%m-%Y')"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
@@ -103,7 +103,7 @@ jobs:
             echo "No changes to commit"
             exit 0
           else
-            git commit -m "Update milestones"
+            git commit -m "chore: update milestones"
             git push origin "$BRANCH_NAME"
           fi
 

--- a/.github/workflows/update-milestones.yml
+++ b/.github/workflows/update-milestones.yml
@@ -92,8 +92,17 @@ jobs:
       - name: Create bump branch
         run: |
           BRANCH_NAME="bump/milestones-$(date +'%d-%m-%Y')"
-          git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          
+          # Check if branch exists remotely
+          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+            echo "Branch $BRANCH_NAME already exists remotely, checking it out"
+            git fetch origin "$BRANCH_NAME"
+            git checkout -b "$BRANCH_NAME" origin/"$BRANCH_NAME"
+          else
+            echo "Creating new branch $BRANCH_NAME"
+            git checkout -b "$BRANCH_NAME"
+          fi
 
       - name: Commit and push changes
         run: |
@@ -103,7 +112,8 @@ jobs:
             exit 0
           else
             git commit -m "chore: update milestones"
-            git push origin "$BRANCH_NAME"
+            # Force push to handle existing branches
+            git push --force-with-lease origin "$BRANCH_NAME"
           fi
 
       - name: Create or update pull request

--- a/.github/workflows/update-milestones.yml
+++ b/.github/workflows/update-milestones.yml
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Build script arguments
-          ARGS=""
+          ARGS="--milestones-file ./milestones.nix"
 
           # Add testnet arguments if provided
           if [ -n "${{ github.event.inputs.testnet-forc-wallet }}" ]; then
@@ -101,7 +101,7 @@ jobs:
           git add milestones.nix
           if git diff --staged --quiet; then
             echo "No changes to commit"
-            exit 1
+            exit 0
           else
             git commit -m "Update milestones"
             git push origin "$BRANCH_NAME"

--- a/ci/update-milestones/src/main.rs
+++ b/ci/update-milestones/src/main.rs
@@ -408,23 +408,23 @@ fn generate_pr_description(
     description.push_str("Bump testnet, ignition and mainnet channels.\n\n");
     description.push_str("**Testnet:**\n");
     if let Some(version) = testnet_versions.get("forc-wallet") {
-        description.push_str(&format!("forc-wallet: `{}`\n", version.tag));
+        description.push_str(&format!("forc-wallet: \`{}\`\n", version.tag));
     }
     if let Some(version) = testnet_versions.get("fuel-core") {
-        description.push_str(&format!("fuel-core: `{}`\n", version.tag));
+        description.push_str(&format!("fuel-core: \`{}\`\n", version.tag));
     }
     if let Some(version) = testnet_versions.get("sway") {
-        description.push_str(&format!("sway: `{}`\n", version.tag));
+        description.push_str(&format!("sway: \`{}\`\n", version.tag));
     }
     description.push_str("\n**Ignition & Mainnet:**\n");
     if let Some(version) = mainnet_versions.get("forc-wallet") {
-        description.push_str(&format!("forc-wallet: `{}`\n", version.tag));
+        description.push_str(&format!("forc-wallet: \`{}\`\n", version.tag));
     }
     if let Some(version) = mainnet_versions.get("fuel-core") {
-        description.push_str(&format!("fuel-core: `{}`\n", version.tag));
+        description.push_str(&format!("fuel-core: \`{}\`\n", version.tag));
     }
     if let Some(version) = mainnet_versions.get("sway") {
-        description.push_str(&format!("sway: `{}`\n", version.tag));
+        description.push_str(&format!("sway: \`{}\`\n", version.tag));
     }
     description
 }

--- a/ci/update-milestones/src/main.rs
+++ b/ci/update-milestones/src/main.rs
@@ -406,25 +406,25 @@ fn generate_pr_description(
 ) -> String {
     let mut description = String::new();
     description.push_str("Bump testnet, ignition and mainnet channels.\n\n");
-    description.push_str("Testnet:\n");
+    description.push_str("**Testnet:**\n");
     if let Some(version) = testnet_versions.get("forc-wallet") {
-        description.push_str(&format!("`forc-wallet`: {}\n", version.tag));
+        description.push_str(&format!("forc-wallet: `{}`\n", version.tag));
     }
     if let Some(version) = testnet_versions.get("fuel-core") {
-        description.push_str(&format!("`fuel-core`: {}\n", version.tag));
+        description.push_str(&format!("fuel-core: `{}`\n", version.tag));
     }
     if let Some(version) = testnet_versions.get("sway") {
-        description.push_str(&format!("`sway`: {}\n", version.tag));
+        description.push_str(&format!("sway: `{}`\n", version.tag));
     }
-    description.push_str("\nIgnition & Mainnet:\n");
+    description.push_str("\n**Ignition & Mainnet:**\n");
     if let Some(version) = mainnet_versions.get("forc-wallet") {
-        description.push_str(&format!("`forc-wallet`: {}\n", version.tag));
+        description.push_str(&format!("forc-wallet: `{}`\n", version.tag));
     }
     if let Some(version) = mainnet_versions.get("fuel-core") {
-        description.push_str(&format!("`fuel-core`: {}\n", version.tag));
+        description.push_str(&format!("fuel-core: `{}`\n", version.tag));
     }
     if let Some(version) = mainnet_versions.get("sway") {
-        description.push_str(&format!("`sway`: {}\n", version.tag));
+        description.push_str(&format!("sway: `{}`\n", version.tag));
     }
     description
 }

--- a/ci/update-milestones/src/main.rs
+++ b/ci/update-milestones/src/main.rs
@@ -408,23 +408,23 @@ fn generate_pr_description(
     description.push_str("Bump testnet, ignition and mainnet channels.\n\n");
     description.push_str("**Testnet:**\n");
     if let Some(version) = testnet_versions.get("forc-wallet") {
-        description.push_str(&format!("forc-wallet: \`{}\`\n", version.tag));
+        description.push_str(&format!(r"forc-wallet: `{}`\n", version.tag));
     }
     if let Some(version) = testnet_versions.get("fuel-core") {
-        description.push_str(&format!("fuel-core: \`{}\`\n", version.tag));
+        description.push_str(&format!(r"fuel-core: `{}`\n", version.tag));
     }
     if let Some(version) = testnet_versions.get("sway") {
-        description.push_str(&format!("sway: \`{}\`\n", version.tag));
+        description.push_str(&format!(r"sway: `{}`\n", version.tag));
     }
     description.push_str("\n**Ignition & Mainnet:**\n");
     if let Some(version) = mainnet_versions.get("forc-wallet") {
-        description.push_str(&format!("forc-wallet: \`{}\`\n", version.tag));
+        description.push_str(&format!(r"forc-wallet: `{}`\n", version.tag));
     }
     if let Some(version) = mainnet_versions.get("fuel-core") {
-        description.push_str(&format!("fuel-core: \`{}\`\n", version.tag));
+        description.push_str(&format!(r"fuel-core: `{}`\n", version.tag));
     }
     if let Some(version) = mainnet_versions.get("sway") {
-        description.push_str(&format!("sway: \`{}\`\n", version.tag));
+        description.push_str(&format!(r"sway: `{}`\n", version.tag));
     }
     description
 }


### PR DESCRIPTION
This pull request introduces updates to the GitHub Actions workflow for milestone updates and improves the formatting of the pull request description in the Rust codebase.
The changes enhance branch handling, commit behavior, and description clarity.

### Workflow updates in `.github/workflows/update-milestones.yml`:

* **Branch handling improvements**: Updated the branch creation logic to check if the branch already exists remotely. If it does, the workflow fetches and checks out the existing branch instead of creating a new one.
* **Commit and push behavior**: Changed the commit message to follow a more descriptive convention (`chore: update milestones`) and added `--force-with-lease` to the push command to handle existing branches gracefully.
* **Milestones file argument**: Added a `--milestones-file` argument to the script to specify the `milestones.nix` file, improving script flexibility.
* **Removed shallow clone**: Removed the `depth: 1` parameter from the repository checkout step to allow fetching branches when needed.

### Pull request description improvements in `ci/update-milestones/src/main.rs`:

* **Enhanced formatting**: Improved the formatting of the generated pull request description by adding bold section headers (e.g., `**Testnet:**`) and ensuring consistent backtick usage for version tags.