### PR TITLE
fix: bump fuel-core nightlies to rust 1.93

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770181073,
-        "narHash": "sha256-ksTL7P9QC1WfZasNlaAdLOzqD8x5EPyods69YBqxSfk=",
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf922a59c5c9998a6584645f7d0de689512e444c",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770174315,
-        "narHash": "sha256-GUaMxDmJB1UULsIYpHtfblskVC6zymAaQ/Zqfo+13jc=",
+        "lastModified": 1772744122,
+        "narHash": "sha256-T9zhmb41IA0tpTaY/nDhCYEXUod48y09/pkSMPklyfE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "095c394bb91342882f27f6c73f64064fb9de9f2a",
+        "rev": "c35dade1cfee9a17f46f429e2983841801461ac9",
         "type": "github"
       },
       "original": {

--- a/manifests/fuel-core-0.47.1-nightly-2026-02-04.nix
+++ b/manifests/fuel-core-0.47.1-nightly-2026-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.47.1";
+  date = "2026-02-04";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "697e692a08f90380f3f573e0d01d9ca813534be2";
+  sha256 = "sha256-f7qfVyUjHolnoKpXbou4qBbmfnpWkJ5JXmN0wNJ8wAI=";
+}

--- a/manifests/fuel-core-0.47.1-nightly-2026-03-05.nix
+++ b/manifests/fuel-core-0.47.1-nightly-2026-03-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.47.1";
+  date = "2026-03-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e9f8651b050dd5cc72993833748dceaa45ef6395";
+  sha256 = "sha256-YSPQJ13pLBBgYvNmeE9VOcMBXOiRyJD3etwTJ8++0h4=";
+}

--- a/manifests/fuel-core-0.47.2.nix
+++ b/manifests/fuel-core-0.47.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core";
+  version = "0.47.2";
+  date = "2026-03-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "66bd387bc53b159ef2e2fbe0f79a490310666f52";
+  sha256 = "sha256-U9v7DfccnsuXAIqNu9Yq+qC65sZPucWk8nfXrB/uqVc=";
+}

--- a/manifests/fuel-core-client-0.47.1-nightly-2026-02-04.nix
+++ b/manifests/fuel-core-client-0.47.1-nightly-2026-02-04.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.47.1";
+  date = "2026-02-04";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "697e692a08f90380f3f573e0d01d9ca813534be2";
+  sha256 = "sha256-f7qfVyUjHolnoKpXbou4qBbmfnpWkJ5JXmN0wNJ8wAI=";
+}

--- a/manifests/fuel-core-client-0.47.1-nightly-2026-03-05.nix
+++ b/manifests/fuel-core-client-0.47.1-nightly-2026-03-05.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.47.1";
+  date = "2026-03-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "e9f8651b050dd5cc72993833748dceaa45ef6395";
+  sha256 = "sha256-YSPQJ13pLBBgYvNmeE9VOcMBXOiRyJD3etwTJ8++0h4=";
+}

--- a/manifests/fuel-core-client-0.47.2.nix
+++ b/manifests/fuel-core-client-0.47.2.nix
@@ -1,0 +1,8 @@
+{
+  pname = "fuel-core-client";
+  version = "0.47.2";
+  date = "2026-03-05";
+  url = "https://github.com/fuellabs/fuel-core";
+  rev = "66bd387bc53b159ef2e2fbe0f79a490310666f52";
+  sha256 = "sha256-U9v7DfccnsuXAIqNu9Yq+qC65sZPucWk8nfXrB/uqVc=";
+}

--- a/patches.nix
+++ b/patches.nix
@@ -490,7 +490,8 @@ in [
   # That commit first appears in nightly manifests dated 2026-03-05.
   {
     condition = m:
-      m.src.gitRepoUrl == "https://github.com/fuellabs/fuel-core"
+      m.src.gitRepoUrl
+      == "https://github.com/fuellabs/fuel-core"
       && m.date >= "2026-03-05";
     patch = m: {
       rust = pkgs.rust-bin.stable."1.93.0".default.override {

--- a/patches.nix
+++ b/patches.nix
@@ -485,4 +485,17 @@ in [
       };
     };
   }
+
+  # `fuel-core` bumped its toolchain to Rust 1.93 in `e9f8651b050dd5...`.
+  # That commit first appears in nightly manifests dated 2026-03-05.
+  {
+    condition = m:
+      m.src.gitRepoUrl == "https://github.com/fuellabs/fuel-core"
+      && m.date >= "2026-03-05";
+    patch = m: {
+      rust = pkgs.rust-bin.stable."1.93.0".default.override {
+        targets = ["wasm32-unknown-unknown"];
+      };
+    };
+  }
 ]


### PR DESCRIPTION
Summary:
- bump fuel-core repo nightlies to Rust 1.93.0 starting 2026-03-05
- fix the fuel-nightly CI failures seen in runs on 2026-03-05 and 2026-03-06 after fuel-core commit e9f8651 bumped its MSRV to 1.93

Validation:
- patches.nix parses successfully
- a synthetic fuel-core nightly dated 2026-03-04 still resolves to rust-default-1.90.0
- a synthetic fuel-core nightly dated 2026-03-05 resolves to rust-default-1.93.0

Reference:
- https://github.com/FuelLabs/fuel.nix/actions/runs/22742880771