### PR TITLE
Stop packaging forc-call and purge regenerated manifests

### DIFF
--- a/manifests/forc-call-0.0.1.nix
+++ b/manifests/forc-call-0.0.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.0.1";
-  date = "2021-09-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c9781a1acca6eea8a1f2f30607466ae40d76de65";
-  sha256 = "sha256-g6pSdahytTJQJ1rgLCku4289C2dnCLqzvSH8Mq8y26I=";
-}

--- a/manifests/forc-call-0.0.2.nix
+++ b/manifests/forc-call-0.0.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.0.2";
-  date = "2021-10-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e0c043bc9463eb266aaf111ff86b8c911602e053";
-  sha256 = "sha256-LwGYEtKpb5eEts1K0TkRPwlWPu7EQLJbtaK8dAFexTk=";
-}

--- a/manifests/forc-call-0.0.3.nix
+++ b/manifests/forc-call-0.0.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.0.3";
-  date = "2021-10-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ce7692d119fa9010dd0937b5f10cf5728fe72393";
-  sha256 = "sha256-ygyqjapnGH+tznuYu5x9vnvhfHaoQ82vlyi90s/ZTCU=";
-}

--- a/manifests/forc-call-0.0.4.nix
+++ b/manifests/forc-call-0.0.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.0.4";
-  date = "2021-11-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d40239e7d49793c7d3d23e0d3de6595e40b89e11";
-  sha256 = "sha256-Udtk0i4LfiXYMWLZtRiDbjXseqiTs83BJgqHaMvJGLA=";
-}

--- a/manifests/forc-call-0.1.0.nix
+++ b/manifests/forc-call-0.1.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.0";
-  date = "2021-12-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "90c9b56a7fc313321fcc7580314284080d00078f";
-  sha256 = "sha256-5VgXmm63O89wp6mayRf6ihMiK/JrXECfkmpo17MPEk4=";
-}

--- a/manifests/forc-call-0.1.1.nix
+++ b/manifests/forc-call-0.1.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.1";
-  date = "2021-12-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8a37329cb1848efdeb46e2be1bfdb940b7750262";
-  sha256 = "sha256-Ci4OJGp+iqmojxmf4Cg9m/2WG8jtKOPMDr2z6LDsOdU=";
-}

--- a/manifests/forc-call-0.1.2.nix
+++ b/manifests/forc-call-0.1.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.2";
-  date = "2021-12-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2431af753ed8fc0a76df53fc72172cb4bdb5d4b9";
-  sha256 = "sha256-FYwNTSaaZdtDGbOQ5/Tk4+lvyZ3PCJBtnNLE6+PuEng=";
-}

--- a/manifests/forc-call-0.1.3.nix
+++ b/manifests/forc-call-0.1.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.3";
-  date = "2021-12-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d30d3225a30c46a9675ca5db270597190cc228bc";
-  sha256 = "sha256-3kvkiTVQ5qSLqBPb3kl2VakJfQlCOYaTY9aonRgN6AY=";
-}

--- a/manifests/forc-call-0.1.4.nix
+++ b/manifests/forc-call-0.1.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.4";
-  date = "2021-12-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "46305882aa552be287b28e55606ba74b81070460";
-  sha256 = "sha256-/sFiQmmk/L+qqK9J/BrhPahg0no7YculAbB+TyB9s+Y=";
-}

--- a/manifests/forc-call-0.1.5.nix
+++ b/manifests/forc-call-0.1.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.5";
-  date = "2021-12-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1923f44784e6d450796b10addd447aeb3325d519";
-  sha256 = "sha256-X/c/HRNrZu3s/wKU2l9pkuuXpqPFZvqeeziW/9iloK4=";
-}

--- a/manifests/forc-call-0.1.6.nix
+++ b/manifests/forc-call-0.1.6.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.6";
-  date = "2021-12-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a38a89a042f7ef13ddf67cc7661b37eac96aad8f";
-  sha256 = "sha256-6HM7WTQsYaOXSvu8Jr0lh6KDQFpFJI+XybvzU8jFEic=";
-}

--- a/manifests/forc-call-0.1.7.nix
+++ b/manifests/forc-call-0.1.7.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.7";
-  date = "2021-12-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4038415bf9f681fca220bcf3951230b0e9129ba6";
-  sha256 = "sha256-gcKYLveFcyiZtPxGjtk8W9dYCVdVUSsUMTW071WavX0=";
-}

--- a/manifests/forc-call-0.1.8.nix
+++ b/manifests/forc-call-0.1.8.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.8";
-  date = "2021-12-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6fd0bc0b6ecf22f3b334a0c8da86e776a7e2b87d";
-  sha256 = "sha256-2M3FGiWEq++cQIkxECjSHabbVuMTkuvCx0eFIuOSeU0=";
-}

--- a/manifests/forc-call-0.1.9.nix
+++ b/manifests/forc-call-0.1.9.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.1.9";
-  date = "2021-12-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6fe6354eb96fa9b85c10e89f628bdf7ee525059d";
-  sha256 = "sha256-Bwn4w93PqCxMquIz52cWQ3u0xtZCXf5TzkKzQvnV15M=";
-}

--- a/manifests/forc-call-0.10.0.nix
+++ b/manifests/forc-call-0.10.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.10.0";
-  date = "2022-04-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a88ea439c95d9fb2701d6479ce496dc6571e92c2";
-  sha256 = "sha256-YdU+xBfyQ6M4UVl/bgp5ba0byVUY7BMwryIZnradFNs=";
-}

--- a/manifests/forc-call-0.10.1.nix
+++ b/manifests/forc-call-0.10.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.10.1";
-  date = "2022-04-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c85d2b712975669d238233297443557969dec43";
-  sha256 = "sha256-8ocDTtJL468H3PpkQu5b9+lZtfjFP3MDK8YE2LtPYy4=";
-}

--- a/manifests/forc-call-0.10.2.nix
+++ b/manifests/forc-call-0.10.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.10.2";
-  date = "2022-04-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "443abbffd520f0f964e837fbc784641741fd7950";
-  sha256 = "sha256-qnU5g9Oxusr67zIIei9cAUqT7VVkA2VDXbarM1abOgc=";
-}

--- a/manifests/forc-call-0.10.3.nix
+++ b/manifests/forc-call-0.10.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.10.3";
-  date = "2022-04-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e7676db6f4ebc7a3885f87514d16a703a99410d7";
-  sha256 = "sha256-/pWNhRZm+ev48LgpQhjGWuXG2TLvZSTpPHsZPLHcMiw=";
-}

--- a/manifests/forc-call-0.11.0.nix
+++ b/manifests/forc-call-0.11.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.11.0";
-  date = "2022-04-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "95816e4e41aae1d3425ba6ff5e7266076d8400fa";
-  sha256 = "sha256-2XvtFdkQwUVlUVSjQeTUHlEROQ8r1GOcG8uCPM3uDTc=";
-}

--- a/manifests/forc-call-0.12.1.nix
+++ b/manifests/forc-call-0.12.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.12.1";
-  date = "2022-05-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a03a5d1c068a91779e5ce08eead6c4626de2eb0d";
-  sha256 = "sha256-nE10IRpnOkNHXfLfYhFhucjJ3JgdPW6AuNneLL14ymI=";
-}

--- a/manifests/forc-call-0.12.2.nix
+++ b/manifests/forc-call-0.12.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.12.2";
-  date = "2022-05-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2b6e9384f06692ec627293ae5db5e2f748fe2c30";
-  sha256 = "sha256-HTo5eP8jZP5tzesGGA1i5YUmofsWxFJGKw0oMfvWv0c=";
-}

--- a/manifests/forc-call-0.13.0.nix
+++ b/manifests/forc-call-0.13.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.13.0";
-  date = "2022-05-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6eef7ab750cd3282f08b6014960cbc02afae717a";
-  sha256 = "sha256-iT90TBcMgmKTl/2MHR37Vtk7LcOshVMSshlU3BLhAG0=";
-}

--- a/manifests/forc-call-0.13.1.nix
+++ b/manifests/forc-call-0.13.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.13.1";
-  date = "2022-05-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d73d9d2b4b547e2035ddfe085d439de56ccee1f0";
-  sha256 = "sha256-jbuvLymTQb8g4ERJeu0K24z2OIw8aDlkBPF+YjiUkIE=";
-}

--- a/manifests/forc-call-0.13.2.nix
+++ b/manifests/forc-call-0.13.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.13.2";
-  date = "2022-05-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dac1b96419a6ed46a4c531492ae5e794a270d4a1";
-  sha256 = "sha256-LBuJ2ukkK1FosaLcZ10ds8/7ybN1UU/o0d9dRmbG5a4=";
-}

--- a/manifests/forc-call-0.14.0.nix
+++ b/manifests/forc-call-0.14.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.14.0";
-  date = "2022-05-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "953dad9cad0defe50ffe04e4031207fd247b63f1";
-  sha256 = "sha256-/z+nNctB9t1qLKiemsg+QuV2jBnuYgd0tCe3cEkI1OU=";
-}

--- a/manifests/forc-call-0.14.1.nix
+++ b/manifests/forc-call-0.14.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.14.1";
-  date = "2022-05-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "02ef7d10b6bf883d73fc1fd23034dc814dfffea2";
-  sha256 = "sha256-8Uh2gbZb1R1llk3h+DeCF3heBO2Ec3nJNqI6hpSTfq8=";
-}

--- a/manifests/forc-call-0.14.2.nix
+++ b/manifests/forc-call-0.14.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.14.2";
-  date = "2022-05-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6fc5c69f29a5aab0b6ca677d9384d0d5eaffb232";
-  sha256 = "sha256-JGicorHY6HfSWoZa2nFOnx45qDrnXmORzHOOKHk/6sM=";
-}

--- a/manifests/forc-call-0.14.3.nix
+++ b/manifests/forc-call-0.14.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.14.3";
-  date = "2022-05-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "17f856bfa0d500e06fff2c470e8e6113533faf97";
-  sha256 = "sha256-VfyRHFmz89GT7UP/JCR8lPZY5vxhfxnyyWheQdWSRn0=";
-}

--- a/manifests/forc-call-0.14.4.nix
+++ b/manifests/forc-call-0.14.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.14.4";
-  date = "2022-05-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b067a7dd64b26bd763eca268fef3849c2c77028d";
-  sha256 = "sha256-VJGi0FlI+majMW66lo4Sxyo9NaaO+LgFyg7hHwckD1k=";
-}

--- a/manifests/forc-call-0.14.5.nix
+++ b/manifests/forc-call-0.14.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.14.5";
-  date = "2022-06-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "60c626cf486d5c53c44d84db1ec81cb90174cad3";
-  sha256 = "sha256-3zI62Q+jaZYml3PjHn5Xsx635ARfUPsXBpOGDc0QzVM=";
-}

--- a/manifests/forc-call-0.15.0.nix
+++ b/manifests/forc-call-0.15.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.15.0";
-  date = "2022-06-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ee7822c411a3d6135ea590bbc5c85527c4ede6d7";
-  sha256 = "sha256-7qdjLcxcKCHt+RNrVU9WRK+DUepB0G/5RkScHHWRFJQ=";
-}

--- a/manifests/forc-call-0.15.1.nix
+++ b/manifests/forc-call-0.15.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.15.1";
-  date = "2022-06-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a34b4b99fcdd065d559f6cbb9dec0697c3f5edd1";
-  sha256 = "sha256-kR1NJqI6fOyDne1zvwIG2M92+dSOn+6Hby+Q4iMJAAQ=";
-}

--- a/manifests/forc-call-0.15.2.nix
+++ b/manifests/forc-call-0.15.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.15.2";
-  date = "2022-06-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "eab07e48bc6dbd0c80aedc1e363bb63a6d5f0e28";
-  sha256 = "sha256-vE29EiJYF4T6FW/1odNJyZOc5HKHR5sC10bASSFcmuc=";
-}

--- a/manifests/forc-call-0.16.0.nix
+++ b/manifests/forc-call-0.16.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.16.0";
-  date = "2022-06-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "948f7aba42b4138433fb5b61c698c8f4a60db424";
-  sha256 = "sha256-5yPftMl1LJkub2yeGHF1BrLZZSYzg82IYFVpVWG0v48=";
-}

