### PR TITLE
ci: upgrade actions to latest versions and fix macOS Nix installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,12 @@ jobs:
   nix-fmt-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v22
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - uses: cachix/cachix-action@v12
         with:
           name: fuellabs
@@ -40,10 +42,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v22
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - uses: cachix/cachix-action@v12
         with:
           name: fuellabs
@@ -53,10 +57,12 @@ jobs:
   verify-nix-shell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v22
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - uses: cachix/cachix-action@v12
         with:
           name: fuellabs
@@ -78,10 +84,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v22
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - uses: cachix/cachix-action@v12
         with:
           name: fuellabs
@@ -91,10 +99,12 @@ jobs:
   nix-build-book:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v22
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - uses: cachix/cachix-action@v12
         with:
           name: fuellabs

--- a/.github/workflows/patch-pr.yml
+++ b/.github/workflows/patch-pr.yml
@@ -19,13 +19,15 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - uses: cachix/cachix-action@v12
         with:
           name: fuellabs

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -9,10 +9,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v22
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - name: build
         run: nix develop --print-build-logs --no-update-lock-file .#book-dev --command mdbook build book
       - name: deploy

--- a/.github/workflows/refresh-manifests.yml
+++ b/.github/workflows/refresh-manifests.yml
@@ -9,10 +9,12 @@ jobs:
   refresh-and-upload-manifests:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v27
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - uses: cachix/cachix-action@v12
         with:
           name: fuellabs
@@ -41,7 +43,7 @@ jobs:
         os: [buildjet-4vcpu-ubuntu-2204, macos-latest-large, macos-latest-xlarge]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - run: rm -r manifests
       - uses: actions/download-artifact@v4
         with:
@@ -50,9 +52,11 @@ jobs:
           overwrite: true
       - name: stage manifests for nix build
         run: git add -v manifests
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+        env:
+          NIX_FIRST_BUILD_UID: 400
       - uses: cachix/cachix-action@v12
         with:
           name: fuellabs
@@ -64,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: fuel-nix-bot
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           ref: master

--- a/.github/workflows/update-milestones.yml
+++ b/.github/workflows/update-milestones.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: master
 


### PR DESCRIPTION
Fixes Nix installation failures on macOS runners where build users already exist.

GitHub's macOS runners now use macOS 15 Sequoia, which reserves UIDs 301-304 for system services that conflict with Nix's traditional build user UIDs. Setting `NIX_FIRST_BUILD_UID=400` moves Nix build users to a safe UID range, resolving the `eDSRecordAlreadyExists` errors.