### PR TITLE
chore: update nightly manifest cutoff date to 2025-04-01

### DIFF
--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -176,7 +176,7 @@ function refresh_nightlies {
         git clone "${pkg[repo]}" "$pkg_repo_dir"
     fi
     local pkg_git_branch="$(cd $pkg_repo_dir && git branch --show-current)"
-    local date_nightly="2024-01-01"
+    local date_nightly="2025-04-01"
     local date_today=$(date -u +"%F")
     echo "Collecting nightlies from $date_nightly to $date_today"
     local last_git_rev=""


### PR DESCRIPTION
This date was [previously updated](https://github.com/FuelLabs/fuel.nix/pull/155) earlier this year, but I think we should bump it again as the refresh manifest job is taking a seriously long time again and there's no need to rebuild from this date. 