--- a/manifests/forc-call-0.16.1.nix
+++ b/manifests/forc-call-0.16.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.16.1";
-  date = "2022-06-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dcf22453aeb054335d96ef810da9d4f756d869b7";
-  sha256 = "sha256-kAZVbgkf7ganCs+sBPL0eMmR3MDCm6s+qL8d1CfHL8U=";
-}

--- a/manifests/forc-call-0.16.2.nix
+++ b/manifests/forc-call-0.16.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.16.2";
-  date = "2022-06-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7920330d34c97cf418b6d0e1561f978068158228";
-  sha256 = "sha256-NpCpZYxgJeUcgw5QqnAhzVmEkMrR7cs2Sj6aW6Rm6JU=";
-}

--- a/manifests/forc-call-0.17.0.nix
+++ b/manifests/forc-call-0.17.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.17.0";
-  date = "2022-07-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b81bcd9652d4fc9908d1971c9215a7cfdde39adc";
-  sha256 = "sha256-cOyJXvwyZbZeTLfw9xoAtY1rsHN29VXLkRsEeCZyDmI=";
-}

--- a/manifests/forc-call-0.18.0.nix
+++ b/manifests/forc-call-0.18.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.18.0";
-  date = "2022-07-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ada0d294a68e5ca3070e3c46eb89619e7d87caf2";
-  sha256 = "sha256-9a39KoLnQ7urf7pBwxFy8B2+SELuhhx6JDZjyZo2rSQ=";
-}

--- a/manifests/forc-call-0.18.1.nix
+++ b/manifests/forc-call-0.18.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.18.1";
-  date = "2022-07-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3bd8eaf4a0f11a3009c9421100cc06c2e897b6c2";
-  sha256 = "sha256-WI7srBdT5WAMZ6OfUWAcihZcpxbn/ogfVE3LaoQptcM=";
-}

--- a/manifests/forc-call-0.19.0.nix
+++ b/manifests/forc-call-0.19.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.19.0";
-  date = "2022-07-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c716e1ba55d755555ed5aa186c883f73c4f90dc";
-  sha256 = "sha256-DKB7ykAHVte8Dt566iNdY6CIkvs06zRxCWT50LoQRBk=";
-}

--- a/manifests/forc-call-0.19.1.nix
+++ b/manifests/forc-call-0.19.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.19.1";
-  date = "2022-08-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1202e790c119ff9f04c847ecaab3411cfaf32f94";
-  sha256 = "sha256-jFtMg6C861fIWZBmX5SbSsvQwPUr+KWQOcQnPDweWUo=";
-}

--- a/manifests/forc-call-0.19.2.nix
+++ b/manifests/forc-call-0.19.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.19.2";
-  date = "2022-08-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6808861389966f99887f71476918a562a9edd90e";
-  sha256 = "sha256-LL5jMwMvw//bN8SkI5K/tNF+7NKuuOXpcMGezEmrQ4g=";
-}

--- a/manifests/forc-call-0.2.0.nix
+++ b/manifests/forc-call-0.2.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.2.0";
-  date = "2022-01-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "38479274e0c50518e20c919682b8173ae4a555d3";
-  sha256 = "sha256-48BfRiY2evrKlcz1bXBWoWQgRtkk4jc2r3GZRj28sPo=";
-}

--- a/manifests/forc-call-0.2.1.nix
+++ b/manifests/forc-call-0.2.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.2.1";
-  date = "2022-01-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a790fd729b2021f837be924c7b8b21099b9f6c12";
-  sha256 = "sha256-TUQQa1uE9JuZzEnXxrOAeBplNkzt9MRWzPjxZdECZg8=";
-}

--- a/manifests/forc-call-0.20.0.nix
+++ b/manifests/forc-call-0.20.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.20.0";
-  date = "2022-08-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "fc3a05d87d1178e937fc5e4742b13fcca490057d";
-  sha256 = "sha256-gJaLWboU9LNEn9Xu+0AIveFvG3wCTMH1P95H+DVJCRw=";
-}

--- a/manifests/forc-call-0.20.1.nix
+++ b/manifests/forc-call-0.20.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.20.1";
-  date = "2022-08-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "21887f4b321bfacb16c7a6602071e3b6ea1c8df1";
-  sha256 = "sha256-mO7vojv7gEfBJaEmBW2uQTo1ecLNoTL6E1o1d68saBQ=";
-}

--- a/manifests/forc-call-0.20.2.nix
+++ b/manifests/forc-call-0.20.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.20.2";
-  date = "2022-08-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6a8116fcee71aa960217b1672bac0c35d1fce42c";
-  sha256 = "sha256-JfjHda4vRGPiZ2EhJbGMzpSJ24bFFS3WlPxtXmI3mno=";
-}

--- a/manifests/forc-call-0.21.0.nix
+++ b/manifests/forc-call-0.21.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.21.0";
-  date = "2022-08-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "32b5b142b54d3d38ae1f7df69f465138e86de82d";
-  sha256 = "sha256-joWJifoFBzzK9FdhQwyYwVuDU4/8hQzmrUgD7+2BSJY=";
-}

--- a/manifests/forc-call-0.22.0.nix
+++ b/manifests/forc-call-0.22.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.22.0";
-  date = "2022-08-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6e1fbca21f0979d226efd7ceea5b6d71696536cd";
-  sha256 = "sha256-cK7YReHEq3Z/wVV6bxTohdHI9c2zSz53Sej8GCWSIrI=";
-}

--- a/manifests/forc-call-0.22.1.nix
+++ b/manifests/forc-call-0.22.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.22.1";
-  date = "2022-08-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c486eabc3ed4d8c53b63735188f2c1db5d17703c";
-  sha256 = "sha256-fChGs4bPxg82noIJooec6Tk908T8BrDUWH6YQNvAuhg=";
-}

--- a/manifests/forc-call-0.23.0.nix
+++ b/manifests/forc-call-0.23.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.23.0";
-  date = "2022-09-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4712e5b26c6c0f778d7771ef1b35a229fe3a371d";
-  sha256 = "sha256-ZdH69u5DOe/fjARXWpJe0J21K/rVL4YJD5/qHQdlr50=";
-}

--- a/manifests/forc-call-0.24.0.nix
+++ b/manifests/forc-call-0.24.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.24.0";
-  date = "2022-09-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ea4f1b7885248c2b4c4d0da394c2cc50ea1583e8";
-  sha256 = "sha256-2DwlfRw+aw9g4E2wPeomlGH/qe6O0kKha3Vu3+HY4AI=";
-}

--- a/manifests/forc-call-0.24.1.nix
+++ b/manifests/forc-call-0.24.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.24.1";
-  date = "2022-09-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "54e1a340e6c0c9a675e8a66aab03f579d5d6b39b";
-  sha256 = "sha256-t/VFaYCANGY5CM2FFrLhNiBB5eAL/CFCZvIzigr3d1I=";
-}

--- a/manifests/forc-call-0.24.2.nix
+++ b/manifests/forc-call-0.24.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.24.2";
-  date = "2022-09-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "057e83aee87d17c3812f223f5fc7884cf6d3468a";
-  sha256 = "sha256-XQePJ7tvPqjAAnqdpavkUxuCtH8MmaiXSDrhIUpjVQo=";
-}

--- a/manifests/forc-call-0.24.3.nix
+++ b/manifests/forc-call-0.24.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.24.3";
-  date = "2022-09-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "95cd150cacef407a1f30c89899c539b0d57f099d";
-  sha256 = "sha256-oWQpD2HohdjQ0lcnOjipT0oTIX68KnoWy13FeXYKi7E=";
-}

--- a/manifests/forc-call-0.24.4.nix
+++ b/manifests/forc-call-0.24.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.24.4";
-  date = "2022-09-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f7800e18979dd8e4c8d672b8e7aae1758c2edb88";
-  sha256 = "sha256-jRqUQv7nsv0xq+CNrEYCnt0yfiVycTUF3eYOMt/DCdQ=";
-}

--- a/manifests/forc-call-0.24.5.nix
+++ b/manifests/forc-call-0.24.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.24.5";
-  date = "2022-09-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e695606d8884a18664f6231681333a784e623bc9";
-  sha256 = "sha256-gsLMsR+sFj3tvE86JvKzj95aMp1o9ERBkTskr+ejUhM=";
-}

--- a/manifests/forc-call-0.25.0.nix
+++ b/manifests/forc-call-0.25.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.25.0";
-  date = "2022-10-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0f84734f6f95a8598d701b087e486caacf23f514";
-  sha256 = "sha256-tXUEiGKpq7H5nSUICGlUeUJtDnKjwDpBvzl5d3jd8OE=";
-}

--- a/manifests/forc-call-0.25.1.nix
+++ b/manifests/forc-call-0.25.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.25.1";
-  date = "2022-10-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "cc9740bea1438cdde7f15fa0d0c2eba705b6aef1";
-  sha256 = "sha256-YeTt1+D8e3VnqBmn5VWa/NUlDEOzf8zxeuYh5QXBEVM=";
-}

--- a/manifests/forc-call-0.25.2.nix
+++ b/manifests/forc-call-0.25.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.25.2";
-  date = "2022-10-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dfa6224932a97c514b707dcfc300715b2a0895dc";
-  sha256 = "sha256-rZrjzlGIdv1ul2xb94YkkUqXWEbACFQKXirpa/uuITs=";
-}

--- a/manifests/forc-call-0.26.0.nix
+++ b/manifests/forc-call-0.26.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.26.0";
-  date = "2022-10-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e7674f704f2706e22f77c0ed32df9c89302e5e7e";
-  sha256 = "sha256-S7jlje5wd2RiO4+IDjoWUiN19h21DK1sUWlziwxb+3I=";
-}

--- a/manifests/forc-call-0.27.0.nix
+++ b/manifests/forc-call-0.27.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.27.0";
-  date = "2022-10-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "40f1e79de08af109f2ebb066f51704f36094ed1e";
-  sha256 = "sha256-qIso6YBCs4HKu1fAqM0fgq0vcaOqgGeZ2CY0ZLjTm+o=";
-}

--- a/manifests/forc-call-0.28.0.nix
+++ b/manifests/forc-call-0.28.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.28.0";
-  date = "2022-10-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a7978381effcf999adc5726587bf8f711f04e414";
-  sha256 = "sha256-3xqbdGXjWIfdZV7po64bp+N79MGfEkL0fRyKcel0A2s=";
-}

--- a/manifests/forc-call-0.28.1.nix
+++ b/manifests/forc-call-0.28.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.28.1";
-  date = "2022-10-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "84f9aad376760cd9c8eacc8a4848bffeb25bf9a5";
-  sha256 = "sha256-S5sB6ahI7P2Qv4Rh3GTE7lkYcEAbp1znpW/hlkyuh9U=";
-}

--- a/manifests/forc-call-0.29.0.nix
+++ b/manifests/forc-call-0.29.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.29.0";
-  date = "2022-10-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dc8e5f6b84741a3a690ba25b473f8b1e01e31103";
-  sha256 = "sha256-HVGhxE8PgPcCok8BE7ESmlbC3RHAOT6QtdhB0W60D6g=";
-}

--- a/manifests/forc-call-0.3.0.nix
+++ b/manifests/forc-call-0.3.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.3.0";
-  date = "2022-01-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b81eee7d23af71958ba1a3276855949277902a57";
-  sha256 = "sha256-25ZOELcJchuJapvGZFigzsl3BPEUW/R3f5NhvoXBKeE=";
-}

--- a/manifests/forc-call-0.3.1.nix
+++ b/manifests/forc-call-0.3.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.3.1";
-  date = "2022-01-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d9b5a1103a1f37672d6f09c8dae34b813872d44b";
-  sha256 = "sha256-eYVjjBkg6Gxc7mKMl7oaK3Ws2XVDHWAt+z3WIjGM3Xs=";
-}

--- a/manifests/forc-call-0.3.2.nix
+++ b/manifests/forc-call-0.3.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.3.2";
-  date = "2022-01-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3012191420362e9ba1df0324b2a9e80eeded7e1d";
-  sha256 = "sha256-5AirUGidtaNFfVf4uSutfrEvs2wd/ROiDyudYHb2EWQ=";
-}

