### PR TITLE
Remove the refresh call for `pkg_forc_node`

### DIFF
--- a/script/refresh-manifests.sh
+++ b/script/refresh-manifests.sh
@@ -235,7 +235,6 @@ refresh pkg_forc_fmt
 refresh pkg_forc_lsp
 refresh pkg_forc_tx
 refresh pkg_forc_migrate
-refresh pkg_forc_node
 refresh pkg_forc_publish
 refresh pkg_forc_wallet
 refresh pkg_fuel_core


### PR DESCRIPTION
This was accidentally left over and should have been removed in the previous PR. it's the reason CI is [failing](https://github.com/FuelLabs/fuel.nix/actions/runs/18114347081/job/51552855943)