--- a/manifests/forc-call-0.3.3.nix
+++ b/manifests/forc-call-0.3.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.3.3";
-  date = "2022-01-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "441ab123839f2eb4f5dd1b055fdbe5a5b26a6736";
-  sha256 = "sha256-QI8nqWfKr+/yGP96NnNdpKGwHHzA6UxEyQvjwQLgcSU=";
-}

--- a/manifests/forc-call-0.30.0.nix
+++ b/manifests/forc-call-0.30.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.30.0";
-  date = "2022-11-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "37deaee8fccf5804d78a003cf64f14fac654fc41";
-  sha256 = "sha256-BIVBDX3i2ym6d/90AuK/I/ATtJqUFZS9OdltCdBtqI0=";
-}

--- a/manifests/forc-call-0.30.1.nix
+++ b/manifests/forc-call-0.30.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.30.1";
-  date = "2022-11-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "158f22115bf000d45862be95ff7fdb0ff5bdee4d";
-  sha256 = "sha256-m0y1Zy0iyWCuyqfMhYGQ2myb4zhcZHqLRZIk4ZWZ338=";
-}

--- a/manifests/forc-call-0.31.0.nix
+++ b/manifests/forc-call-0.31.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.31.0";
-  date = "2022-11-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7a389ddb35bae051938e5441c8ef4a8b63dd269c";
-  sha256 = "sha256-fRGQtZxDPD0sPfpt6xKYOaR9Ty1NDqR8El6rRIuU83M=";
-}

--- a/manifests/forc-call-0.31.1.nix
+++ b/manifests/forc-call-0.31.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.31.1";
-  date = "2022-11-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c32b0759d25c0b515cbf535f9fb9b8e6fda38ff2";
-  sha256 = "sha256-5GlH4fTix4r+b66tsE1vx/iyJCsNPnWjfuY7Iu36234=";
-}

--- a/manifests/forc-call-0.31.2.nix
+++ b/manifests/forc-call-0.31.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.31.2";
-  date = "2022-11-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "12239f7d57441a75b0979f2f34d5151a777a5c0a";
-  sha256 = "sha256-9qHs1OatcgPBSLToDkCvTfTXxeAOTjrM1jABQZxqUaI=";
-}

--- a/manifests/forc-call-0.31.3.nix
+++ b/manifests/forc-call-0.31.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.31.3";
-  date = "2022-11-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "12ad8423811d566972dd75fbb954cdb95afde8d8";
-  sha256 = "sha256-vsRRV7NAxSQw+NlZr7dUe2g0Hd8LSjkyXxDiygVfb54=";
-}

--- a/manifests/forc-call-0.32.0.nix
+++ b/manifests/forc-call-0.32.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.32.0";
-  date = "2022-12-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ed1610a2f6bce5fba39ec53fe7da1ba2f05da4ce";
-  sha256 = "sha256-ZteML6BecCLkj7w5fVJcRVxRYpZocpgNXuNRjDszEYc=";
-}

--- a/manifests/forc-call-0.32.1.nix
+++ b/manifests/forc-call-0.32.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.32.1";
-  date = "2022-12-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "50c1b6c858c044acf88760cb7eb1b39d076f322d";
-  sha256 = "sha256-GnF8eHwhcCC0Yr73jNVjyZUh1lOU9YmFslFzeZnSqHo=";
-}

--- a/manifests/forc-call-0.32.2.nix
+++ b/manifests/forc-call-0.32.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.32.2";
-  date = "2022-12-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b9996f13463c324e256014935c053c334b880ab5";
-  sha256 = "sha256-ZCAsObQ50XJnsc64XFB/6ia8fjX3vi4rHug6FuC2ySc=";
-}

--- a/manifests/forc-call-0.33.0.nix
+++ b/manifests/forc-call-0.33.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.33.0";
-  date = "2023-01-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2b2b4b117c4f6a5e762e368af0dfc6896fa31e7d";
-  sha256 = "sha256-K/RT9WFv1uGpBbwckvhcvXPdEnNjluSd2f7CNdjeGhQ=";
-}

--- a/manifests/forc-call-0.33.1.nix
+++ b/manifests/forc-call-0.33.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.33.1";
-  date = "2023-01-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "acd4c1e0fbdc406800a06c845430a80dd3560fcc";
-  sha256 = "sha256-00KVxZUcyCrE4RT2WrmHtxFFFyxLuiD6nJV9PoDzHng=";
-}

--- a/manifests/forc-call-0.34.0.nix
+++ b/manifests/forc-call-0.34.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.34.0";
-  date = "2023-02-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ddb0ede05e649489b554da4f7a8003b507443ad0";
-  sha256 = "sha256-LI/cJybVpg/cpY6vD5YdmlAJkPc0q9hIeGlE4j+YfAc=";
-}

--- a/manifests/forc-call-0.35.0.nix
+++ b/manifests/forc-call-0.35.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.35.0";
-  date = "2023-02-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b6f19a3be7b2fb5ef88e358a926854dac10cb281";
-  sha256 = "sha256-gXmI2j0z7OP3iXMT8F7HNH4Gvei6aFxluYRgbiyU7fo=";
-}

--- a/manifests/forc-call-0.35.1.nix
+++ b/manifests/forc-call-0.35.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.35.1";
-  date = "2023-02-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1f9debfaf9b85d41f3b704c45633eb4daddcb594";
-  sha256 = "sha256-dcPtllP66f7J5YVqY+T9gj9DvOZX1fvZb2EOCi3DsRM=";
-}

--- a/manifests/forc-call-0.35.2.nix
+++ b/manifests/forc-call-0.35.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.35.2";
-  date = "2023-02-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4";
-  sha256 = "sha256-FArhyYdJxGWDkJ0gpVufzbMfsQ4ZHiPqQu/9W3mUWco=";
-}

--- a/manifests/forc-call-0.35.3.nix
+++ b/manifests/forc-call-0.35.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.35.3";
-  date = "2023-02-21";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff";
-  sha256 = "sha256-hHQRdaQR3Qs05VfLc0nJD3lFldGuYTT6XQbszplA3vA=";
-}

--- a/manifests/forc-call-0.35.4.nix
+++ b/manifests/forc-call-0.35.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.35.4";
-  date = "2023-03-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3770dd8c21540e54dee818aa5cbc0a6170102695";
-  sha256 = "sha256-8e10JdvWKDarXNFk5Oyc1I3+5s108M2ck/yLTIlVI5I=";
-}

--- a/manifests/forc-call-0.35.5.nix
+++ b/manifests/forc-call-0.35.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.35.5";
-  date = "2023-03-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "49eae2dd93a1957e2a2c2fb3f51b11eb3791fc24";
-  sha256 = "sha256-RibkxvZno7nLScV14AwnndbzJ29IWTSFQ/xB4PmO5ZE=";
-}

--- a/manifests/forc-call-0.36.0.nix
+++ b/manifests/forc-call-0.36.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.36.0";
-  date = "2023-04-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "77f575ab7921fdb23d5373072272512264bd99f4";
-  sha256 = "sha256-GeQ643/pJahTBmGTtIUl34QH4UCYvfeeQuFXKnlN2Ng=";
-}

--- a/manifests/forc-call-0.36.1.nix
+++ b/manifests/forc-call-0.36.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.36.1";
-  date = "2023-04-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "92818a4d5ec89b5d4fb62196261cf578d58e52e3";
-  sha256 = "sha256-F+qUImoSCv8H90IOpmtdIYSmNdLZivkN/Nm7W3oUdM4=";
-}

--- a/manifests/forc-call-0.37.0.nix
+++ b/manifests/forc-call-0.37.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.37.0";
-  date = "2023-04-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "607ac50176db8bef936f91bacf435d0ea37d041e";
-  sha256 = "sha256-+FrktHUq2mX2u4fl4C9hLrV8fQ9DrSSbpf5umSMHQNw=";
-}

--- a/manifests/forc-call-0.37.1.nix
+++ b/manifests/forc-call-0.37.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.37.1";
-  date = "2023-04-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "83e5479462ed2883591669a42552606ac25f0a04";
-  sha256 = "sha256-fR9E77G2Vc+StVZ/whmnan2/hWZFKPjoRJsJHV2MI5k=";
-}

--- a/manifests/forc-call-0.37.2.nix
+++ b/manifests/forc-call-0.37.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.37.2";
-  date = "2023-04-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dc6af913939698452359474c33ecebe0ad35ca48";
-  sha256 = "sha256-DA3ryR//UYhbX8nSWiA+UL23TyejhfMzTbmFhDte/OY=";
-}

--- a/manifests/forc-call-0.37.3.nix
+++ b/manifests/forc-call-0.37.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.37.3";
-  date = "2023-04-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d09ef912828f5fc7193501ccf8a0d0fb0f36a821";
-  sha256 = "sha256-+s9bBrFC5Mun+FwaYS28Wn9nPyxaACAfiW0tuKRPQvg=";
-}

--- a/manifests/forc-call-0.38.0.nix
+++ b/manifests/forc-call-0.38.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.38.0";
-  date = "2023-04-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2d16d70ab9d5ab0de0255941048f811b6d07c6b1";
-  sha256 = "sha256-xweooodyzG11dWyrrP3MZ6e0vSnkk20svbgbIXkBolw=";
-}

--- a/manifests/forc-call-0.39.0.nix
+++ b/manifests/forc-call-0.39.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.39.0";
-  date = "2023-05-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7a095280e7e1c0bfbbfc201867896e720aab7209";
-  sha256 = "sha256-zUzS+IKW2eNbd3L0lArS4BqJ1bkecnxDN62tCIIvYb8=";
-}

--- a/manifests/forc-call-0.39.1.nix
+++ b/manifests/forc-call-0.39.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.39.1";
-  date = "2023-05-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e3065657c907225a8fdfe2d2210a7a3bd2b55c73";
-  sha256 = "sha256-ytLjZOrHW8XkqzwVRoTPNrzozDF1jmYxxKGVxGqS2G4=";
-}

--- a/manifests/forc-call-0.4.0.nix
+++ b/manifests/forc-call-0.4.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.4.0";
-  date = "2022-02-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6332f9ad955e1f8e744cc87e07d028092874e0d5";
-  sha256 = "sha256-lDyAgfNC5ezqptxuM7lycuVEofI5W62hzY011MzXUt8=";
-}

--- a/manifests/forc-call-0.40.0.nix
+++ b/manifests/forc-call-0.40.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.40.0";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "164c7c8bea3ce264581058d4165df71ee761e0b3";
-  sha256 = "sha256-J3csh7R4IydBXmq3cY/hbHlVWiXcfhkDA9XLSH8PD58=";
-}

--- a/manifests/forc-call-0.40.1.nix
+++ b/manifests/forc-call-0.40.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.40.1";
-  date = "2023-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "48104d0bde0d343154a5bc39a310092532883235";
-  sha256 = "sha256-6qGMJ5W+/b9ZW+IBgvK0FXmDYWk5Yalund1mgb50yPg=";
-}

--- a/manifests/forc-call-0.41.0.nix
+++ b/manifests/forc-call-0.41.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.41.0";
-  date = "2023-06-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0d45b890c9eaa75b88093a9a4cbecbf5ca8c0731";
-  sha256 = "sha256-G9KOf1V44mXHMoqhWHUu68NOywE1pcOIhV1eB2DU44g=";
-}

--- a/manifests/forc-call-0.42.0.nix
+++ b/manifests/forc-call-0.42.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.42.0";
-  date = "2023-07-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c4e4ef7e4ae52a21ae1aa709d1f43ac680987bd1";
-  sha256 = "sha256-6kSeffKJqJCA4jpfFSDFOpu/d15qeh4lk/CYp/qd148=";
-}

--- a/manifests/forc-call-0.42.1.nix
+++ b/manifests/forc-call-0.42.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.42.1";
-  date = "2023-07-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3b66f8e424bd21e3ba467783b10b36e808cfa6ee";
-  sha256 = "sha256-lFBConaiCIcElcN35eZH8WW+opGc2bur+UZkw8wPtTw=";
-}

--- a/manifests/forc-call-0.43.0.nix
+++ b/manifests/forc-call-0.43.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.43.0";
-  date = "2023-08-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3efc60e22b4a7b6898b2cb0c678a36fccbe1b9c9";
-  sha256 = "sha256-V56LmioCJyq50586GqeveEj79Yd1j859BbYW6yJAuow=";
-}

--- a/manifests/forc-call-0.43.1.nix
+++ b/manifests/forc-call-0.43.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.43.1";
-  date = "2023-08-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "923157bcf1dbda7f3a58effcef22fcccd11fcfbc";
-  sha256 = "sha256-/Tr9oexI8EyIQdp45VvaHGGlRc5jyK4B0a/8mUrflnI=";
-}

--- a/manifests/forc-call-0.43.2.nix
+++ b/manifests/forc-call-0.43.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.43.2";
-  date = "2023-08-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d8cf6118405164359fdf420c95cd07342e0eca8b";
-  sha256 = "sha256-g4u8pGUaxRAZ+t3qo5NamSciWDSeQIKZIORvAUcAFuI=";
-}

--- a/manifests/forc-call-0.44.0.nix
+++ b/manifests/forc-call-0.44.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.44.0";
-  date = "2023-08-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "241d30f7cde5cdd1f378eb2bc1daae945f329d0c";
-  sha256 = "sha256-xYpxwBARtWVgLm9yN50/5olOJ8smGCPYZY8kVbrxXuI=";
-}

--- a/manifests/forc-call-0.44.1.nix
+++ b/manifests/forc-call-0.44.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.44.1";
-  date = "2023-08-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "04a597093e7441898933dd412b8e4dc6ac860cd3";
-  sha256 = "sha256-Up8C2e27cM8UYr52jhxA84tNz0CeFpLepH7A/l025v4=";
-}

--- a/manifests/forc-call-0.45.0.nix
+++ b/manifests/forc-call-0.45.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.45.0";
-  date = "2023-08-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "92dc9f361a9508a940c0d0708130f26fa044f6b3";
-  sha256 = "sha256-NUuym7X6HslAVjdq7kPTidzuXlGth+YPY2LBuiokIkw=";
-}

--- a/manifests/forc-call-0.46.0.nix
+++ b/manifests/forc-call-0.46.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.46.0";
-  date = "2023-09-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e75f14b03636bc96751a6760304a1a6d3eb5937d";
-  sha256 = "sha256-mTqo8B7XUbherC9XBpDtlEtjewCxEzn6yC2kmiCFjVI=";
-}

--- a/manifests/forc-call-0.46.1.nix
+++ b/manifests/forc-call-0.46.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.46.1";
-  date = "2023-09-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "512a3386f8961185188302f391ccc96553d23a7a";
-  sha256 = "sha256-pqoyYzUCeyBL0dy0uCSqaMxcR+yqu7ZBUNIMuyQy0EY=";
-}

--- a/manifests/forc-call-0.47.0.nix
+++ b/manifests/forc-call-0.47.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.47.0";
-  date = "2023-11-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "34265301c6037d51444899a99df1cfc563df6016";
-  sha256 = "sha256-lsYDHU3In4tSL8nof1iA+dXemVMP3v56kDJJ+/Tj79A=";
-}

--- a/manifests/forc-call-0.48.0.nix
+++ b/manifests/forc-call-0.48.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.48.0";
-  date = "2023-12-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e451140ce0a804e00de7936d2f569f1df3ec7b21";
-  sha256 = "sha256-gSkH4a213nmk3Tt7UeTBpViLiQnJetVJYekMi/hJEWI=";
-}

--- a/manifests/forc-call-0.48.1.nix
+++ b/manifests/forc-call-0.48.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.48.1";
-  date = "2023-12-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6886ef050ce62afd3fe3186ed562fd33bd76bffa";
-  sha256 = "sha256-qVwtmDqAut7C0Cx0fngAxXpDOIsMV20xx0Hl8cDw4Dg=";
-}

--- a/manifests/forc-call-0.49.0.nix
+++ b/manifests/forc-call-0.49.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.49.0";
-  date = "2024-01-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a17fbf3e7d8dc9845458260c343b4d8f006f3633";
-  sha256 = "sha256-kNy0O+DO9Xnlv41+gTzELqTaKfaYTkghy+wsLFiHm0Q=";
-}

--- a/manifests/forc-call-0.49.1.nix
+++ b/manifests/forc-call-0.49.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.49.1";
-  date = "2024-01-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1";
-  sha256 = "sha256-XPcInwiDCSlwOt5VMYEH3g3hY/o9VvHVvL1q25x2Fkg=";
-}

--- a/manifests/forc-call-0.49.2.nix
+++ b/manifests/forc-call-0.49.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.49.2";
-  date = "2024-02-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a70c746d27b3300beef896ccd1dcce1299836192";
-  sha256 = "sha256-R07m9fTIbsJURYmH1HVFTK87rwp0JwYHnD+vrHH8LTw=";
-}

--- a/manifests/forc-call-0.49.3-patch.1.nix
+++ b/manifests/forc-call-0.49.3-patch.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.49.3-patch.1";
-  date = "2024-03-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0dc6570377ee9c4a6359ade597fa27351e02a728";
-  sha256 = "sha256-wqNERqRNtL0OfQPoJqLDFBB8bMiyA1TIAkTpsdPqrAQ=";
-}

--- a/manifests/forc-call-0.49.3.nix
+++ b/manifests/forc-call-0.49.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.49.3";
-  date = "2024-03-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0dc6570377ee9c4a6359ade597fa27351e02a728";
-  sha256 = "sha256-wqNERqRNtL0OfQPoJqLDFBB8bMiyA1TIAkTpsdPqrAQ=";
-}

--- a/manifests/forc-call-0.5.0.nix
+++ b/manifests/forc-call-0.5.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.5.0";
-  date = "2022-02-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c58c09ffba1719b187a3e1112639eec649eab5e";
-  sha256 = "sha256-11OIZruYjYrylHv8zQOfLW9Fzs0p7aGOWQfq7UQN+5w=";
-}

--- a/manifests/forc-call-0.50.0.nix
+++ b/manifests/forc-call-0.50.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.50.0";
-  date = "2024-02-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "11231184a073a3e9c179d1d2e68c90d205638d45";
-  sha256 = "sha256-C3iFrYeTRgfodJjhHL5LlT++2vu0qW9aAQ40T0ixc9I=";
-}

--- a/manifests/forc-call-0.51.0.nix
+++ b/manifests/forc-call-0.51.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.51.0";
-  date = "2024-02-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "694457da6a507ecee047c1ef8a5865ef4cc07147";
-  sha256 = "sha256-tk75ovG3ZxQCe3f13LNLxiBcQT9nf4ZuoIaip0RQgLQ=";
-}

--- a/manifests/forc-call-0.51.1.nix
+++ b/manifests/forc-call-0.51.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.51.1";
-  date = "2024-02-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d1e8f019c1da46273c3d3a72b385ce356ba2bc20";
-  sha256 = "sha256-bFuBpcZE0CZGmm5wWURhTIZaVSHxL1e0Bs57UhGZWTI=";
-}

--- a/manifests/forc-call-0.52.0.nix
+++ b/manifests/forc-call-0.52.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.52.0";
-  date = "2024-03-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "98d8f4cadbac34f232926b9a44b1170ec9da425d";
-  sha256 = "sha256-toAWqJlcXknCUsU1+sQefUZKtFdwrBFmmGL8/5TE8NI=";
-}

--- a/manifests/forc-call-0.52.1.nix
+++ b/manifests/forc-call-0.52.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.52.1";
-  date = "2024-04-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c1ea517f0522c780ca41120247cde2f450605a3c";
-  sha256 = "sha256-PwKDmmPRGMlNqBMrMycdoFFCvBfD6Ly+mimg3AI4sAI=";
-}

--- a/manifests/forc-call-0.53.0.nix
+++ b/manifests/forc-call-0.53.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.53.0";
-  date = "2024-04-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b30f0e83d3f3d336007e3dfce45a48a87e731345";
-  sha256 = "sha256-PYr3xSTIhBNC1RDbr2IVp6HjHydURhCS3cyBZB1jhuY=";
-}

--- a/manifests/forc-call-0.54.0.nix
+++ b/manifests/forc-call-0.54.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.54.0";
-  date = "2024-04-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d90cbc8419e47283519e39046c3ea5616e64df84";
-  sha256 = "sha256-bI5+vL8dVpAuRMcrznrYhnMUPpax6Q0iC/w7sps3ims=";
-}

--- a/manifests/forc-call-0.55.0.nix
+++ b/manifests/forc-call-0.55.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.55.0";
-  date = "2024-04-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "60ea55e692f4f70730b500735e13c29df2ac727e";
-  sha256 = "sha256-zfIGerybZgEYDqYIWD5r/iQLJFJTzmvoJKqUqmwwF6Q=";
-}

--- a/manifests/forc-call-0.56.0.nix
+++ b/manifests/forc-call-0.56.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.56.0";
-  date = "2024-04-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b495d0df6956524fd68dab7e062df04d2e581ac3";
-  sha256 = "sha256-ag0rl2Q0a+J03SRhj4dh19pbvKVt8PJ83XKkRlDq+vo=";
-}

--- a/manifests/forc-call-0.56.1.nix
+++ b/manifests/forc-call-0.56.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.56.1";
-  date = "2024-05-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4a63b41de136ab68bdf396c6720708fbf4dca83e";
-  sha256 = "sha256-FW8P8+dujrVbUz1YyL+OSzOmpsDy1Ggaf3S6U4fHDtk=";
-}

--- a/manifests/forc-call-0.57.0.nix
+++ b/manifests/forc-call-0.57.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.57.0";
-  date = "2024-05-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8148817c02b0015ac3f299a8935f9a73d395a35e";
-  sha256 = "sha256-jwTGhefYuJybXizPV/TLWQ60JNGSzyexzYTHk4lVDQU=";
-}

--- a/manifests/forc-call-0.58.0.nix
+++ b/manifests/forc-call-0.58.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.58.0";
-  date = "2024-05-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "9579dd2f77c8597995d6d7d2995640c26cfb3fe4";
-  sha256 = "sha256-3KqSYUixgLALy+eZWxOyjjwJR/mXpdUaygPGdEnSYlA=";
-}

--- a/manifests/forc-call-0.59.0.nix
+++ b/manifests/forc-call-0.59.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.59.0";
-  date = "2024-05-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d9985d8111f94235edba9a08fc71a9513ec2a95c";
-  sha256 = "sha256-eXTLIonA9dyRCed1vUGsR8nrjq7Dm3T/eKdQ95+iqUs=";
-}

--- a/manifests/forc-call-0.6.0.nix
+++ b/manifests/forc-call-0.6.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.6.0";
-  date = "2022-03-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "35e5a2f12e137953b82470e9637e4969ca064e4a";
-  sha256 = "sha256-HKmNBduWtyIoaUwkj2Nu9GznUOoZFctcaRhFJOnTWLY=";
-}

--- a/manifests/forc-call-0.6.1.nix
+++ b/manifests/forc-call-0.6.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.6.1";
-  date = "2022-03-10";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3268092ce50e5058b11a5ea2e7f35c6e19352d68";
-  sha256 = "sha256-JOH4UosK8x7FmMqx2qkEqWnyO+z9XPl1C/BrnXWz4uw=";
-}

--- a/manifests/forc-call-0.60.0.nix
+++ b/manifests/forc-call-0.60.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.60.0";
-  date = "2024-05-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2f0392ee35a1e4dd80bd8034962d5b4083dfb8b6";
-  sha256 = "sha256-2y1wRiRnY8Z5lgnIeu6BYQFVtJPHmDpaeHZVceeqjiA=";
-}

--- a/manifests/forc-call-0.61.0.nix
+++ b/manifests/forc-call-0.61.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.61.0";
-  date = "2024-06-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4b4fb53eb2ef3390a0186a7048b060ff8e973a15";
-  sha256 = "sha256-lM9Hzl70uO/QtOhDf6hN4ulOFSo9M5UaVTK22Y6rjJc=";
-}

--- a/manifests/forc-call-0.61.1.nix
+++ b/manifests/forc-call-0.61.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.61.1";
-  date = "2024-07-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d86bb863697550b76f9209894e7a4ed84d1a8f39";
-  sha256 = "sha256-O/KRqfnTeS2Z01GvCiCzu/Iwg/ccC+Tp/MO9mjY9wf0=";
-}

--- a/manifests/forc-call-0.61.2.nix
+++ b/manifests/forc-call-0.61.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.61.2";
-  date = "2024-07-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e1b1c2bee73e0ba825e07736cefa6c0abd079595";
-  sha256 = "sha256-HOmwpzWp02DkXK+wiL2vCvuOKdFQNlPEvxMLGgfL11I=";
-}

--- a/manifests/forc-call-0.62.0.nix
+++ b/manifests/forc-call-0.62.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.62.0";
-  date = "2024-07-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "efda0397c7bee77de73bd726ec0b732d57614973";
-  sha256 = "sha256-24306qdH3UupJ8iGYcCAJRmWow7o/0e1ym7htSRPTjE=";
-}

--- a/manifests/forc-call-0.63.0.nix
+++ b/manifests/forc-call-0.63.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.63.0";
-  date = "2024-08-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "da9b3230706bfbe6e4efec179b7ddc0322909b57";
-  sha256 = "sha256-P5zhjVT5uwYcdprPN6gZ6UbiML0KLkw4CwNOkBlCIAE=";
-}

--- a/manifests/forc-call-0.63.1.nix
+++ b/manifests/forc-call-0.63.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.63.1";
-  date = "2024-08-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "169f91ae0a6a698bd1cb459c4c203bab646a38ec";
-  sha256 = "sha256-/9medkNesN+JuYEBasGDmhzZEMeCC4PVh2VKrTkb8NI=";
-}

--- a/manifests/forc-call-0.63.2.nix
+++ b/manifests/forc-call-0.63.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.63.2";
-  date = "2024-08-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a9e83955bcb50aa1a8b95d04235066b3dd34c9c4";
-  sha256 = "sha256-mCFw0F0HC4hrNUdnfMePO1DSWQE/CvKpXbdMwbq4RQQ=";
-}

--- a/manifests/forc-call-0.63.3.nix
+++ b/manifests/forc-call-0.63.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.63.3";
-  date = "2024-08-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f55c81cce61aac31913ac0e87306cbaed7da679a";
-  sha256 = "sha256-SLdimVN0rjpKrWcAF3Kg3+DgyGT/zbkvePIdZrayH6Q=";
-}

--- a/manifests/forc-call-0.63.4.nix
+++ b/manifests/forc-call-0.63.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.63.4";
-  date = "2024-09-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2538442a67f893f2e878214ba37a11b51f4ed41e";
-  sha256 = "sha256-TA4HerMYUBunE+wyPwYS3z9ziSThJdEAcX81Hx8VZSI=";
-}

--- a/manifests/forc-call-0.63.5.nix
+++ b/manifests/forc-call-0.63.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.63.5";
-  date = "2024-09-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "31a1d6f98395f571cd3674b492d9bf4773c55f65";
-  sha256 = "sha256-WZkfaz+4mU3TydLoBxoaKdzMCLPq8hISg0GCmFujuh4=";
-}

--- a/manifests/forc-call-0.63.6.nix
+++ b/manifests/forc-call-0.63.6.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.63.6";
-  date = "2024-09-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "cba9a005ef2a5b61e13eb02ba6e9e93ebd19a31a";
-  sha256 = "sha256-9JH/vWzDBAMENzp7gFtSrP68AimsrmqfEhRaS6Aw6TM=";
-}

--- a/manifests/forc-call-0.64.0.nix
+++ b/manifests/forc-call-0.64.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.64.0";
-  date = "2024-09-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2156bfbbee01ffb85bfca2aae8f185f8e7c715a4";
-  sha256 = "sha256-HtzITm4CMH3td35GSGTCzcBzUSjzH/TAu7SwEzjbA3c=";
-}

--- a/manifests/forc-call-0.65.0.nix
+++ b/manifests/forc-call-0.65.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.65.0";
-  date = "2024-10-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "32d1cc91dc3cf8fbda12fe217e563b139feef8a7";
-  sha256 = "sha256-Et4e/N8pKQdrMH9g5ZrAqsk++2n40mv/iTVx4p5PuUM=";
-}

--- a/manifests/forc-call-0.65.1.nix
+++ b/manifests/forc-call-0.65.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.65.1";
-  date = "2024-10-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3a9c171cd43611d7ccad94ab66a5093c6634717b";
-  sha256 = "sha256-6KoM3dIOS+6HJ8/mfQtzeX8efrRc3EjcXpU32RAmXiU=";
-}

--- a/manifests/forc-call-0.65.2.nix
+++ b/manifests/forc-call-0.65.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.65.2";
-  date = "2024-10-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "66bb430395daf5b8f7205f7b9d8d008e2e812d54";
-  sha256 = "sha256-J1/9pvWYBdZY4vPd9T0MGsg2g6OtZQG4KWk8QlKVtG8=";
-}

--- a/manifests/forc-call-0.66.0.nix
+++ b/manifests/forc-call-0.66.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.0";
-  date = "2024-10-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b7e59f42aebed08c2e015cbd5d0776c8953fc57f";
-  sha256 = "sha256-9iIlZi2eMIcyGylR9mkXANaBcfOJk308f3DArLwjDGM=";
-}

--- a/manifests/forc-call-0.66.1.nix
+++ b/manifests/forc-call-0.66.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.1";
-  date = "2024-10-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d5662c6bd0e5519446aa1b3ebb6af703025accec";
-  sha256 = "sha256-Uf8qe94rUZhInAM/o0ue/W5vNW1bpubqYaWt6OVE2Aw=";
-}

--- a/manifests/forc-call-0.66.10.nix
+++ b/manifests/forc-call-0.66.10.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.10";
-  date = "2025-03-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6c00a44822ce2bec4d0754ef285566a8b8de72fb";
-  sha256 = "sha256-cfFsArmLkpXUvwO3Jf3KkFYU7MmMyxEbVUEsUvzZtpA=";
-}

--- a/manifests/forc-call-0.66.2.nix
+++ b/manifests/forc-call-0.66.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.2";
-  date = "2024-10-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "31486c0b47669612acb7c64d66ecb50aea281282";
-  sha256 = "sha256-k/53TarSPDFgljkqMb41ecV+aiqWDNwzZRBoPk4Itps=";
-}

--- a/manifests/forc-call-0.66.3.nix
+++ b/manifests/forc-call-0.66.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.3";
-  date = "2024-10-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5b7d720cf97e88eedc3c069b617ee7493bb16637";
-  sha256 = "sha256-35bHX4r/WB3peaTJ5qK2TV3xRtxx5nBxUpDA+4oOlm4=";
-}

--- a/manifests/forc-call-0.66.4.nix
+++ b/manifests/forc-call-0.66.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.4";
-  date = "2024-11-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d7dd104dac4394aa7af56f05b720c975744db853";
-  sha256 = "sha256-lpX7PSEE+glDj7284dRC7KtU4yIfjRnQZnySaTL+AQc=";
-}

--- a/manifests/forc-call-0.66.5.nix
+++ b/manifests/forc-call-0.66.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.5";
-  date = "2024-11-21";
-  url = "https://github.com/fuellabs/sway";
-  rev = "94a066652468b4afa3bd396dacef482ed590976b";
-  sha256 = "sha256-+8fwP6jkBr5hyzDBZmcAXDq8ciu5PrsZDmDrA8gEzA0=";
-}

--- a/manifests/forc-call-0.66.6.nix
+++ b/manifests/forc-call-0.66.6.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.6";
-  date = "2025-01-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "986aee2c1e34c9cd958c81e7fd6b84638b26619b";
-  sha256 = "sha256-O4pyhoFbxQ5O00OH8DZZTns3l4QGGFvr3gmqanToMD8=";
-}

--- a/manifests/forc-call-0.66.7.nix
+++ b/manifests/forc-call-0.66.7.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.7";
-  date = "2025-02-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5ed7cec6dbcd42f0c2f84df8511a4c0007b1902e";
-  sha256 = "sha256-xuyG/6Kkr4w1lKTb4VkdC/zf5+RaC9HfgOYcsJmV2sc=";
-}

--- a/manifests/forc-call-0.66.8.nix
+++ b/manifests/forc-call-0.66.8.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.8";
-  date = "2025-03-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ba46576c8601aadf23532de001375879f72f109b";
-  sha256 = "sha256-95FNf10T4HmIV2Uj6hHps4SQduIKS7pMEeTgaVxSKQk=";
-}

--- a/manifests/forc-call-0.66.9.nix
+++ b/manifests/forc-call-0.66.9.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.66.9";
-  date = "2025-03-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ef377e78bf597ea3b324f6b021a105b232d1cd98";
-  sha256 = "sha256-3yeZrK2+x+apfQ7GyebOT65TgPNqrwB7Wsr+dve6H0Q=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-01.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-01.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4eb0705fce706299c8d2efcf967edd58a9679fca";
-  sha256 = "sha256-+w495nHeddHIj3hBbl34nE3nnFuEtUZEDefV3uqhyJQ=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-02.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "34aa19ca86fe1b5b5eea87ef0d13708bd62796c2";
-  sha256 = "sha256-W3cgYBZ16gmKjHniHklMcaHJqQ2VgK+89uUs217uBP8=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-03.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-03.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c1b63c87b21452d51d2b3244328d1ca9cb9dc3ef";
-  sha256 = "sha256-wf0YdiVZM+lPcm3rN3TxIfz/uesiElQ0BAec2iktleE=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-04.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-04.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f11c5cd6cdff86b1bd106cd0fb86604a5d350720";
-  sha256 = "sha256-Xjr1c1HAqytooSuDLvtVIoCo1xGB8sxl2O2MNCCcfUY=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-05.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-05.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8e162c9661fb566255cad6113a8cfcda8d7d7dca";
-  sha256 = "sha256-NojfLZBf5CSPp7JQvgiG1GWfsF9DCYUt5uufOEQJzf8=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-08.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-08.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b59e1b627d0e8f1f904c28d681ccc66cf2830542";
-  sha256 = "sha256-8aMBJhA+64WeAh+JEOkFvAG2F1xI6mBiC7D8ZDOkrrA=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-09.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-09.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1c68f1c9e0cc7ec34a7195e11d92891290aaa8de";
-  sha256 = "sha256-m9c+pCaoYwWLQi7cDuMLJm7xqI1PFs/bJ6X/8JN0Wbg=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-10.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-10.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-10";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4d18d527495483af3c7d81543da347cfaa236147";
-  sha256 = "sha256-sMQnl/QZVpkJnOsYDw322ERey+SNB9Fe4nev4Wk/Fro=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-11.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-11.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ba3a0d56352ed7a95c7f901ab094954d003e7098";
-  sha256 = "sha256-AyhTCZke7FbmJn5O53ZElsUXsQqvfLyf2J7uvluqoNo=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-14.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-14.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f4477cfb909e6d153133df352c147d4ee2ad6f3f";
-  sha256 = "sha256-vIoJ8iW3NC278+VnhaSwb7GrcBGIdHmLsbWc6Y53RL0=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-15.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-15.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8c132f1b56afa491e044147c647bec1059c9ef81";
-  sha256 = "sha256-nUp9I2y6b8BVKdlVUD0PWOKrMo0CJynSyyZxd3saav4=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-16.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-16.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-16";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ddec15af093f6be7f0ef983dbd1040764c7e2bf8";
-  sha256 = "sha256-JLTmnhL1eLG7iynyr0ulHqOllmJH9sdFqb/24KZJeIE=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-17.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-17.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8c2af95cc36dc034a4e21669ae6b8d5e49eadbca";
-  sha256 = "sha256-P0LOySjweT23bu4xycNzUZv6D18IGglouTRERecGDEg=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-18.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-18.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "3afc5c18c87b82ac00ffd38a81de01d534af087b";
-  sha256 = "sha256-+MWlXlp7dJXv8gY+qZ8wNvxa8U9u7J1Uhlxl654uw8A=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-20.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-20.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-20";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7cb78097d0bfbed1e3196639c2aff50a2c02666b";
-  sha256 = "sha256-FznW8ID2ykfvqBkCRn96vC3hharM6SWoX6VUpv6OxIM=";
-}

--- a/manifests/forc-call-0.67.0-nightly-2025-04-22.nix
+++ b/manifests/forc-call-0.67.0-nightly-2025-04-22.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-04-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f607a674e303bc497887beab06f022127cfd67b7";
-  sha256 = "sha256-ABQBvGxHTZX5KzSzg+VXUIVZShBRuSVTDq742WP/Q5I=";
-}

--- a/manifests/forc-call-0.67.0.nix
+++ b/manifests/forc-call-0.67.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.0";
-  date = "2025-03-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d821dcb0c7edb1d6e2a772f5a1ccefe38902eaec";
-  sha256 = "sha256-PgElgNdhBb/moj5GTMT+uwhWMDOdPzRe37y4V7MTIYc=";
-}

--- a/manifests/forc-call-0.67.1-nightly-2025-04-23.nix
+++ b/manifests/forc-call-0.67.1-nightly-2025-04-23.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.1";
-  date = "2025-04-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6a896339a688eb4e0ddb2e966e8164f05742ca71";
-  sha256 = "sha256-WUkC6JVB1NGHXXvmkHqkhzZ4K+ezhsvpVdqlvAQ3REM=";
-}

--- a/manifests/forc-call-0.67.1.nix
+++ b/manifests/forc-call-0.67.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.1";
-  date = "2025-04-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6a896339a688eb4e0ddb2e966e8164f05742ca71";
-  sha256 = "sha256-WUkC6JVB1NGHXXvmkHqkhzZ4K+ezhsvpVdqlvAQ3REM=";
-}

--- a/manifests/forc-call-0.67.2.nix
+++ b/manifests/forc-call-0.67.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.67.2";
-  date = "2025-04-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "58a77073382e6992a40f21ed89dc4ea4d46010b1";
-  sha256 = "sha256-BcTIuM6CazfMsjmubcuFsL0KC5JaVHyYn2UawLiyosc=";
-}

--- a/manifests/forc-call-0.68.0-nightly-2025-04-24.nix
+++ b/manifests/forc-call-0.68.0-nightly-2025-04-24.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.0";
-  date = "2025-04-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "cbe8005a2388ec481d557aa4a58d7df96be9cad0";
-  sha256 = "sha256-Oqp9k6fdhu0jIn/OTcZYwFRGOoL4neFmNkDkS48Nsc0=";
-}

--- a/manifests/forc-call-0.68.0.nix
+++ b/manifests/forc-call-0.68.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.0";
-  date = "2025-04-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "cbe8005a2388ec481d557aa4a58d7df96be9cad0";
-  sha256 = "sha256-Oqp9k6fdhu0jIn/OTcZYwFRGOoL4neFmNkDkS48Nsc0=";
-}

--- a/manifests/forc-call-0.68.1-nightly-2025-04-25.nix
+++ b/manifests/forc-call-0.68.1-nightly-2025-04-25.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.1";
-  date = "2025-04-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5f999595d377c2de6111836249614bae031d562e";
-  sha256 = "sha256-Zfm1ImQ7w8igCFcXduW9rZ2etU/femHbxwPdVNd6/5s=";
-}

--- a/manifests/forc-call-0.68.1-nightly-2025-04-26.nix
+++ b/manifests/forc-call-0.68.1-nightly-2025-04-26.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.1";
-  date = "2025-04-26";
-  url = "https://github.com/fuellabs/sway";
-  rev = "eb57cbf2849ed118f8f403954b545fd4d08a3643";
-  sha256 = "sha256-w0r9OpTG1gSYk8xx53VLqA5fP6MzPJ6IWsHQdqwwhis=";
-}

--- a/manifests/forc-call-0.68.1-nightly-2025-04-29.nix
+++ b/manifests/forc-call-0.68.1-nightly-2025-04-29.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.1";
-  date = "2025-04-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "76268dcff70744288297a778aae46df77eb5a2a7";
-  sha256 = "sha256-7EEPnkERP5rkcekMiBMP8kmh6oBIcCP+NiNn5aGWKCE=";
-}

--- a/manifests/forc-call-0.68.1-nightly-2025-04-30.nix
+++ b/manifests/forc-call-0.68.1-nightly-2025-04-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.1";
-  date = "2025-04-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "26e2ef875c10d7bab696c28f2127073422a7da15";
-  sha256 = "sha256-qKjgPESiwmz9ZC6rOIvVAsiFkkrc6FBSMC3xwkFZghA=";
-}

--- a/manifests/forc-call-0.68.1-nightly-2025-05-01.nix
+++ b/manifests/forc-call-0.68.1-nightly-2025-05-01.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.1";
-  date = "2025-05-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "42321ef0e0eef3e4de690759d3d197a21a8a7aa0";
-  sha256 = "sha256-tOjGwpoTNuRQvApDngxGrDHDAdao8p8mQ3VVbBJ4Arg=";
-}

--- a/manifests/forc-call-0.68.1.nix
+++ b/manifests/forc-call-0.68.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.1";
-  date = "2025-04-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7e1bc152face6f1ae20b4274d98446100920e573";
-  sha256 = "sha256-ME7GHU+Y9nrVJiI6OaHMyyPcPQYB57afi4/TAmx1Mcs=";
-}

--- a/manifests/forc-call-0.68.2-nightly-2025-05-02.nix
+++ b/manifests/forc-call-0.68.2-nightly-2025-05-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "05480bb07ed7b62e4123a2696ba22bce57ffb049";
-  sha256 = "sha256-12BK6qvONpLLM37jGY0lDfhHN+JT5TgjQfIueJrkY9E=";
-}

--- a/manifests/forc-call-0.68.2-nightly-2025-05-03.nix
+++ b/manifests/forc-call-0.68.2-nightly-2025-05-03.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "324f04fbab358a8e7eb729d03e0293605755ba5a";
-  sha256 = "sha256-0gh3Yi3GUWf6QmXUtVPyIzJd8MjGBJtI5qLUu40txHM=";
-}

--- a/manifests/forc-call-0.68.2-nightly-2025-05-06.nix
+++ b/manifests/forc-call-0.68.2-nightly-2025-05-06.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "804d6df0d9c950dbdfc887e2ca6dc39be3abc23a";
-  sha256 = "sha256-ioawcNFkhCeo0rMk5xL0gABv7ipkeWha35fS9Z6vlqc=";
-}

--- a/manifests/forc-call-0.68.2-nightly-2025-05-07.nix
+++ b/manifests/forc-call-0.68.2-nightly-2025-05-07.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f635cc22ead32fedc2e0bcb1ed43f51f1c63090f";
-  sha256 = "sha256-D6iuParzkjmyMjrUHmemvdtQgbaSaWeFhxQgvwKNhDQ=";
-}

--- a/manifests/forc-call-0.68.2-nightly-2025-05-08.nix
+++ b/manifests/forc-call-0.68.2-nightly-2025-05-08.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8fb7a55f2145f2012d2d2df82b790e44a76106a1";
-  sha256 = "sha256-Cq9aCSoap1QiqmIDLeqnAP6Uu1vx0A6tsDfD3jVz3W8=";
-}

--- a/manifests/forc-call-0.68.2-nightly-2025-05-09.nix
+++ b/manifests/forc-call-0.68.2-nightly-2025-05-09.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "bd3813606ad2c4685ae979c7d4443573642c929d";
-  sha256 = "sha256-SQX3NYAWZDIGwYpzgx8i+4IWemHPn4Y+L1m4AY7el4Q=";
-}

--- a/manifests/forc-call-0.68.2-nightly-2025-05-10.nix
+++ b/manifests/forc-call-0.68.2-nightly-2025-05-10.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-10";
-  url = "https://github.com/fuellabs/sway";
-  rev = "dffa29c5994988a2f7202793363c91a9e9476ee9";
-  sha256 = "sha256-JXrQ9pL2fCkycFlYl77ZapokfPSLIAsQB3ouApH3jaw=";
-}

--- a/manifests/forc-call-0.68.2-nightly-2025-05-13.nix
+++ b/manifests/forc-call-0.68.2-nightly-2025-05-13.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7386b19846863ae6252800270587815520adc750";
-  sha256 = "sha256-xT9wiL5n3PUSOWO0Bu56rhj09inWUNGJBKFuZ+B9y5I=";
-}

--- a/manifests/forc-call-0.68.2.nix
+++ b/manifests/forc-call-0.68.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.2";
-  date = "2025-05-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "05480bb07ed7b62e4123a2696ba22bce57ffb049";
-  sha256 = "sha256-12BK6qvONpLLM37jGY0lDfhHN+JT5TgjQfIueJrkY9E=";
-}

--- a/manifests/forc-call-0.68.3-nightly-2025-05-14.nix
+++ b/manifests/forc-call-0.68.3-nightly-2025-05-14.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.3";
-  date = "2025-05-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "be7a9698b1a751d91045d7492336e10912fdc376";
-  sha256 = "sha256-g+EP0CEsXlV6JjehFcZiNDkdXgLEx2qQb9nVSWALJH8=";
-}

--- a/manifests/forc-call-0.68.3.nix
+++ b/manifests/forc-call-0.68.3.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.3";
-  date = "2025-05-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "48d95fc22eaeb700cf6cc52f17f3087a7a17693a";
-  sha256 = "sha256-wJfPIkI0QSyqiiA9Mp+Vq7yfPS+v6+6rAlRlxE10trY=";
-}

--- a/manifests/forc-call-0.68.4-nightly-2025-05-15.nix
+++ b/manifests/forc-call-0.68.4-nightly-2025-05-15.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.4";
-  date = "2025-05-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "39251b665b110e6cbe85f312135eaeb97738583f";
-  sha256 = "sha256-5pAFmTLLHjcINfJHClHQiOAFLAVAF37GilM7P5PSBTc=";
-}

--- a/manifests/forc-call-0.68.4-nightly-2025-05-18.nix
+++ b/manifests/forc-call-0.68.4-nightly-2025-05-18.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.4";
-  date = "2025-05-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0e3d949dbf3c7346f990738dba99cdd64f079ffd";
-  sha256 = "sha256-kcaCOTbiviYKwT7KWwJAENixqj5FPOukU6SwYfhAF+c=";
-}

--- a/manifests/forc-call-0.68.4-nightly-2025-05-20.nix
+++ b/manifests/forc-call-0.68.4-nightly-2025-05-20.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.4";
-  date = "2025-05-20";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a4283762afbb19720c1976edc3952ea015506f1a";
-  sha256 = "sha256-kerOcUFqrRGfWXL9tx2fQoMgvhiqTgJeEsBBOQbfTXM=";
-}

--- a/manifests/forc-call-0.68.4.nix
+++ b/manifests/forc-call-0.68.4.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.4";
-  date = "2025-05-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1fb61fdc42054109c54a57544b9aeb88afd3cae8";
-  sha256 = "sha256-gMxxjQGCNyB2H9kAvk8BTGpu6PNkUyfFRIjmxBK4Erg=";
-}

--- a/manifests/forc-call-0.68.5-nightly-2025-05-21.nix
+++ b/manifests/forc-call-0.68.5-nightly-2025-05-21.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.5";
-  date = "2025-05-21";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5a95c65b61f098897d8e46f25f722f636fe127e0";
-  sha256 = "sha256-NUItVZ/577fYObUjchf5/mKTppuiv9Xxax+omZ1rk7o=";
-}

--- a/manifests/forc-call-0.68.5-nightly-2025-05-23.nix
+++ b/manifests/forc-call-0.68.5-nightly-2025-05-23.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.5";
-  date = "2025-05-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ee565f9145f072001b0cf10f58f838cb2566e934";
-  sha256 = "sha256-juA6XgvN12UzmE8Vvfrf0icEeXBqDLEWA2cjRpqZrqU=";
-}

--- a/manifests/forc-call-0.68.5-nightly-2025-05-24.nix
+++ b/manifests/forc-call-0.68.5-nightly-2025-05-24.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.5";
-  date = "2025-05-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c8625a029c588fcd8d4ffbfcee08326cfbf5b703";
-  sha256 = "sha256-rvhRnyTjJ9bg+swsz0JkwfrPGgoPMvt5Q/xU4H9fuHQ=";
-}

--- a/manifests/forc-call-0.68.5-nightly-2025-05-27.nix
+++ b/manifests/forc-call-0.68.5-nightly-2025-05-27.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.5";
-  date = "2025-05-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d972e423ac65442611cb6bec06693f0cd263b8a6";
-  sha256 = "sha256-dE8cXbZzXemKYllz/Kzkss8jyor0qSBH7Hk3irEBc+M=";
-}

--- a/manifests/forc-call-0.68.5-nightly-2025-05-28.nix
+++ b/manifests/forc-call-0.68.5-nightly-2025-05-28.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.5";
-  date = "2025-05-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f03d5ecdb0e63c66b5391fc907a5a272300a294a";
-  sha256 = "sha256-D/xec8B/hC0136GPS+n24aLscvptlTfITYYhGOF9+4A=";
-}

--- a/manifests/forc-call-0.68.5.nix
+++ b/manifests/forc-call-0.68.5.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.5";
-  date = "2025-05-20";
-  url = "https://github.com/fuellabs/sway";
-  rev = "512bbfccdb15a0045576604ba97d7943c9b7520f";
-  sha256 = "sha256-BpBo/uJd52ahBSzRYXpLk3cfNV4hjH3J/ZszRfWCNM0=";
-}

--- a/manifests/forc-call-0.68.6-nightly-2025-05-29.nix
+++ b/manifests/forc-call-0.68.6-nightly-2025-05-29.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.6";
-  date = "2025-05-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ac5280641599d4e81017e18d04e47380722074ed";
-  sha256 = "sha256-ZUYUeHtlLguGmwkdKE/HFgg47zWKhudM8J2JqC44F+Q=";
-}

--- a/manifests/forc-call-0.68.6-nightly-2025-05-30.nix
+++ b/manifests/forc-call-0.68.6-nightly-2025-05-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.6";
-  date = "2025-05-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "2d0021c20bf348aaf5ae7ee41ac8dd610ba48cea";
-  sha256 = "sha256-SfAzslGTI61qClSQzDlTI/ymcUJDUnVIR1AvkGnKuGo=";
-}

--- a/manifests/forc-call-0.68.6-nightly-2025-05-31.nix
+++ b/manifests/forc-call-0.68.6-nightly-2025-05-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.6";
-  date = "2025-05-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d6804729c962513736253f377f25a323492ded93";
-  sha256 = "sha256-bvH+zuVN1AgA5b21X5gkNa5TWYRIWRcZrlJ8KKtIFVU=";
-}

--- a/manifests/forc-call-0.68.6-nightly-2025-06-03.nix
+++ b/manifests/forc-call-0.68.6-nightly-2025-06-03.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.6";
-  date = "2025-06-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e1e51fd81fa16872888a6f5ec25b9125181ca89a";
-  sha256 = "sha256-j7GLeNt0l5vexHU78M5n9mgDZyYH3CteqMh9yQZ2oDU=";
-}

--- a/manifests/forc-call-0.68.6-nightly-2025-06-04.nix
+++ b/manifests/forc-call-0.68.6-nightly-2025-06-04.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.6";
-  date = "2025-06-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0ac62945305079d94366062f1928293cefbe9dbf";
-  sha256 = "sha256-xVyqCswbWWKSjVYWiyH19eFHcRZl/Z2PYxN1G6cZEIk=";
-}

--- a/manifests/forc-call-0.68.6.nix
+++ b/manifests/forc-call-0.68.6.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.6";
-  date = "2025-05-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "ac5280641599d4e81017e18d04e47380722074ed";
-  sha256 = "sha256-ZUYUeHtlLguGmwkdKE/HFgg47zWKhudM8J2JqC44F+Q=";
-}

--- a/manifests/forc-call-0.68.7-nightly-2025-06-05.nix
+++ b/manifests/forc-call-0.68.7-nightly-2025-06-05.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.7";
-  date = "2025-06-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "58bf38ef9c737edbd677d2e0c5e5f32e8353ea00";
-  sha256 = "sha256-1T2N3nbh16xaewOrHjAtnbWvMADJcsT6DToPOmGyh/M=";
-}

--- a/manifests/forc-call-0.68.7-nightly-2025-06-06.nix
+++ b/manifests/forc-call-0.68.7-nightly-2025-06-06.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.7";
-  date = "2025-06-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "fe8a3ef37a8a138e2c6aa583ae9ebb67c876a500";
-  sha256 = "sha256-XFndqF78eXbmshZCZsbpKtjEwSEVVR+saxbXdJUTe4k=";
-}

--- a/manifests/forc-call-0.68.7-nightly-2025-06-11.nix
+++ b/manifests/forc-call-0.68.7-nightly-2025-06-11.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.7";
-  date = "2025-06-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "14dc75275479666ddbfc3ade6a70333388a338a9";
-  sha256 = "sha256-utIIwK4kzlqWDDYbV5Ord/Xdw1ptb32UJEA7f+w/3SY=";
-}

--- a/manifests/forc-call-0.68.7-nightly-2025-06-12.nix
+++ b/manifests/forc-call-0.68.7-nightly-2025-06-12.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.7";
-  date = "2025-06-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0e24afdc4fc4e7d8b463a9f264cc68d0e1522655";
-  sha256 = "sha256-5TnV7w7vg/WYp5WEh0LszwUR0UHH0oFHPXq+iKsGuGM=";
-}

--- a/manifests/forc-call-0.68.7-nightly-2025-06-14.nix
+++ b/manifests/forc-call-0.68.7-nightly-2025-06-14.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.7";
-  date = "2025-06-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e0724422c6a867b15c1ff0e3f1bf85f445bc59e4";
-  sha256 = "sha256-9GtBz+XdwsKpipMJh3wHIcky7N+5wXXeGpM51K++7bc=";
-}

--- a/manifests/forc-call-0.68.7-nightly-2025-06-18.nix
+++ b/manifests/forc-call-0.68.7-nightly-2025-06-18.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.7";
-  date = "2025-06-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "cd89f62ece16b3d4ff37dbbd07d68ec056f18a6e";
-  sha256 = "sha256-FRhXivoZUnUDbY0XRh7/XXyz0D2KHycu/vtZeGjctTY=";
-}

--- a/manifests/forc-call-0.68.7-nightly-2025-06-19.nix
+++ b/manifests/forc-call-0.68.7-nightly-2025-06-19.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.7";
-  date = "2025-06-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b9ac2a9bdb2069b1c70637be4e2d4ae93361c73f";
-  sha256 = "sha256-yxzmVuW3N7RV7L6qNDgA/2UMR3qjvwa3fCbRQLFXNnM=";
-}

--- a/manifests/forc-call-0.68.7.nix
+++ b/manifests/forc-call-0.68.7.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.7";
-  date = "2025-06-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "58bf38ef9c737edbd677d2e0c5e5f32e8353ea00";
-  sha256 = "sha256-1T2N3nbh16xaewOrHjAtnbWvMADJcsT6DToPOmGyh/M=";
-}

--- a/manifests/forc-call-0.68.8-nightly-2025-06-20.nix
+++ b/manifests/forc-call-0.68.8-nightly-2025-06-20.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.8";
-  date = "2025-06-20";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b2028431508c0ff64b97de4998a15d214b56e0eb";
-  sha256 = "sha256-nbUx/CRvR/k/o14fduZNy+aE8g7bfiNTq6GHD2T7pJI=";
-}

--- a/manifests/forc-call-0.68.8-nightly-2025-06-22.nix
+++ b/manifests/forc-call-0.68.8-nightly-2025-06-22.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.8";
-  date = "2025-06-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "83154ab6615d70479a11df50e7ea25733a8222cc";
-  sha256 = "sha256-LiIlx3TwVKWegJNHnd942lPTtW9ImkPxBQULb3FCH2I=";
-}

--- a/manifests/forc-call-0.68.8.nix
+++ b/manifests/forc-call-0.68.8.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.8";
-  date = "2025-06-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "93ae73db745a60dfd782b340ca21804bdde54aeb";
-  sha256 = "sha256-JwKPK9Dyjb/ZgVwz2+7hybLzU6PqY8KKBz8MMQeyJVQ=";
-}

--- a/manifests/forc-call-0.68.9.nix
+++ b/manifests/forc-call-0.68.9.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.68.9";
-  date = "2025-06-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e054b396280942cb43a40bbc0b3a9b8cc30237ed";
-  sha256 = "sha256-a+P/SqwMkQ0aDbaJH9VWNSxbvDBl4v6S5yb6HMuXABY=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-06-24.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-06-24.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-06-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c22e3398756548f8b6dbbe32c6dbd7d6d77451c";
-  sha256 = "sha256-0HIFZcZQvA/QxJNkBTQyMLSapTjFhUQAaUyRY3ZdA9M=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-06-28.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-06-28.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-06-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c37dc92952247c1366d26702e6f72ee1dc77d046";
-  sha256 = "sha256-ilGTFqb+5/rI8ya8E0K+BHR8Us3cVKuAOjOOdv9bXMU=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-07-01.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-07-01.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-07-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0cae7a31951587aa2787e622b5fb25527ed035d8";
-  sha256 = "sha256-vKMgZWr3/YNVWhprR+I5ZADfIjv8H270ED2EA2g5Ljs=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-07-02.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-07-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-07-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "73fb34320e61b0a01f5c8375dfaeb534871b0586";
-  sha256 = "sha256-cCSC9W5FbByd263qSq/WUqHm26x50KS1tTbV2Y6htIg=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-07-05.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-07-05.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-07-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b54fce7727d1d07c6fa38d8aeaf8db821a78c0f3";
-  sha256 = "sha256-4ZHUtGtlY+SI/MXU6MpwraFr4DzmVzW+/FFmqENS/qk=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-07-08.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-07-08.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-07-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5ca3dcab93f0064f47438927fad8899ade888e9b";
-  sha256 = "sha256-EJ5+cQolHJeY5GXRFggq9i4ocHfEdYwJLCfRmDVTDcU=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-07-10.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-07-10.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-07-10";
-  url = "https://github.com/fuellabs/sway";
-  rev = "403a7e5780f5328c83bcf349a3f67189be158eea";
-  sha256 = "sha256-dCOgyZ0fvH1q95Ibtm5MBn9MDAGfycbPpovGiYsYPo0=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-07-12.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-07-12.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-07-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8b7524666b3349d5c51f2b9d2910f1ee9e20c3ff";
-  sha256 = "sha256-n0VxAxi4ZcApi8Fxs+jd6t/Z4S1WWiSgoSxo0t4HO/0=";
-}

--- a/manifests/forc-call-0.69.0-nightly-2025-07-13.nix
+++ b/manifests/forc-call-0.69.0-nightly-2025-07-13.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-07-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "74092cbbcdd11d39c184097e10a34d2104c55209";
-  sha256 = "sha256-WItCuXu1VzuDvH5PAkNoP96O+5Iv+ANZ/tY/Mu3bU2I=";
-}

--- a/manifests/forc-call-0.69.0.nix
+++ b/manifests/forc-call-0.69.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.0";
-  date = "2025-06-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5c22e3398756548f8b6dbbe32c6dbd7d6d77451c";
-  sha256 = "sha256-0HIFZcZQvA/QxJNkBTQyMLSapTjFhUQAaUyRY3ZdA9M=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-18.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-18.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-18";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b68a3861db866f33078b3c966eaf5b3379e716cf";
-  sha256 = "sha256-k4WlC6P7kXANf2kwJg8j9W1tMpW8ds74pVB2waDELzY=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-19.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-19.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-19";
-  url = "https://github.com/fuellabs/sway";
-  rev = "03398522890e7b99511ec45343613de20b6edcd6";
-  sha256 = "sha256-eV3/Qeg+8YReAM9/hCd7kcZd9Yve0dXgaNBa3Vnf8ao=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-21.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-21.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-21";
-  url = "https://github.com/fuellabs/sway";
-  rev = "926cb4d098fd57da46e28ddd043af2d55b094ce1";
-  sha256 = "sha256-j03PiBlN+LY3a9JwaxBN2LgFVYNzb4c9omhhNclXDKo=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-22.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-22.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d8536d384f63c5ed4a4800b995e0b278be23c232";
-  sha256 = "sha256-7KNnQuOE52zoQmJ33nnjloRXWh24r0Fg/uWHAozOaek=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-23.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-23.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a5e61488daff5db9a262173dcd0d4a78cb9e90cd";
-  sha256 = "sha256-1wiGWfXw3lCWH4MijZ7xk6oQ9OnmKSd6LX3Say7T4QE=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-24.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-24.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "22d858682b2ff06f01a3d74b1646508a00d623ac";
-  sha256 = "sha256-QwBRrzuNNnfT/xBsq+bF4IK6Y67WqBUQVWxRYhuEdjc=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-25.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-25.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4c9c4c29bfcda957cf58e1f6c6ed711c09334117";
-  sha256 = "sha256-HEIgNOxMuTTCHcZrNH1SlBO4bNFcG6rVkKvPGXOTk/I=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-30.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "32dcbaa2431bbdaa0f40e4fc8c61d51c7e765967";
-  sha256 = "sha256-b12wpFXPX1wDAlpJbQpQjpycanhR0gt5mNR4nePL0ek=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-07-31.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-07-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c7ff31207a535386431afcd468c70592ec5ffa31";
-  sha256 = "sha256-Pj7+7QlL/ftL3ZK7KrmA1XZb/ws1LAUhr5A+e2DdBQo=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-01.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-01.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-01";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8b29cc39c52cf7a3fd7857290f9741334923d362";
-  sha256 = "sha256-jtCaouazr3gN9MKoqkH3okGnqo3AXzhue4Lwdt3rK8Q=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-02.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-02.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-02";
-  url = "https://github.com/fuellabs/sway";
-  rev = "05e667dfc973f8aa26ab2081dc53ea804b7bf94e";
-  sha256 = "sha256-EpdlAE9+PuaVZu29+oXFo2ir29m+62GCImj1DLzIr1E=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-06.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-06.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-06";
-  url = "https://github.com/fuellabs/sway";
-  rev = "56e0c10a3a37055741b16d38710b4c0ab78277af";
-  sha256 = "sha256-yI6H6cLYHem79lHcyVFEh0ZTPPC7Es5VFrCNK5sU98A=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-08.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-08.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-08";
-  url = "https://github.com/fuellabs/sway";
-  rev = "fb6ea52a964dc3b6b8deaafb93ae2779d2822f10";
-  sha256 = "sha256-VmIWWWoJPkMmLRLHvGt/UP2+EGdQt0d8vU+zDPk7mZ4=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-09.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-09.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "95130c4172e5e4986e3eefe8f597f1d1faa025ce";
-  sha256 = "sha256-NyLtu7U9wLLg2uTPVmxyLMNjhQjqnTemDtbtTeEGhS0=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-14.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-14.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-14";
-  url = "https://github.com/fuellabs/sway";
-  rev = "5d5ca3494954451e2b8799d7165d34516efe8d52";
-  sha256 = "sha256-H63IGp3TEjidtyDq1bi64486mfvT8c1TPSIpmexWYqs=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-15.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-15.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-15";
-  url = "https://github.com/fuellabs/sway";
-  rev = "fe9bbe39b9f06d455c8d5be403dd120a42d6a54c";
-  sha256 = "sha256-xMinksVvWu2HgCCMoZJIBAS3yyuMxsgSVaFxJytLqtQ=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-20.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-20.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-20";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f036d4c45f730676608bd0bbe0f0e68d11af6fca";
-  sha256 = "sha256-1wSq/TNkumriBbfawPUAB/30utkpox45uI/Pw3GyhvM=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-21.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-21.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-21";
-  url = "https://github.com/fuellabs/sway";
-  rev = "f59835a78a87502d1aef8bb8be61c7a6517c0210";
-  sha256 = "sha256-2R+qajT3WPKinp1liG5/Ef220Q+PH4+Ypml6TsVp44Q=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-23.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-23.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b2c965e6970e1c8079ef77f359b14957a39e5546";
-  sha256 = "sha256-vDtXSpLsam7EOPHND9xa+QVCN0CcelXtVsx98DnDCDg=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-24.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-24.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-24";
-  url = "https://github.com/fuellabs/sway";
-  rev = "be5871da225d79dc2f3325788033ddb49e42928f";
-  sha256 = "sha256-V1pUYHa1dVmGURn96EcU3J9I8lPHL5TQkZhWNsxazhU=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-25.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-25.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "a347631478939613690c303d2f636506e4c44b0f";
-  sha256 = "sha256-CVIBdk6+o6CY95cnVApwJ3zGJxx7mWpEzZFNoUU5vL8=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-27.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-27.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-27";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8be2dae76b6c6c7fa1dc6ba7cc58e55c00abb573";
-  sha256 = "sha256-SyHl1eMG9fcxs7xfLwLrk4MbyuROeyr12Xh2rMfhr2E=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-28.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-28.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "8cb7c57344d230258222110e22fef54e8bdef165";
-  sha256 = "sha256-VA51UnSCNxSJAvcXJPV5hMLr7jPi0d9hHz/rL/YgZTc=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-29.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-29.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "d49cf8e92c9b5512c471571d135dc546fc456ac9";
-  sha256 = "sha256-xOEmt3raPrVXhQvMqbqmmudbSxLTC0r7ne5GMjQJkJE=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-30.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-30.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "84e575ab5266b1103457bbca61b047a967c3d116";
-  sha256 = "sha256-isNB7/VsDsBCXnyhWEgyOuHHMydLd3fjUD0sqV+7xuE=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-08-31.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-08-31.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-08-31";
-  url = "https://github.com/fuellabs/sway";
-  rev = "0aef56aa59abf7669d1b159a645b848b2721ee11";
-  sha256 = "sha256-39FRxaXFWIsvVjwid77rjIOAMXA16WDuWnc2gT6kYZU=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-03.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-03.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-03";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1e04b80c3a25e475023b978a5987686de962eb49";
-  sha256 = "sha256-AMmx1suCuWuywmHiZahhBQM9vqnCvsUSOTIhgRPVrF8=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-04.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-04.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-04";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c58ddbc57f716dcbbc9debed941b0c378ee800bc";
-  sha256 = "sha256-TiufOKOHYgVJMsk9yYJSDNI5UH4pK2qSZQQYCWlL9tU=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-05.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-05.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-05";
-  url = "https://github.com/fuellabs/sway";
-  rev = "1f9880f60d288f36b623309b601da404792acbda";
-  sha256 = "sha256-oZfoMFSTBuQji+d4OKqo07/f2cGKsJ7ZqP7y9cTwhQc=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-07.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-07.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-07";
-  url = "https://github.com/fuellabs/sway";
-  rev = "c2696d6c7b359ae014edf96b29e623f4ddcac0ee";
-  sha256 = "sha256-MCV+t/k/JHE4vvOqhRzpiMap/pdfP57tZw7WzA8J+l4=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-09.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-09.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-09";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6981d3dc884e8b2033509d40e4e9c9b888b82936";
-  sha256 = "sha256-xaA/J8nptOBPkVtw8Jqk24z0KMA1/1TA+b7b9p3ZNco=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-11.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-11.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-11";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b552ba17c8a1b0f9d46fdaeb808879060f8ba1f4";
-  sha256 = "sha256-c+gs8HsPM2LGcu+I0PD7Sqys/9bbaGDNP59Kqx32PLI=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-12.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-12.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-12";
-  url = "https://github.com/fuellabs/sway";
-  rev = "608fc526adea252edf37c8512e3151f555b69aa7";
-  sha256 = "sha256-mNWc0PgsO5V0kyi5hPCNzZhmhYAsdrEVMJbZZ1y+cZs=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-13.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-13.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-13";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4f1af4316a019aca20fdbe4fca862b2006457cb3";
-  sha256 = "sha256-FTVhC6xAxhaWh5qtuzHG6P5U6Oy8HyEjQZroL8gk6vk=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-17.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-17.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "6553dce5a2765362cdfe772d989240198c87f5dd";
-  sha256 = "sha256-8zEV6A6+hlvzqVU8AqLr7G3R2rEs1vw9gkpcj1WfhNw=";
-}

--- a/manifests/forc-call-0.69.1-nightly-2025-09-22.nix
+++ b/manifests/forc-call-0.69.1-nightly-2025-09-22.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-09-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e4672e3e1794e31eb53cf83c1821890b8c876a16";
-  sha256 = "sha256-zevCtBXQmNriCMBNmpagzVnxD+9S7aQA4Qa+sHSLnw4=";
-}

--- a/manifests/forc-call-0.69.1.nix
+++ b/manifests/forc-call-0.69.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.1";
-  date = "2025-07-17";
-  url = "https://github.com/fuellabs/sway";
-  rev = "b68a3861db866f33078b3c966eaf5b3379e716cf";
-  sha256 = "sha256-k4WlC6P7kXANf2kwJg8j9W1tMpW8ds74pVB2waDELzY=";
-}

--- a/manifests/forc-call-0.69.2-nightly-2025-09-23.nix
+++ b/manifests/forc-call-0.69.2-nightly-2025-09-23.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.2";
-  date = "2025-09-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e8b4fda1fd645155416eca01d6bfd5c3fc46ff71";
-  sha256 = "sha256-Tp0TYFMpzkMeY7tnbXBeKtTwgpbtHWtcwAKjfS2REhw=";
-}

--- a/manifests/forc-call-0.69.2.nix
+++ b/manifests/forc-call-0.69.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.69.2";
-  date = "2025-09-23";
-  url = "https://github.com/fuellabs/sway";
-  rev = "e8b4fda1fd645155416eca01d6bfd5c3fc46ff71";
-  sha256 = "sha256-Tp0TYFMpzkMeY7tnbXBeKtTwgpbtHWtcwAKjfS2REhw=";
-}

--- a/manifests/forc-call-0.7.0.nix
+++ b/manifests/forc-call-0.7.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.7.0";
-  date = "2022-03-22";
-  url = "https://github.com/fuellabs/sway";
-  rev = "7dd186041fbd2d4040b9a374fedc9a0cbed9eecb";
-  sha256 = "sha256-B37FgsnDop9Vyn5t7aSn2RceGG3pdLxrHUJHZ2s53d8=";
-}

--- a/manifests/forc-call-0.8.0.nix
+++ b/manifests/forc-call-0.8.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.8.0";
-  date = "2022-03-25";
-  url = "https://github.com/fuellabs/sway";
-  rev = "04d26d6924788875fb01fa4fe58fe969849dcfc5";
-  sha256 = "sha256-MTQlnuP9WVHL/rNHsMdmYqvIgHL5IJmIjUF9WqM55M0=";
-}

--- a/manifests/forc-call-0.9.0.nix
+++ b/manifests/forc-call-0.9.0.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.9.0";
-  date = "2022-03-28";
-  url = "https://github.com/fuellabs/sway";
-  rev = "fdebe28e2803ef32238e6b39693748b6bdf6f34e";
-  sha256 = "sha256-dzEkvJ+nP6+Xzp+nVz+VKy0RmfN/UkX/JlP/0cXqaY0=";
-}

--- a/manifests/forc-call-0.9.1.nix
+++ b/manifests/forc-call-0.9.1.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.9.1";
-  date = "2022-03-29";
-  url = "https://github.com/fuellabs/sway";
-  rev = "72aa51d6da3d49b1bad2e6d6fffe6d4b3e331380";
-  sha256 = "sha256-Mu3niggbgovHWhm6GtU/hhWqANm5YWFvdsrDExUPKYc=";
-}

--- a/manifests/forc-call-0.9.2.nix
+++ b/manifests/forc-call-0.9.2.nix
@@ -1,8 +1,0 @@
-{
-  pname = "forc-call";
-  version = "0.9.2";
-  date = "2022-03-30";
-  url = "https://github.com/fuellabs/sway";
-  rev = "4905aa0b2b6cb7178d6229e7bed94c241a418c26";
-  sha256 = "sha256-C+1vF48WryCdT2X09E8RwcY8LRHxGX3ncRkc2MtNnY4=";
-}

--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -58,10 +58,6 @@ declare -A pkg_forc_tx=(
     [name]="forc-tx"
     [repo]="${fuel_repos[sway]}"
 )
-declare -A pkg_forc_call=(
-    [name]="forc-call"
-    [repo]="${fuel_repos[sway]}"
-)
 declare -A pkg_forc_migrate=(
     [name]="forc-migrate"
     [repo]="${fuel_repos[sway]}"
@@ -242,7 +238,6 @@ refresh pkg_forc_doc
 refresh pkg_forc_fmt
 refresh pkg_forc_lsp
 refresh pkg_forc_tx
-refresh pkg_forc_call
 refresh pkg_forc_migrate
 refresh pkg_forc_node
 refresh pkg_forc_publish


### PR DESCRIPTION
Remove forc-call from `script/refresh-manifests.sh` so refresh runs stop recreating manifests for a non-existent crate.

Delete all `manifests/forc-call-*.nix` files so mkManifests no longer feeds forc-call into the build graph.